### PR TITLE
Implement trace logging, ensemble CLI, and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main", "master"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run pytest
+        run: pytest

--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -9,12 +9,13 @@ from rich.console import Console
 from rich.table import Table
 
 from po_core import __author__, __email__, __version__
+from po_core import po_self, po_trace, po_viewer
 
 console = Console()
 
 
 @click.group()
-@click.version_option(version="0.1.0-alpha", prog_name="po-core")
+@click.version_option(version=__version__, prog_name="po-core")
 def main() -> None:
     """
     Po_core: Philosophy-Driven AI System 🐷🎈
@@ -40,9 +41,9 @@ def status() -> None:
     console.print("✅ Philosophical Framework: 100%")
     console.print("✅ Documentation: 100%")
     console.print("✅ Architecture Design: 100%")
-    console.print("🔄 Implementation: 30%")
-    console.print("⏳ Testing: 0%")
-    console.print("⏳ Visualization: 0%")
+    console.print("🔄 Implementation: 40%")
+    console.print("⏳ Testing: 10%")
+    console.print("⏳ Visualization: 10%")
 
 
 @main.command()
@@ -61,6 +62,11 @@ def version() -> None:
     console.print("\n")
     console.print(table)
     console.print("\n[dim]A frog in a well may not know the ocean, but it can know the sky.[/dim]")
+
+
+main.add_command(po_trace.cli, name="trace")
+main.add_command(po_self.cli, name="self")
+main.add_command(po_viewer.cli, name="view")
 
 
 if __name__ == "__main__":

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -1,21 +1,103 @@
-"""
-Po_self: Philosophical Ensemble Module
+"""Po_self: Philosophical Ensemble Module.
 
-The core reasoning engine that integrates multiple philosophers
-as interacting tensors.
+Provides a minimal ensemble that loads philosophers and generates a blended
+response with freedom pressure metadata.
 """
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Dict, Iterable, List, Sequence
 
 import click
 from rich.console import Console
+from rich.table import Table
+
+from po_core.philosophers.base import Philosopher
 
 console = Console()
 
 
-def cli() -> None:
-    """Po_self CLI entry point"""
-    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+class PoSelf:
+    """Minimal orchestrator that coordinates a small ensemble of philosophers."""
+
+    def __init__(self, philosopher_names: Sequence[str] | None = None) -> None:
+        default = ["Sartre", "Jung", "Derrida"]
+        self.philosopher_names = list(philosopher_names or default)
+        self.philosophers = self._load_philosophers(self.philosopher_names)
+
+    def _load_philosophers(self, names: Iterable[str]) -> List[Philosopher]:
+        philosophers: List[Philosopher] = []
+        for name in names:
+            module = import_module(f"po_core.philosophers.{name.lower()}")
+            philosopher_cls = getattr(module, name)
+            philosophers.append(philosopher_cls())
+        return philosophers
+
+    def generate(self, prompt: str) -> Dict[str, object]:
+        """Generate reasoning output using the available philosophers."""
+
+        contributions = []
+        tensions: List[float] = []
+        for philosopher in self.philosophers:
+            result = philosopher.reason(prompt, context={"mode": "ensemble"})
+            contributions.append(
+                {
+                    "philosopher": philosopher.name,
+                    "perspective": result.get("perspective"),
+                    "excerpt": result.get("reasoning"),
+                }
+            )
+            tension_value = result.get("tension") or len(result.get("reasoning", "")) % 10 / 10
+            tensions.append(float(tension_value))
+
+        freedom_pressure = round(sum(tensions) / max(len(tensions), 1), 2)
+        commentary = (
+            " | ".join(entry["perspective"] or "Perspective" for entry in contributions)
+            + " synthesis"
+        )
+
+        return {
+            "prompt": prompt,
+            "freedom_pressure": freedom_pressure,
+            "commentary": commentary,
+            "contributions": contributions,
+        }
 
 
-if __name__ == "__main__":
-    cli()
+def render_response(response: Dict[str, object]) -> None:
+    """Render the generate() output as a rich table."""
+
+    console.print(f"[bold magenta]🧠 Po_self[/bold magenta] responded to: [cyan]{response['prompt']}[/cyan]\n")
+
+    table = Table(title="Philosopher Contributions", show_header=True, header_style="bold")
+    table.add_column("Philosopher")
+    table.add_column("Perspective")
+    table.add_column("Excerpt")
+
+    for contribution in response.get("contributions", []):
+        table.add_row(
+            str(contribution.get("philosopher", "Unknown")),
+            str(contribution.get("perspective", "")),
+            str(contribution.get("excerpt", "")),
+        )
+
+    console.print(table)
+    console.print(
+        f"Freedom pressure: [bold yellow]{response.get('freedom_pressure', 'N/A')}[/bold yellow]",
+    )
+    console.print(f"Commentary: {response.get('commentary', '')}\n")
+
+
+@click.command()
+@click.option("--prompt", required=True, help="Prompt to send to the philosophical ensemble.")
+def cli(prompt: str) -> None:
+    """Run the minimal Po_self ensemble for a given prompt."""
+
+    engine = PoSelf()
+    response = engine.generate(prompt)
+    render_response(response)
+
+
+__all__ = ["PoSelf", "render_response"]
+

