### PR TITLE
Implement Po_self reasoning ensemble pipeline

### DIFF
--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from po_core import __author__, __email__, __version__
+from po_core.po_self import run_ensemble
 
 console = Console()
 
@@ -61,6 +62,30 @@ def version() -> None:
     console.print("\n")
     console.print(table)
     console.print("\n[dim]A frog in a well may not know the ocean, but it can know the sky.[/dim]")
+
+
+@main.command()
+@click.option("--prompt", required=True, help="Prompt to run through the Po_self ensemble")
+def self(prompt: str) -> None:
+    """Run Po_self ensemble reasoning."""
+
+    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
+    result = run_ensemble(prompt)
+
+    console.print("\n[bold]Minimal Response[/bold]")
+    console.print(result.response)
+
+    console.print("\n[bold]Design Signals[/bold]")
+    console.print(
+        f"Freedom Pressure: {result.design_signals.freedom_pressure}\n"
+        f"Ethical Resonance: {result.design_signals.ethical_resonance}\n"
+        f"Responsibility Pressure: {result.design_signals.responsibility_pressure}\n"
+        f"Meaning Profile: {result.design_signals.meaning_profile}"
+    )
+
+    console.print("\n[bold]Philosopher Log[/bold]")
+    for signal in result.philosopher_signals:
+        console.print(f"- {signal.name} (w={result.weights.get(signal.name, 0):.2f}): {signal.reasoning}")
 
 
 if __name__ == "__main__":

--- a/src/po_core/philosophers/__init__.py
+++ b/src/po_core/philosophers/__init__.py
@@ -8,7 +8,7 @@ Each philosopher represents a different perspective and approach to meaning gene
 from po_core.philosophers.arendt import Arendt
 from po_core.philosophers.aristotle import Aristotle
 from po_core.philosophers.badiou import Badiou
-from po_core.philosophers.base import Philosopher
+from po_core.philosophers.base import Philosopher, PhilosopherSignal
 from po_core.philosophers.confucius import Confucius
 from po_core.philosophers.deleuze import Deleuze
 from po_core.philosophers.derrida import Derrida
@@ -49,4 +49,5 @@ __all__ = [
     "Watsuji",
     "Wittgenstein",
     "Zhuangzi",
+    "PhilosopherSignal",
 ]

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -1,21 +1,143 @@
-"""
-Po_self: Philosophical Ensemble Module
+"""Philosophical ensemble and design signals for Po_self."""
 
-The core reasoning engine that integrates multiple philosophers
-as interacting tensors.
-"""
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional
 
-import click
-from rich.console import Console
-
-console = Console()
-
-
-def cli() -> None:
-    """Po_self CLI entry point"""
-    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+from po_core.philosophers import (
+    Heidegger,
+    Levinas,
+    Nietzsche,
+    Philosopher,
+    PhilosopherSignal,
+    Sartre,
+    Watsuji,
+)
 
 
-if __name__ == "__main__":
-    cli()
+@dataclass
+class DesignSignals:
+    """Lightweight container for README-driven design cues."""
+
+    freedom_pressure: float
+    ethical_resonance: float
+    responsibility_pressure: float
+    meaning_profile: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class EnsembleResult:
+    """Aggregated result of Po_self ensemble reasoning."""
+
+    prompt: str
+    response: str
+    weights: Dict[str, float]
+    philosopher_signals: List[PhilosopherSignal]
+    design_signals: DesignSignals
+
+
+def compute_meaning_profile(prompt: str) -> Dict[str, float]:
+    """Derive a minimal meaning profile inspired by README signals."""
+
+    tokens = [token.strip(".,!?") for token in prompt.lower().split() if token]
+    length = max(len(tokens), 1)
+
+    poetic = sum(1 for token in tokens if len(token) >= 7) / length
+    action = sum(1 for token in tokens if token.endswith("ing")) / length
+    relation = sum(1 for token in tokens if token in {"with", "together", "between", "relation"}) / length
+
+    return {
+        "poetic_granularity": round(poetic, 3),
+        "action_intent": round(action, 3),
+        "relational_density": round(relation, 3),
+    }
+
+
+def compute_freedom_pressure_tensor(prompt: str, observation_pressure: float = 0.5) -> float:
+    """Approximate the freedom pressure tensor from prompt features."""
+
+    prompt_energy = min(len(prompt) / 280, 1.0)
+    creativity_bias = 0.35 if any(symbol in prompt for symbol in {"?", "!"}) else 0.15
+    freedom_pressure = prompt_energy * (1 - observation_pressure) + creativity_bias
+
+    return round(min(max(freedom_pressure, 0.0), 1.0), 3)
+
+
+def compute_ethical_resonance(prompt: str) -> float:
+    """Estimate ethical resonance by detecting normative vocabulary."""
+
+    ethical_tokens = {"should", "must", "responsibility", "ethic", "care", "justice", "duty"}
+    tokens = prompt.lower().split()
+    if not tokens:
+        return 0.0
+
+    matches = sum(1 for token in tokens if any(key in token for key in ethical_tokens))
+    return round(min(matches / len(tokens) + 0.1, 1.0), 3)
+
+
+def compute_design_signals(prompt: str, observation_pressure: float = 0.5) -> DesignSignals:
+    """Bundle core design signals (freedom, ethics, responsibility)."""
+
+    freedom_pressure = compute_freedom_pressure_tensor(prompt, observation_pressure)
+    ethical_resonance = compute_ethical_resonance(prompt)
+    meaning_profile = compute_meaning_profile(prompt)
+
+    responsibility_pressure = round(
+        (freedom_pressure + ethical_resonance) / 2 + meaning_profile["relational_density"] * 0.2,
+        3,
+    )
+
+    return DesignSignals(
+        freedom_pressure=freedom_pressure,
+        ethical_resonance=ethical_resonance,
+        responsibility_pressure=min(responsibility_pressure, 1.0),
+        meaning_profile=meaning_profile,
+    )
+
+
+def _normalize_weights(philosophers: Iterable[Philosopher], weights: Optional[Mapping[str, float]]) -> Dict[str, float]:
+    provided = weights or {}
+    normalized: Dict[str, float] = {}
+
+    for philosopher in philosophers:
+        normalized[philosopher.name] = float(provided.get(philosopher.name, 1.0))
+
+    total = sum(normalized.values()) or 1.0
+    return {name: value / total for name, value in normalized.items()}
+
+
+def load_default_philosophers() -> List[Philosopher]:
+    """Load a compact yet diverse ensemble of philosophers."""
+
+    return [Nietzsche(), Sartre(), Heidegger(), Levinas(), Watsuji()]
+
+
+def run_ensemble(
+    prompt: str,
+    *,
+    observation_pressure: float = 0.5,
+    weights: Optional[Mapping[str, float]] = None,
+    philosophers: Optional[List[Philosopher]] = None,
+) -> EnsembleResult:
+    """Execute Po_self ensemble reasoning with simple weighted aggregation."""
+
+    if not prompt.strip():
+        raise ValueError("Prompt must not be empty")
+
+    philosopher_instances = philosophers or load_default_philosophers()
+    weight_map = _normalize_weights(philosopher_instances, weights)
+
+    signals = [philosopher.analyze(prompt) for philosopher in philosopher_instances]
+    design_signals = compute_design_signals(prompt, observation_pressure)
+
+    weighted_fragments = [
+        f"{signal.name}: {signal.reasoning}" for signal in signals if signal.reasoning
+    ]
+    response = " \n".join(weighted_fragments[:3]) or "No reasoning available."
+
+    return EnsembleResult(
+        prompt=prompt,
+        response=response,
+        weights=weight_map,
+        philosopher_signals=signals,
+        design_signals=design_signals,
+    )

