### PR TITLE
Implement Po_self orchestrator and enhance CLI

### DIFF
--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -4,50 +4,139 @@ Po_core CLI - Main Command Line Interface
 Entry point for the po-core command.
 """
 
+import json
+from typing import Any, Dict, Iterable, Tuple
+
 import click
 from rich.console import Console
 from rich.table import Table
 
 from po_core import __author__, __email__, __version__
+from po_core.po_self import PoSelf
 
 console = Console()
 
 
+def _parse_key_value_pairs(entries: Iterable[str]) -> Dict[str, Any]:
+    context: Dict[str, Any] = {}
+    for entry in entries:
+        if "=" not in entry:
+            continue
+        key, value = entry.split("=", 1)
+        context[key.strip()] = value.strip()
+    return context
+
+
 @click.group()
-@click.version_option(version="0.1.0-alpha", prog_name="po-core")
-def main() -> None:
+@click.version_option(version=__version__, prog_name="po-core")
+@click.pass_context
+def main(ctx: click.Context) -> None:
     """
     Po_core: Philosophy-Driven AI System 🐷🎈
 
     A system that integrates philosophers as dynamic tensors
     for responsible meaning generation.
     """
-    pass
+    ctx.ensure_object(dict)
+    ctx.obj["engine"] = PoSelf()
 
 
 @main.command()
-def hello() -> None:
-    """Say hello from Po_core"""
+@click.pass_context
+def hello(ctx: click.Context) -> None:
+    """Say hello from Po_core."""
+
+    engine: PoSelf = ctx.obj["engine"]
     console.print("[bold blue]🐷🎈 Po_core へようこそ![/bold blue]")
-    console.print("Philosophy-Driven AI System - Alpha v0.1.0")
-    console.print("\n[italic]A frog in a well may not know the ocean, but it can know the sky.[/italic]")
+    console.print(f"Philosophy-Driven AI System - v{__version__}")
+    console.print(
+        f"\n[italic]Currently hosting {len(engine.philosophers)} philosophers ready to reason.[/italic]"
+    )
+    console.print("[dim]A frog in a well may not know the ocean, but it can know the sky.[/dim]")
 
 
 @main.command()
-def status() -> None:
-    """Show project status"""
-    console.print("[bold]📊 Po_core Project Status[/bold]\n")
-    console.print("✅ Philosophical Framework: 100%")
-    console.print("✅ Documentation: 100%")
-    console.print("✅ Architecture Design: 100%")
-    console.print("🔄 Implementation: 30%")
-    console.print("⏳ Testing: 0%")
-    console.print("⏳ Visualization: 0%")
+@click.pass_context
+def status(ctx: click.Context) -> None:
+    """Show project status."""
+
+    engine: PoSelf = ctx.obj["engine"]
+    table = Table(title="📊 Po_core Project Status", show_header=False, box=None)
+    table.add_row("Philosophers loaded", str(len(engine.philosophers)))
+    table.add_row("Available", ", ".join(engine.available_names()))
+    table.add_row("Pipeline", "Reasoning orchestrator active")
+    table.add_row("Testing", "Ensemble and CLI smoke tests ready")
+
+    console.print(table)
+
+
+@main.command()
+@click.argument("prompt")
+@click.option(
+    "--philosopher",
+    "philosophers",
+    multiple=True,
+    help="Limit execution to a specific philosopher name. Can be passed multiple times.",
+)
+@click.option(
+    "--context",
+    "context_items",
+    multiple=True,
+    help="Optional context key=value pairs to pass into the ensemble.",
+)
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["rich", "json"], case_sensitive=False),
+    default="rich",
+    show_default=True,
+    help="Format to display ensemble results.",
+)
+@click.pass_context
+def run(
+    ctx: click.Context,
+    prompt: str,
+    philosophers: Tuple[str, ...],
+    context_items: Tuple[str, ...],
+    output_format: str,
+) -> None:
+    """Run the philosopher ensemble on a prompt."""
+
+    engine: PoSelf = ctx.obj["engine"]
+    context = _parse_key_value_pairs(context_items)
+    result = engine.run_prompt(prompt, context=context, selected=list(philosophers))
+
+    if output_format.lower() == "json":
+        console.print_json(json.dumps(result, default=lambda o: o.__dict__))
+        return
+
+    console.print(f"\n[bold]Prompt:[/bold] {prompt}\n")
+    console.print(f"[bold cyan]Ensemble summary[/bold cyan]\n{result.summary}\n")
+
+    influence_table = Table(title="Influence Weights", show_header=True, header_style="bold")
+    influence_table.add_column("Philosopher")
+    influence_table.add_column("Perspective")
+    influence_table.add_column("Weight")
+    for influence in result.influences:
+        influence_table.add_row(
+            influence["name"], influence.get("perspective", ""), str(influence["weight"])
+        )
+    console.print(influence_table)
+
+    for output in result.outputs:
+        console.rule(output.name)
+        console.print(f"[bold]Perspective:[/bold] {output.perspective}")
+        console.print(output.reasoning)
+
+    if result.failed:
+        console.print(
+            f"\n[bold red]The following philosophers failed to respond:[/bold red] {', '.join(result.failed)}"
+        )
 
 
 @main.command()
 def version() -> None:
-    """Show version information"""
+    """Show version information."""
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column(style="bold cyan")
     table.add_column()

--- a/src/po_core/philosophers/base.py
+++ b/src/po_core/philosophers/base.py
@@ -6,7 +6,7 @@ Each philosopher provides a unique perspective for analyzing and generating mean
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 
 class Philosopher(ABC):
@@ -28,6 +28,20 @@ class Philosopher(ABC):
         self.name = name
         self.description = description
         self._context: Dict[str, Any] = {}
+
+    @property
+    def context(self) -> Dict[str, Any]:
+        """Return a shallow copy of the current context state."""
+        return dict(self._context)
+
+    def set_context(self, context: Optional[Mapping[str, Any]] = None) -> None:
+        """Replace the current context with provided mapping."""
+        self._context = dict(context) if context else {}
+
+    def update_context(self, context: Optional[Mapping[str, Any]] = None) -> None:
+        """Merge additional context values into the current state."""
+        if context:
+            self._context.update(dict(context))
 
     @abstractmethod
     def reason(self, prompt: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -1,21 +1,135 @@
 """
 Po_self: Philosophical Ensemble Module
 