--- a/src/po_core/po_trace.py
+++ b/src/po_core/po_trace.py
@@ -1,21 +1,190 @@
-"""
-Po_trace: Reasoning Audit Log Module
+"""Po_trace: Reasoning Audit Log Module.
 
-Tracks and logs the complete reasoning process,
-including what was said and what was not said.
+Tracks and logs the complete reasoning process, including what was said and
+what was not said.
 """
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence
 
 import click
 from rich.console import Console
+from rich.table import Table
 
 console = Console()
 
 
-def cli() -> None:
-    """Po_trace CLI entry point"""
-    console.print("[bold green]🔍 Po_trace - Reasoning Audit Log[/bold green]")
-    console.print("Implementation coming soon...")
+@dataclass
+class TraceEvent:
+    """An individual reasoning event in a trace log."""
+
+    utterance: str
+    philosophers: List[str]
+    accepted: bool = True
+    rejection_reason: Optional[str] = None
+    comment: Optional[str] = None
+    tension: Optional[float] = None
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
 
 
-if __name__ == "__main__":
-    cli()
+def save_trace(
+    events: Sequence[TraceEvent],
+    path: Path | str,
+    *,
+    ndjson: bool = True,
+) -> Path:
+    """Save trace events to a JSON or NDJSON file."""
+
+    trace_path = Path(path)
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if ndjson:
+        trace_path.write_text(
+            "\n".join(json.dumps(asdict(event), ensure_ascii=False) for event in events)
+            + "\n",
+            encoding="utf-8",
+        )
+    else:
+        trace_path.write_text(
+            json.dumps([asdict(event) for event in events], ensure_ascii=False, indent=2)
+            + "\n",
+            encoding="utf-8",
+        )
+
+    return trace_path
+
+
+def load_trace(path: Path | str) -> List[TraceEvent]:
+    """Load trace events from a JSON or NDJSON file."""
+
+    trace_path = Path(path)
+    content = trace_path.read_text(encoding="utf-8").strip()
+    if not content:
+        return []
+
+    if content.startswith("["):
+        data = json.loads(content)
+    else:
+        data = [json.loads(line) for line in content.splitlines() if line.strip()]
+
+    events: List[TraceEvent] = []
+    for item in data:
+        events.append(
+            TraceEvent(
+                utterance=item.get("utterance", ""),
+                philosophers=list(item.get("philosophers", [])),
+                accepted=item.get("accepted", True),
+                rejection_reason=item.get("rejection_reason"),
+                comment=item.get("comment"),
+                tension=item.get("tension"),
+                timestamp=item.get("timestamp", datetime.now(timezone.utc).isoformat()),
+            )
+        )
+
+    return events
+
+
+def demo_trace_events() -> List[TraceEvent]:
+    """Generate a short set of demo events for showcasing Po_trace."""
+
+    return [
+        TraceEvent(
+            utterance="Prompt received: How do we balance freedom and responsibility?",
+            philosophers=["System"],
+            comment="Initial prompt",
+            tension=0.1,
+        ),
+        TraceEvent(
+            utterance="Authenticity emerges when choice meets responsibility.",
+            philosophers=["Jean-Paul Sartre"],
+            comment="Existential framing",
+            tension=0.35,
+        ),
+        TraceEvent(
+            utterance="The shadow reminds us that unowned duties return as projections.",
+            philosophers=["Carl Jung"],
+            comment="Depth psychology",
+            tension=0.42,
+        ),
+        TraceEvent(
+            utterance="Binary oppositions hide the play of différance.",
+            philosophers=["Jacques Derrida"],
+            accepted=False,
+            rejection_reason="Too abstract for the user's immediate need",
+            tension=0.55,
+        ),
+        TraceEvent(
+            utterance="Synthesis: Freedom is lived as accountable improvisation.",
+            philosophers=["Ensemble"],
+            comment="Draft response",
+            tension=0.28,
+        ),
+    ]
+
+
+def render_trace(events: Sequence[TraceEvent]) -> None:
+    """Render a trace log to the console."""
+
+    table = Table(title="Po_trace Log", show_lines=True)
+    table.add_column("Timestamp", style="dim", no_wrap=True)
+    table.add_column("Philosophers")
+    table.add_column("Utterance")
+    table.add_column("Accepted", justify="center")
+    table.add_column("Rejection Reason")
+    table.add_column("Tension", justify="right")
+
+    for event in events:
+        table.add_row(
+            event.timestamp,
+            ", ".join(event.philosophers),
+            event.utterance,
+            "✅" if event.accepted else "❌",
+            event.rejection_reason or "-",
+            f"{event.tension:.2f}" if event.tension is not None else "-",
+        )
+
+    console.print(table)
+
+
+@click.command()
+@click.option(
+    "--log",
+    "log_path",
+    default="po_trace_demo.jsonl",
+    show_default=True,
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    help="Path to save the trace log (JSONL).",
+)
+@click.option(
+    "--json",
+    "use_json",
+    is_flag=True,
+    default=False,
+    help="Save as JSON array instead of NDJSON.",
+)
+def cli(log_path: Path, use_json: bool) -> None:
+    """Generate and save a demo reasoning trace."""
+
+    events = demo_trace_events()
+    save_trace(events, log_path, ndjson=not use_json)
+    console.print(
+        f"[bold green]🔍 Po_trace[/bold green] wrote {len(events)} events to [cyan]{log_path}[/cyan]"
+    )
+    render_trace(events)
+
+
+__all__ = [
+    "TraceEvent",
+    "save_trace",
+    "load_trace",
+    "demo_trace_events",
+    "render_trace",
+]
+

--- a/src/po_core/po_viewer.py
+++ b/src/po_core/po_viewer.py
@@ -1,21 +1,107 @@
-"""
-Po_viewer: Visualization Module
+"""Po_viewer: Visualization Module.
 
-Visualizes the reasoning process, tension maps,
-and philosophical interactions.
+Visualizes Po_trace output and summarizes philosopher contributions.
 """
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, Sequence
 
 import click
 from rich.console import Console
