### PR TITLE
Add reasoning log serialization and philosopher ensemble pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ data/processed/
 # Except: Keep small example datasets
 !examples/**/*.csv
 !examples/**/*.json
+!tests/fixtures/**/*.json
 
 # Tensor board logs
 events.out.tfevents.*

--- a/docs/specs/reason_log.md
+++ b/docs/specs/reason_log.md
@@ -1,0 +1,49 @@
+# Reason Log Specification
+
+The reason log captures **why** Po_core made a decision at a specific time.
+The schema is intentionally compact so that it can be emitted from CLI tools or
+stored alongside other traces.
+
+## Required fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string (UUID) | Unique identifier for the reasoning event. |
+| `version` | string | Schema version. Current: `1.0`. |
+| `created_at` | string (ISO 8601) | Timestamp in UTC. |
+| `actor` | string | Name of the module or user that authored the log. |
+| `prompt` | string | Input prompt or situation being evaluated. |
+| `conclusion` | string | Final decision, answer, or selected action. |
+| `rationale` | string | Explanation of how the conclusion was reached. |
+| `influences` | array[string] | References to signals or prior logs that shaped the outcome. |
+| `evidence` | array[string] | Concrete artifacts, citations, or data points. |
+| `confidence` | float (0-1) | Normalized confidence value. |
+| `tags` | array[string] | Lightweight labels for filtering. |
+| `metadata` | object | Free-form structured metadata. |
+
+## Serialization rules
+
+- **JSON**: UTF-8 encoded object that preserves all fields above. `created_at`
+  uses `datetime.isoformat()` in UTC without microseconds.
+- **Markdown**: Human-friendly report including headings for Prompt, Conclusion,
+  Rationale, and optional sections for Influences, Evidence, and Metadata.
+- Unknown fields are ignored when parsing to keep forward compatibility.
+
+## Example
+
+```json
+{
+  "id": "7f7ab1c6-7f5d-4ed3-9410-19e2d88a7bb7",
+  "version": "1.0",
+  "created_at": "2024-04-01T12:00:00",
+  "actor": "po-trace",
+  "prompt": "Should we deploy the new viewer module?",
+  "conclusion": "Proceed with staged rollout",
+  "rationale": "User feedback is positive and regression tests are passing",
+  "influences": ["user-feedback:R02", "test-report:2024-04-01"],
+  "evidence": ["ci:green", "doc:viewer-release-notes"],
+  "confidence": 0.82,
+  "tags": ["release", "viewer"],
+  "metadata": {"reviewers": ["po-self", "po-viewer"]}
+}
+```

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -1,20 +1,173 @@
-"""
-Po_self: Philosophical Ensemble Module
+"""Philosophical ensemble orchestration."""
 
-The core reasoning engine that integrates multiple philosophers
-as interacting tensors.
-"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional
 
 import click
 from rich.console import Console
+from rich.table import Table
+
+from po_core.philosophers import Philosopher
+from po_core.philosophers import (  # type: ignore
+    Arendt,
+    Aristotle,
+    Badiou,
+    Confucius,
+    Deleuze,
+    Derrida,
+    Dewey,
+    Heidegger,
+    Jung,
+    Kierkegaard,
+    Lacan,
+    Levinas,
+    MerleauPonty,
+    Nietzsche,
+    Peirce,
+    Sartre,
+    WabiSabi,
+    Watsuji,
+    Wittgenstein,
+    Zhuangzi,
+)
+
 
 console = Console()
 
 
+@dataclass
+class PhilosopherResponse:
+    name: str
+    reasoning: str
+    perspective: str
+    metadata: Mapping[str, object]
+    score: float
+
+
+class PhilosopherRegistry:
+    """Lightweight registry for philosopher implementations."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Philosopher] = {}
+        self._populate_defaults()
+
+    def _populate_defaults(self) -> None:
+        for philo in [
+            Arendt(),
+            Aristotle(),
+            Badiou(),
+            Confucius(),
+            Deleuze(),
+            Derrida(),
+            Dewey(),
+            Heidegger(),
+            Jung(),
+            Kierkegaard(),
+            Lacan(),
+            Levinas(),
+            MerleauPonty(),
+            Nietzsche(),
+            Peirce(),
+            Sartre(),
+            WabiSabi(),
+            Watsuji(),
+            Wittgenstein(),
+            Zhuangzi(),
+        ]:
+            self._registry[philo.name] = philo
+
+    @property
+    def names(self) -> List[str]:
+        return sorted(self._registry.keys())
+
+    def get_selected(self, selected: Optional[Iterable[str]]) -> List[Philosopher]:
+        if not selected:
+            return list(self._registry.values())
+        chosen = []
+        for name in selected:
+            philosopher = self._registry.get(name)
+            if philosopher:
+                chosen.append(philosopher)
+        return chosen
+
+
+class PhilosopherEngine:
+    """Broadcast prompts to philosophers and aggregate their perspectives."""
+
+    def __init__(self, registry: Optional[PhilosopherRegistry] = None) -> None:
+        self.registry = registry or PhilosopherRegistry()
+
+    def run(
+        self, prompt: str, *, selected: Optional[Iterable[str]] = None
+    ) -> Dict[str, object]:
+        philosophers = self.registry.get_selected(selected)
+        responses: List[PhilosopherResponse] = []
+        if not philosophers:
+            return {"combined_reasoning": "", "responses": responses, "score": 0.0}
+
+        for philosopher in philosophers:
+            payload = philosopher.reason(prompt, context={"prompt": prompt})
+            reasoning = str(payload.get("reasoning", ""))
+            perspective = str(payload.get("perspective", philosopher.description))
+            metadata = payload.get("metadata", {"philosopher": philosopher.name})
+            score = float(payload.get("score", 1.0 / len(philosophers)))
+            responses.append(
+                PhilosopherResponse(
+                    name=philosopher.name,
+                    reasoning=reasoning,
+                    perspective=perspective,
+                    metadata=metadata,
+                    score=score,
+                )
+            )
+
+        combined = self._combine(responses)
+        return {
+            "combined_reasoning": combined,
+            "responses": responses,
+            "score": sum(r.score for r in responses) / len(responses),
+        }
+
+    @staticmethod
+    def _combine(responses: List[PhilosopherResponse]) -> str:
+        summaries = [
+            f"[{resp.name}] {resp.perspective}: {resp.reasoning} (score={resp.score:.2f})"
+            for resp in responses
+        ]
+        return "\n".join(summaries)
+
+
+@click.group()
 def cli() -> None:
-    """Po_self CLI entry point"""
-    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+    """Po_self CLI entry point."""
+
+
+@cli.command()
+@click.option("--prompt", required=True, help="Prompt to broadcast to philosophers")
+@click.option(
+    "--philosopher",
+    multiple=True,
+    help="Optional philosopher names to restrict the ensemble",
+)
+def run(prompt: str, philosopher: Iterable[str]) -> None:
+    """Execute the mini philosopher ensemble and display merged reasoning."""
+
+    engine = PhilosopherEngine()
+    result = engine.run(prompt, selected=philosopher)
+    table = Table(title="Po_self Ensemble Result")
+    table.add_column("Philosopher")
+    table.add_column("Perspective")
+    table.add_column("Reasoning")
+    table.add_column("Score")
+
+    for resp in result["responses"]:
+        table.add_row(resp.name, resp.perspective, resp.reasoning, f"{resp.score:.2f}")
+
+    console.print(table)
+    console.print("\n[bold]Combined Reasoning[/bold]")
+    console.print(result["combined_reasoning"])
 
 
 if __name__ == "__main__":

--- a/src/po_core/po_trace.py
+++ b/src/po_core/po_trace.py
@@ -1,20 +1,264 @@
-"""
-Po_trace: Reasoning Audit Log Module
+"""Reasoning audit logging utilities for Po_core."""
 
-Tracks and logs the complete reasoning process,
-including what was said and what was not said.
-"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid4
 
 import click
 from rich.console import Console
+from rich.table import Table
+
+
+def _now() -> datetime:
+    return datetime.utcnow().replace(microsecond=0)
+
+
+@dataclass(slots=True)
+class ReasonLog:
+    """Structured record of a reasoning step.
+
+    The schema is aligned with ``docs/specs/reason_log.md`` and is designed to be
+    stable for CLI serialization in JSON and Markdown formats.
+    """
+
+    id: str
+    version: str
+    created_at: datetime
+    actor: str
+    prompt: str
+    conclusion: str
+    rationale: str
+    influences: List[str] = field(default_factory=list)
+    evidence: List[str] = field(default_factory=list)
+    confidence: float = 0.5
+    tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.confidence = max(0.0, min(1.0, float(self.confidence)))
+        self.tags = sorted(set(self.tags))
+        self.influences = list(self.influences)
+        self.evidence = list(self.evidence)
+        if isinstance(self.created_at, str):
+            self.created_at = datetime.fromisoformat(self.created_at)
+
+    @classmethod
+    def new(
+        cls,
+        prompt: str,
+        conclusion: str,
+        rationale: str,
+        *,
+        actor: str = "po-trace",
+        influences: Optional[Iterable[str]] = None,
+        evidence: Optional[Iterable[str]] = None,
+        confidence: float = 0.5,
+        tags: Optional[Iterable[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        version: str = "1.0",
+    ) -> "ReasonLog":
+        """Create a new ``ReasonLog`` with generated identifiers and timestamp."""
+
+        return cls(
+            id=str(uuid4()),
+            version=version,
+            created_at=_now(),
+            actor=actor,
+            prompt=prompt,
+            conclusion=conclusion,
+            rationale=rationale,
+            influences=list(influences or []),
+            evidence=list(evidence or []),
+            confidence=confidence,
+            tags=list(tags or []),
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ReasonLog":
+        return cls(
+            id=data["id"],
+            version=data.get("version", "1.0"),
+            created_at=data.get("created_at", _now().isoformat()),
+            actor=data["actor"],
+            prompt=data["prompt"],
+            conclusion=data["conclusion"],
+            rationale=data["rationale"],
+            influences=data.get("influences", []),
+            evidence=data.get("evidence", []),
+            confidence=data.get("confidence", 0.5),
+            tags=data.get("tags", []),
+            metadata=data.get("metadata", {}),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "version": self.version,
+            "created_at": self.created_at.isoformat(),
+            "actor": self.actor,
+            "prompt": self.prompt,
+            "conclusion": self.conclusion,
+            "rationale": self.rationale,
+            "influences": self.influences,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "tags": self.tags,
+            "metadata": self.metadata,
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Reason Log {self.id}",
+            f"- Version: {self.version}",
+            f"- Created At: {self.created_at.isoformat()}",
+            f"- Actor: {self.actor}",
+            f"- Confidence: {self.confidence:.2f}",
+            f"- Tags: {', '.join(self.tags) if self.tags else 'none'}",
+            "\n## Prompt",
+            self.prompt,
+            "\n## Conclusion",
+            self.conclusion,
+            "\n## Rationale",
+            self.rationale,
+        ]
+        if self.influences:
+            lines.append("\n## Influences")
+            lines.extend(f"- {item}" for item in self.influences)
+        if self.evidence:
+            lines.append("\n## Evidence")
+            lines.extend(f"- {item}" for item in self.evidence)
+        if self.metadata:
+            lines.append("\n## Metadata")
+            lines.extend(f"- {k}: {v}" for k, v in sorted(self.metadata.items()))
+        return "\n".join(lines)
+
+    @classmethod
+    def from_json(cls, content: str) -> "ReasonLog":
+        return cls.from_dict(json.loads(content))
+
+    @classmethod
+    def load(cls, path: Path) -> "ReasonLog":
+        data = path.read_text(encoding="utf-8")
+        return cls.from_json(data)
+
+    def save(self, path: Path, fmt: str = "json") -> None:
+        if fmt == "markdown":
+            path.write_text(self.to_markdown(), encoding="utf-8")
+        else:
+            path.write_text(self.to_json(), encoding="utf-8")
+
 
 console = Console()
 
 
+@click.group()
 def cli() -> None:
-    """Po_trace CLI entry point"""
-    console.print("[bold green]🔍 Po_trace - Reasoning Audit Log[/bold green]")
-    console.print("Implementation coming soon...")
+    """Po_trace CLI entry point."""
+
+
+@cli.command(name="log")
+@click.option("prompt", "--prompt", required=False, help="Input prompt to record")
+@click.option("conclusion", "--conclusion", required=False, help="Outcome or decision")
+@click.option("rationale", "--rationale", required=False, help="Explanation of the decision")
+@click.option("actor", "--actor", default="po-trace", show_default=True, help="Source actor")
+@click.option("tags", "--tag", multiple=True, help="Tags to attach to the log")
+@click.option("confidence", "--confidence", type=float, default=0.5, show_default=True)
+@click.option("influence", "--influence", multiple=True, help="Influence references")
+@click.option("evidence", "--evidence", multiple=True, help="Evidence references")
+@click.option(
+    "fmt",
+    "--format",
+    type=click.Choice(["json", "markdown"], case_sensitive=False),
+    default="json",
+    show_default=True,
+    help="Serialization format",
+)
+@click.option(
+    "load_path",
+    "--load",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    help="Load and display an existing log",
+)
+@click.option(
+    "save_path",
+    "--save",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Save the generated log to a file",
+)
+def log_command(
+    *,
+    prompt: Optional[str],
+    conclusion: Optional[str],
+    rationale: Optional[str],
+    actor: str,
+    tags: Iterable[str],
+    confidence: float,
+    influence: Iterable[str],
+    evidence: Iterable[str],
+    fmt: str,
+    load_path: Optional[Path],
+    save_path: Optional[Path],
+) -> None:
+    """Create or view reasoning logs.
+
+    Without ``--load`` the command generates a new log from the provided prompt,
+    conclusion, and rationale. When ``--load`` is used the CLI renders the
+    existing log in a human-readable table.
+    """
+
+    if load_path:
+        log = ReasonLog.load(load_path)
+        _display_log(log)
+        return
+
+    if not prompt or not conclusion or not rationale:
+        raise click.UsageError("prompt, conclusion, and rationale are required when creating a log")
+
+    log = ReasonLog.new(
+        prompt=prompt,
+        conclusion=conclusion,
+        rationale=rationale,
+        actor=actor,
+        influences=influence,
+        evidence=evidence,
+        confidence=confidence,
+        tags=tags,
+    )
+
+    if save_path:
+        log.save(save_path, fmt=fmt)
+        console.print(f"[green]Saved reason log to {save_path} ({fmt}).[/green]")
+    else:
+        console.print(log.to_markdown() if fmt == "markdown" else log.to_json())
+
+
+def _display_log(log: ReasonLog) -> None:
+    table = Table(title=f"Reason Log {log.id}")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+
+    table.add_row("Version", log.version)
+    table.add_row("Created At", log.created_at.isoformat())
+    table.add_row("Actor", log.actor)
+    table.add_row("Prompt", log.prompt)
+    table.add_row("Conclusion", log.conclusion)
+    table.add_row("Rationale", log.rationale)
+    table.add_row("Confidence", f"{log.confidence:.2f}")
+    table.add_row("Tags", ", ".join(log.tags) if log.tags else "-")
+    table.add_row("Influences", ", ".join(log.influences) if log.influences else "-")
+    table.add_row("Evidence", ", ".join(log.evidence) if log.evidence else "-")
+    table.add_row("Metadata", json.dumps(log.metadata, ensure_ascii=False))
+
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+# Ensure src directory is importable for tests without installation
+ROOT = Path(__file__).resolve().parents[1]
+src = ROOT / "src"
+if str(src) not in sys.path:
+    sys.path.insert(0, str(src))
+
+
+def pytest_addoption(parser):
+    """Provide stubs for coverage options when pytest-cov is unavailable."""
+
+    parser.addoption("--cov", action="append", default=[])
+    parser.addoption("--cov-report", action="append", default=[])

--- a/tests/fixtures/reason_log_sample.json
+++ b/tests/fixtures/reason_log_sample.json
@@ -1,0 +1,14 @@
+{
+  "id": "11111111-2222-3333-4444-555555555555",
+  "version": "1.0",
+  "created_at": "2024-01-01T00:00:00",
+  "actor": "unit-test",
+  "prompt": "Why choose a modular philosophy engine?",
+  "conclusion": "Modularity keeps philosophical perspectives composable.",
+  "rationale": "Each philosopher can evolve independently while sharing a stable interface.",
+  "influences": ["design-review:2024-01"],
+  "evidence": ["docs/specs/reason_log.md"],
+  "confidence": 0.73,
+  "tags": ["architecture", "reason-log"],
+  "metadata": {"reviewer": "cli"}
+}

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,25 @@
+from click.testing import CliRunner
+
+from po_core import __version__
+from po_core.cli import hello, status, version
+
+
+def test_hello() -> None:
+    runner = CliRunner()
+    result = runner.invoke(hello)
+    assert result.exit_code == 0
+    assert "Po_core" in result.output
+
+
+def test_status() -> None:
+    runner = CliRunner()
+    result = runner.invoke(status)
+    assert result.exit_code == 0
+    assert "Project Status" in result.output
+
+
+def test_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(version)
+    assert result.exit_code == 0
+    assert __version__ in result.output

--- a/tests/test_po_self.py
+++ b/tests/test_po_self.py
@@ -1,0 +1,22 @@
+from click.testing import CliRunner
+
+from po_core.po_self import PhilosopherEngine, PhilosopherRegistry, cli as self_cli
+
+
+def test_registry_has_entries() -> None:
+    registry = PhilosopherRegistry()
+    assert len(registry.names) > 3
+
+
+def test_engine_combines_reasoning() -> None:
+    engine = PhilosopherEngine()
+    result = engine.run("What is courage?", selected=list(engine.registry.names)[:2])
+    assert result["combined_reasoning"]
+    assert result["responses"]
+
+
+def test_po_self_cli_run() -> None:
+    runner = CliRunner()
+    result = runner.invoke(self_cli, ["run", "--prompt", "Test prompt", "--philosopher", "Friedrich Nietzsche"])
+    assert result.exit_code == 0
+    assert "Combined Reasoning" in result.output

--- a/tests/test_po_trace.py
+++ b/tests/test_po_trace.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from po_core.po_trace import ReasonLog, cli as trace_cli
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "reason_log_sample.json"
+
+
+def test_reason_log_matches_spec_fields() -> None:
+    data = ReasonLog.load(FIXTURE)
+    spec_keys = {
+        "id",
+        "version",
+        "created_at",
+        "actor",
+        "prompt",
+        "conclusion",
+        "rationale",
+        "influences",
+        "evidence",
+        "confidence",
+        "tags",
+        "metadata",
+    }
+    assert set(data.to_dict().keys()) == spec_keys
+    assert data.created_at.isoformat() == "2024-01-01T00:00:00"
+    assert data.tags == sorted(data.tags)
+
+
+def test_reason_log_markdown_roundtrip(tmp_path: Path) -> None:
+    log = ReasonLog.new(
+        prompt="Test prompt",
+        conclusion="Test conclusion",
+        rationale="Because tests demand it.",
+        actor="tester",
+        tags=["demo"],
+        evidence=["unit"],
+        influences=["spec"],
+        confidence=0.9,
+    )
+    markdown_path = tmp_path / "log.md"
+    log.save(markdown_path, fmt="markdown")
+    assert markdown_path.exists()
+    assert "## Prompt" in markdown_path.read_text(encoding="utf-8")
+
+
+def test_po_trace_cli_create_and_load(tmp_path: Path) -> None:
+    runner = CliRunner()
+    output_path = tmp_path / "log.json"
+    result_create = runner.invoke(
+        trace_cli,
+        [
+            "log",
+            "--prompt",
+            "CLI prompt",
+            "--conclusion",
+            "Answer",
+            "--rationale",
+            "Reasoning",
+            "--tag",
+            "cli",
+            "--save",
+            str(output_path),
+        ],
+    )
+    assert result_create.exit_code == 0
+    assert output_path.exists()
+
+    result_load = runner.invoke(trace_cli, ["log", "--load", str(output_path)])
+    assert result_load.exit_code == 0
+    assert "Reason Log" in result_load.output


### PR DESCRIPTION
## Summary
- add ReasonLog dataclass with JSON/Markdown serialization and CLI read/write commands
- document reason log schema and provide fixtures plus pytest coverage for po-trace CLI and core commands
- implement philosopher registry/engine with CLI runner and add CI workflow plus smoke tests

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ee8a5ab883289568f22946da9182)