-The core reasoning engine that integrates multiple philosophers
-as interacting tensors.
+Coordinates philosopher instances to provide collective reasoning.
 """
 
-import click
-from rich.console import Console
+from __future__ import annotations
 
-console = Console()
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 
-
-def cli() -> None:
-    """Po_self CLI entry point"""
-    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+import po_core.philosophers as philosophers
+from po_core.philosophers import Philosopher
 
 
-if __name__ == "__main__":
-    cli()
+@dataclass
+class PhilosopherResponse:
+    """Normalized response structure for a single philosopher."""
+
+    name: str
+    perspective: str
+    reasoning: str
+    metadata: Dict[str, Any]
+    raw: Dict[str, Any]
+
+
+@dataclass
+class EnsembleResult:
+    """Combined response from the philosopher ensemble."""
+
+    prompt: str
+    summary: str
+    influences: List[Dict[str, Any]]
+    outputs: List[PhilosopherResponse]
+    failed: List[str]
+
+
+class PoSelf:
+    """Orchestrates philosopher reasoning and aggregates responses."""
+
+    def __init__(self, selected: Optional[Sequence[str]] = None) -> None:
+        self._philosophers = self._load_philosophers(selected)
+
+    def _load_philosophers(
+        self, selected: Optional[Sequence[str]] = None
+    ) -> MutableMapping[str, Philosopher]:
+        available: MutableMapping[str, Philosopher] = {}
+        wanted = {name.lower() for name in selected} if selected else None
+
+        for name in getattr(philosophers, "__all__", []):
+            if name == "Philosopher":
+                continue
+            cls = getattr(philosophers, name, None)
+            if not cls or not issubclass(cls, Philosopher):
+                continue
+            instance = cls()
+            if wanted and instance.name.lower() not in wanted and name.lower() not in wanted:
+                continue
+            available[instance.name] = instance
+        return available
+
+    @property
+    def philosophers(self) -> Mapping[str, Philosopher]:
+        return dict(self._philosophers)
+
+    def available_names(self) -> List[str]:
+        return sorted(self._philosophers.keys())
+
+    def run_prompt(
+        self,
+        prompt: str,
+        context: Optional[Mapping[str, Any]] = None,
+        selected: Optional[Sequence[str]] = None,
+    ) -> EnsembleResult:
+        context = dict(context) if context else {}
+        outputs: List[PhilosopherResponse] = []
+        failed: List[str] = []
+
+        chosen = {name.lower() for name in selected} if selected else None
+
+        for name, philosopher in sorted(self._philosophers.items()):
+            if chosen and name.lower() not in chosen:
+                continue
+            philosopher.set_context(context)
+            try:
+                raw = philosopher.reason(prompt, context=context)
+                outputs.append(
+                    PhilosopherResponse(
+                        name=philosopher.name,
+                        perspective=str(raw.get("perspective", philosopher.__class__.__name__)),
+                        reasoning=str(raw.get("reasoning", "")),
+                        metadata={"philosopher": philosopher.name, **raw.get("metadata", {})},
+                        raw=raw,
+                    )
+                )
+            except Exception:
+                failed.append(philosopher.name)
+
+        influences = self._calculate_influences(outputs)
+        summary = self.combine_reasoning(outputs)
+
+        return EnsembleResult(
+            prompt=prompt,
+            summary=summary,
+            influences=influences,
+            outputs=outputs,
+            failed=failed,
+        )
+
+    def _calculate_influences(self, outputs: Iterable[PhilosopherResponse]) -> List[Dict[str, Any]]:
+        outputs_list = list(outputs)
+        total = len(outputs_list) or 1
+        weight = 1 / total
+        return [
+            {
+                "name": response.name,
+                "perspective": response.perspective,
+                "weight": round(weight, 3),
+            }
+            for response in outputs_list
+        ]
+
+    def combine_reasoning(self, outputs: Iterable[PhilosopherResponse]) -> str:
+        thoughts = [f"{response.name}: {response.reasoning}" for response in outputs if response.reasoning]
+        if not thoughts:
+            return "No philosophical responses were generated."
+        return " \n---\n".join(thoughts)
+
+
+def run_ensemble(prompt: str, context: Optional[Mapping[str, Any]] = None) -> EnsembleResult:
+    """Helper for quickly running the ensemble from external callers."""
+
+    engine = PoSelf()
+    return engine.run_prompt(prompt=prompt, context=context)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for resolving project imports."""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,32 @@
+"""CLI smoke tests using Click's runner."""
+
+from click.testing import CliRunner
+
+from po_core import __version__
+from po_core.cli import main
+
+
+def test_hello_command() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["hello"])
+
+    assert result.exit_code == 0
+    assert "Po_core" in result.output
+    assert __version__ in result.output
+
+
+def test_status_command() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+
+    assert result.exit_code == 0
+    assert "Philosophers loaded" in result.output
+
+
+def test_version_command() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.output
+