+from rich.table import Table
+
+from po_core.po_trace import TraceEvent, load_trace
 
 console = Console()
 
 
-def cli() -> None:
-    """Po_viewer CLI entry point"""
-    console.print("[bold cyan]🎨 Po_viewer - Reasoning Visualization[/bold cyan]")
-    console.print("Implementation coming soon...")
+def summarize_contributions(events: Sequence[TraceEvent]) -> Counter:
+    """Summarize how many times each philosopher contributed."""
+
+    counter: Counter[str] = Counter()
+    for event in events:
+        for philosopher in event.philosophers:
+            counter[philosopher] += 1
+    return counter
 
 
-if __name__ == "__main__":
-    cli()
+def render_trace_table(events: Sequence[TraceEvent]) -> None:
+    """Render a table of individual events."""
+
+    table = Table(title="Trace Events", show_lines=True)
+    table.add_column("Philosophers")
+    table.add_column("Utterance")
+    table.add_column("Accepted", justify="center")
+    table.add_column("Rejection Reason")
+    table.add_column("Tension", justify="right")
+
+    for event in events:
+        table.add_row(
+            ", ".join(event.philosophers),
+            event.utterance,
+            "✅" if event.accepted else "❌",
+            event.rejection_reason or "-",
+            f"{event.tension:.2f}" if event.tension is not None else "-",
+        )
+
+    console.print(table)
+
+
+def render_summary(counter: Counter, tensions: Iterable[float]) -> None:
+    """Render summary tables and a simple sparkline."""
+
+    summary = Table(title="Philosopher Contributions")
+    summary.add_column("Philosopher")
+    summary.add_column("Events", justify="right")
+
+    for philosopher, count in counter.most_common():
+        summary.add_row(philosopher, str(count))
+
+    sparkline = "".join(_spark_char(value) for value in tensions)
+    console.print(summary)
+    console.print(f"Tension trend: [bold blue]{sparkline}[/bold blue]\n")
+
+
+def _spark_char(value: float) -> str:
+    """Convert a numeric tension into a simple sparkline character."""
+
+    if value < 0.2:
+        return "▁"
+    if value < 0.4:
+        return "▂"
+    if value < 0.6:
+        return "▃"
+    if value < 0.8:
+        return "▄"
+    return "▅"
+
+
+@click.command()
+@click.option(
+    "--trace",
+    "trace_path",
+    required=True,
+    type=click.Path(dir_okay=False, exists=True, readable=True, path_type=Path),
+    help="Path to a Po_trace JSON/JSONL file.",
+)
+def cli(trace_path: Path) -> None:
+    """Visualize a Po_trace file in the terminal."""
+
+    events = load_trace(trace_path)
+    if not events:
+        console.print("[yellow]No events found in trace.[/yellow]")
+        return
+
+    counter = summarize_contributions(events)
+    tensions = [event.tension or 0.0 for event in events]
+
+    console.print(f"[bold cyan]🎨 Po_viewer[/bold cyan] loading [cyan]{trace_path}[/cyan]\n")
+    render_summary(counter, tensions)
+    render_trace_table(events)
+
+
+__all__ = ["render_trace_table", "render_summary", "summarize_contributions"]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Test configuration for Po_core.
+
+Provides a lightweight fallback for coverage flags when pytest-cov is not
+installed in constrained environments.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def pytest_addoption(parser: Any) -> None:  # pragma: no cover - helper
+    if importlib.util.find_spec("pytest_cov") is not None:
+        return
+
+    parser.addoption("--cov", action="append", default=[], help="(stub) coverage target")
+    parser.addoption(
+        "--cov-report", action="append", default=[], help="(stub) coverage report"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from po_core import cli
+from po_core.po_trace import demo_trace_events, load_trace, save_trace
+
+
+def test_hello_status_version_commands() -> None:
+    runner = CliRunner()
+
+    hello = runner.invoke(cli.main, ["hello"])
+    assert hello.exit_code == 0
+    assert "Po_core" in hello.output
+
+    status = runner.invoke(cli.main, ["status"])
+    assert status.exit_code == 0
+    assert "Project Status" in status.output
+
+    version = runner.invoke(cli.main, ["version"])
+    assert version.exit_code == 0
+    assert "Po_core" in version.output
+
+
+def test_trace_command_writes_log(tmp_path: Path) -> None:
+    runner = CliRunner()
+    log_path = tmp_path / "demo.jsonl"
+
+    result = runner.invoke(cli.main, ["trace", "--log", str(log_path)])
+    assert result.exit_code == 0
+    assert log_path.exists()
+
+    events = load_trace(log_path)
+    assert len(events) == len(demo_trace_events())
+    assert any(not event.accepted for event in events)
+
+
+def test_self_command_generates_output() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["self", "--prompt", "What is freedom?"])
+
+    assert result.exit_code == 0
+    assert "Freedom pressure" in result.output
+    assert "Philosopher" in result.output
+
+
+def test_view_command_renders_trace(tmp_path: Path) -> None:
+    runner = CliRunner()
+    trace_path = tmp_path / "trace.jsonl"
+    save_trace(demo_trace_events(), trace_path)
+
+    result = runner.invoke(cli.main, ["view", "--trace", str(trace_path)])
+    assert result.exit_code == 0
+    assert "Philosopher Contributions" in result.output
+    assert "Tension trend" in result.output


### PR DESCRIPTION
## Summary
- implement Po_trace trace events with JSON/NDJSON serialization and CLI demo logging
- add minimal Po_self ensemble pipeline plus Po_viewer trace visualization and CLI integration
- introduce CLI smoke tests and GitHub Actions workflow to run pytest on multiple Python versions

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cbd907648328891e56d7ec2129ee)