--- a/tests/test_po_self.py
+++ b/tests/test_po_self.py
@@ -1,0 +1,60 @@
+"""Unit tests for Po_self ensemble and design signals."""
+
+from po_core.philosophers.base import Philosopher
+from po_core.po_self import (
+    EnsembleResult,
+    compute_design_signals,
+    compute_freedom_pressure_tensor,
+    compute_meaning_profile,
+    run_ensemble,
+)
+
+
+class MockPhilosopher(Philosopher):
+    """Lightweight mock philosopher for ensemble tests."""
+
+    def __init__(self, name: str, reasoning: str):
+        super().__init__(name=name, description="mock")
+        self._reasoning = reasoning
+
+    def reason(self, prompt: str, context=None):  # type: ignore[override]
+        return {
+            "reasoning": f"{self._reasoning}-{prompt}",
+            "perspective": "test",
+            "tension": ["mock tension"],
+            "metadata": {"mock": True},
+        }
+
+
+def test_meaning_profile_contains_expected_keys() -> None:
+    profile = compute_meaning_profile("Acting together with curiosity and responsibility")
+
+    assert set(profile.keys()) == {"poetic_granularity", "action_intent", "relational_density"}
+    assert all(0.0 <= value <= 1.0 for value in profile.values())
+
+
+def test_freedom_pressure_tensor_is_bounded() -> None:
+    freedom_pressure = compute_freedom_pressure_tensor("What should I do?", observation_pressure=0.25)
+
+    assert 0.0 <= freedom_pressure <= 1.0
+
+
+def test_run_ensemble_with_mock_philosophers() -> None:
+    philosophers = [
+        MockPhilosopher("Mock A", "reasoning-A"),
+        MockPhilosopher("Mock B", "reasoning-B"),
+    ]
+
+    result = run_ensemble(
+        "prompt",
+        observation_pressure=0.4,
+        weights={"Mock A": 2.0, "Mock B": 1.0},
+        philosophers=philosophers,
+    )
+
+    assert isinstance(result, EnsembleResult)
+    assert len(result.philosopher_signals) == 2
+    assert result.weights["Mock A"] > result.weights["Mock B"]
+    assert "Mock A" in result.response
+    assert result.design_signals.responsibility_pressure <= 1.0
+


### PR DESCRIPTION
## Summary
- add a normalized PhilosopherSignal interface so philosopher modules can be aggregated consistently
- implement Po_self ensemble reasoning with design signal calculations and CLI exposure via `po-core self`
- add mock-based unit tests to cover design signal computation and ensemble flow

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924bb37a9148328ad41908d3e66a6eb)