### PR TITLE
Wire CLI to Po_self and Po_trace modules

### DIFF
--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -4,22 +4,27 @@ Po_core CLI - Main Command Line Interface
 Entry point for the po-core command.
 """
 
+from pathlib import Path
+from typing import Iterable, List
+
 import click
 from rich.console import Console
 from rich.table import Table
 
 from po_core import __author__, __email__, __version__
+from po_core.po_self import available_philosophers, render_po_self_summary, run_po_self
+from po_core.po_trace import log_trace
 
 console = Console()
 
 
 @click.group()
-@click.version_option(version="0.1.0-alpha", prog_name="po-core")
+@click.version_option(version=__version__, prog_name="po-core")
 def main() -> None:
     """
     Po_core: Philosophy-Driven AI System 🐷🎈
 
-    A system that integrates philosophers as dynamic tensors
+    Orchestrates philosophical ensembles (Po_self) and trace logging (Po_trace)
     for responsible meaning generation.
     """
     pass
@@ -33,16 +38,47 @@ def hello() -> None:
     console.print("\n[italic]A frog in a well may not know the ocean, but it can know the sky.[/italic]")
 
 
+def _default_philosophers() -> List[str]:
+    """Return the default philosopher selection for the CLI."""
+
+    defaults = ["confucius", "nietzsche", "wittgenstein"]
+    return [name for name in defaults if name in available_philosophers()]
+
+
 @main.command()
-def status() -> None:
-    """Show project status"""
-    console.print("[bold]📊 Po_core Project Status[/bold]\n")
-    console.print("✅ Philosophical Framework: 100%")
-    console.print("✅ Documentation: 100%")
-    console.print("✅ Architecture Design: 100%")
-    console.print("🔄 Implementation: 30%")
-    console.print("⏳ Testing: 0%")
-    console.print("⏳ Visualization: 0%")
+@click.option(
+    "--prompt",
+    "-p",
+    required=True,
+    help="Prompt to route through the Po_self ensemble.",
+)
+@click.option(
+    "--philosopher",
+    "-f",
+    multiple=True,
+    help="Philosophers to activate (e.g., nietzsche, confucius). Defaults to a curated trio.",
+)
+@click.option(
+    "--log-path",
+    "-l",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=Path("po_trace.log"),
+    show_default=True,
+    help="Where to store the Po_trace JSONL log.",
+)
+def status(prompt: str, philosopher: Iterable[str], log_path: Path) -> None:
+    """Route a prompt through Po_self and persist its Po_trace audit."""
+
+    selection = list(philosopher) or _default_philosophers()
+    try:
+        results = run_po_self(prompt, selection)
+    except (KeyError, ValueError) as exc:
+        raise click.BadParameter(str(exc)) from exc
+
+    render_po_self_summary(prompt, results)
+
+    trace_path = log_trace(prompt, results, log_path)
+    console.print(f"\n[green]🔍 Trace saved to[/green] {trace_path}")
 
 
 @main.command()
@@ -52,7 +88,7 @@ def version() -> None:
     table.add_column(style="bold cyan")
     table.add_column()
 
-    table.add_row("🐷🎈 Po_core", f"v{__version__}")
+    table.add_row("🐷🎈 Po_core", f"v{__version__} (with Po_self & Po_trace)")
     table.add_row("Author", __author__)
     table.add_row("Email", __email__)
     table.add_row("Philosophy", "Flying Pig - When Pigs Fly")

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -5,16 +5,106 @@ The core reasoning engine that integrates multiple philosophers
 as interacting tensors.
 """
 
-import click
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Type
+
 from rich.console import Console
+
+from po_core import philosophers
 
 console = Console()
 
