### PR TITLE
Add baseline tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run linters
+        run: |
+          black --check .
+          isort --check-only .
+          flake8 .
+
+      - name: Run tests
+        run: |
+          python -m pytest -m "unit and not philosophical"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Po_core testing guide
+
+This directory contains automated tests for the Po_core CLI and future modules. Use it to validate changes locally before opening a pull request and to mirror the checks run in CI.
+
+## Environment setup
+
+- Python: 3.9–3.12 (project is tested with 3.11 in CI).
+- Create and activate a virtual environment (e.g., `python -m venv .venv && source .venv/bin/activate`).
+- Install dependencies:
+  - Recommended: `python -m pip install --upgrade pip`
+  - Development extras: `python -m pip install -e .[dev]`
+  - Alternatively, `python -m pip install -r requirements-dev.txt`
+
+## Running tests
+
+- All tests: `python -m pytest`
+- Unit tests only: `python -m pytest -m unit`
+- Include integration tests: `python -m pytest -m "unit or integration"`
+- Run full suite including philosophical scenarios: `python -m pytest -m "unit or integration or philosophical"`
+
+## Marker policy
+
+- `unit`: Fast, deterministic checks suitable for every push and PR. CI runs these markers by default.
+- `integration`: Broader surface tests that may touch external resources or larger flows. Run locally when you modify boundaries or integrations.
+- `philosophical`: Narrative or exploratory scenarios that may be slower or have richer output. Opt-in locally.
+
+## Notes
+
+- Keep tests idempotent and free of network calls by default.
+- Align new tests with existing markers so contributors can target the right scope.

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,0 +1,34 @@
+import pytest
+from click.testing import CliRunner
+
+from po_core import __version__
+from po_core.cli import main
+
+
+@pytest.mark.unit
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Po_core: Philosophy-Driven AI System" in result.output
+    assert "hello" in result.output
+
+
+@pytest.mark.unit
+def test_cli_version_option():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+@pytest.mark.unit
+def test_cli_hello_command():
+    runner = CliRunner()
+    result = runner.invoke(main, ["hello"])
+
+    assert result.exit_code == 0
+    assert "Po_core へようこそ" in result.output
+    assert "Po_core へようこそ" in result.stdout


### PR DESCRIPTION
## Summary
- add a testing guide under `tests/` outlining environment setup and marker usage
- introduce CLI smoke tests that exercise help, version, and hello flows
- set up a GitHub Actions workflow to run linting and the unit test suite on pushes and pull requests

## Testing
- PYTHONPATH=src python -m pytest -m unit -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243aa4e23083288e22dac5d43db789)