--- a/tests/unit/test_philosophers_base.py
+++ b/tests/unit/test_philosophers_base.py
@@ -1,0 +1,36 @@
+"""Tests for philosopher base class behavior."""
+
+import pytest
+
+from po_core.philosophers.base import Philosopher
+
+
+class ExamplePhilosopher(Philosopher):
+    def __init__(self) -> None:
+        super().__init__(name="Example", description="Example description")
+
+    def reason(self, prompt: str, context=None):
+        self.update_context(context)
+        return {"reasoning": f"Echo: {prompt}", "perspective": "Example"}
+
+
+def test_cannot_instantiate_base_class() -> None:
+    with pytest.raises(TypeError):
+        Philosopher(name="Invalid", description="Should not instantiate")  # type: ignore
+
+
+def test_context_management_merges_values() -> None:
+    philosopher = ExamplePhilosopher()
+    philosopher.set_context({"foo": "bar"})
+    philosopher.update_context({"bar": "baz"})
+
+    assert philosopher.context == {"foo": "bar", "bar": "baz"}
+
+
+def test_reason_receives_context() -> None:
+    philosopher = ExamplePhilosopher()
+    response = philosopher.reason("test prompt", context={"a": 1})
+
+    assert response["reasoning"].startswith("Echo: test prompt")
+    assert philosopher.context["a"] == 1
+

--- a/tests/unit/test_po_self.py
+++ b/tests/unit/test_po_self.py
@@ -1,0 +1,26 @@
+"""Tests for the PoSelf reasoning orchestrator."""
+
+from po_core.po_self import PoSelf, run_ensemble
+
+
+def test_loads_philosophers() -> None:
+    engine = PoSelf()
+
+    assert len(engine.available_names()) > 0
+
+
+def test_run_prompt_returns_outputs() -> None:
+    engine = PoSelf()
+    result = engine.run_prompt("What is justice?", selected=engine.available_names()[:2])
+
+    assert result.outputs
+    assert result.summary
+    assert len(result.influences) == len(result.outputs)
+
+
+def test_helper_run_ensemble() -> None:
+    result = run_ensemble("How do we live well?", context={"tone": "reflective"})
+
+    assert result.prompt.startswith("How")
+    assert result.outputs
+


### PR DESCRIPTION
## Summary
- add the PoSelf ensemble orchestrator that loads philosopher modules, runs prompts, and aggregates their outputs
- connect the CLI to the ensemble with richer status messaging, dynamic version display, and a new `run` command with context handling
- introduce pytest-based unit tests for the philosopher base class, PoSelf orchestration, and CLI commands plus shared test configuration

## Testing
- pytest -o addopts=""


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cfac6d508328b73c9bc2502c1939)