+PHILOSOPHER_REGISTRY: Mapping[str, Type[philosophers.Philosopher]] = {
+    "arendt": philosophers.Arendt,
+    "aristotle": philosophers.Aristotle,
+    "badiou": philosophers.Badiou,
+    "confucius": philosophers.Confucius,
+    "deleuze": philosophers.Deleuze,
+    "derrida": philosophers.Derrida,
+    "dewey": philosophers.Dewey,
+    "heidegger": philosophers.Heidegger,
+    "jung": philosophers.Jung,
+    "kierkegaard": philosophers.Kierkegaard,
+    "lacan": philosophers.Lacan,
+    "levinas": philosophers.Levinas,
+    "merleau_ponty": philosophers.MerleauPonty,
+    "nietzsche": philosophers.Nietzsche,
+    "peirce": philosophers.Peirce,
+    "sartre": philosophers.Sartre,
+    "wabi_sabi": philosophers.WabiSabi,
+    "watsuji": philosophers.Watsuji,
+    "wittgenstein": philosophers.Wittgenstein,
+    "zhuangzi": philosophers.Zhuangzi,
+}
+
+
+def available_philosophers() -> List[str]:
+    """Return a sorted list of available philosopher keys."""
+
+    return sorted(PHILOSOPHER_REGISTRY.keys())
+
+
+def _normalize_selection(selection: Iterable[str]) -> List[str]:
+    """Normalize user-provided philosopher names to registry keys."""
+
+    normalized: List[str] = []
+    for name in selection:
+        key = name.lower().replace("-", "_").replace(" ", "_")
+        if key not in PHILOSOPHER_REGISTRY:
+            raise KeyError(f"Unknown philosopher '{name}'. Try one of: {', '.join(available_philosophers())}")
+        normalized.append(key)
+    return normalized
+
+
+def run_po_self(prompt: str, selection: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Run the Po_self reasoning ensemble for the given prompt."""
+
+    if not prompt.strip():
+        raise ValueError("Prompt cannot be empty.")
+
+    normalized_selection = _normalize_selection(selection) if selection else available_philosophers()[:3]
+    results: Dict[str, Dict[str, Any]] = {}
+
+    for key in normalized_selection:
+        philosopher_cls = PHILOSOPHER_REGISTRY[key]
+        thinker = philosopher_cls()
+        analysis = thinker.reason(prompt)
+
+        display_name = thinker.name
+        results[display_name] = {
+            "reasoning": analysis.get("reasoning", ""),
+            "perspective": analysis.get("perspective", ""),
+            "metadata": analysis.get("metadata", {}),
+        }
+
+    return results
+
+
+def render_po_self_summary(prompt: str, results: Mapping[str, Mapping[str, Any]]) -> None:
+    """Render a Rich table summarizing Po_self analyses."""
+
+    console.print("[bold magenta]\n🧠 Po_self - Philosophical Ensemble[/bold magenta]")
+    console.print(f"[dim]Prompt:[/dim] {prompt}\n")
+
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Philosopher", style="bold")
+    table.add_column("Perspective")
+    table.add_column("Reasoning")
+
+    for name, analysis in results.items():
+        table.add_row(name, analysis.get("perspective", ""), analysis.get("reasoning", ""))
+
+    console.print(table)
+
 
 def cli() -> None:
-    """Po_self CLI entry point"""
+    """Po_self CLI entry point for manual invocation."""
+
     console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+    console.print("This module is designed to be orchestrated through the main Po_core CLI.")
 
 
 if __name__ == "__main__":

--- a/src/po_core/po_trace.py
+++ b/src/po_core/po_trace.py
@@ -5,16 +5,42 @@ Tracks and logs the complete reasoning process,
 including what was said and what was not said.
 """
 
-import click
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional
+
 from rich.console import Console
 
 console = Console()
 
 
+def log_trace(prompt: str, analyses: Mapping[str, Mapping[str, Any]], log_path: Optional[Path] = None) -> Path:
+    """Persist a reasoning trace to disk as a JSONL entry."""
+
+    target_path = log_path or Path("po_trace.log")
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry: MutableMapping[str, Any] = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "prompt": prompt,
+        "analyses": analyses,
+    }
+
+    with target_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False))
+        handle.write("\n")
+
+    return target_path
+
+
 def cli() -> None:
-    """Po_trace CLI entry point"""
+    """Po_trace CLI entry point for manual invocation."""
+
     console.print("[bold green]🔍 Po_trace - Reasoning Audit Log[/bold green]")
-    console.print("Implementation coming soon...")
+    console.print("This module is designed to be orchestrated through the main Po_core CLI.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route the po-core CLI through the Po_self ensemble with prompt, philosopher, and log path options
- add Po_trace logging support and Rich summaries for analyses
- refresh CLI metadata to reflect the integrated modules while keeping hello/version commands

## Testing
- PYTHONPATH=src python -m po_core.cli --help
- PYTHONPATH=src python -m po_core.cli status -p "Should we explore the ocean?" --log-path /tmp/test_log.jsonl


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c46b590083288f1b938dac58f093)