### PR TITLE
Add CLI smoke tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --no-deps
+          pip install pytest pytest-randomly pytest-cov click rich
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ A frog in a well may not know the ocean, but it can know the sky.
 
 ---
 
+## Testing
+
+The project includes smoke tests for the current CLI commands (`hello`, `status`, `version`).
+
+```bash
+# Install development dependencies (including pytest)
+pip install -r requirements-dev.txt
+
+# Run the test suite
+pytest
+```
+
+If you prefer a lightweight setup focused on the CLI tests, install only the runtime and test tooling:
+
+```bash
+pip install -e . --no-deps
+pip install pytest pytest-cov pytest-randomly click rich
+pytest
+```
+
+---
+
 ## Future Usage (Planned)
 
 The full philosophical AI system is under development:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ pytest-cov>=4.1.0
 pytest-asyncio>=0.21.0
 pytest-mock>=3.12.0
 pytest-xdist>=3.5.0  # Parallel testing
+pytest-randomly>=3.15.0  # Deterministic test order
 
 # Test Utilities
 hypothesis>=6.92.0  # Property-based testing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+from click.testing import CliRunner
+
+from po_core.cli import main
+
+
+def test_hello_command_outputs_welcome_message() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["hello"])
+
+    assert result.exit_code == 0
+    assert "Po_core" in result.output
+    assert "Philosophy-Driven AI System" in result.output
+
+
+def test_status_command_reports_project_progress() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["status"])
+
+    assert result.exit_code == 0
+    assert "Project Status" in result.output
+    assert "Testing" in result.output
+    assert "Visualization" in result.output
+
+
+def test_version_command_displays_project_metadata() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["version"])
+
+    assert result.exit_code == 0
+    assert "Po_core" in result.output
+    assert "Author" in result.output
+    assert "Email" in result.output


### PR DESCRIPTION
## Summary
- add smoke tests for the existing CLI commands
- document test execution steps and expand dev test dependencies
- introduce a GitHub Actions workflow to run pytest in CI

## Testing
- PYTHONPATH=src pytest -c /dev/null tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c0e80a988328bda62745c593508b)