### PR TITLE
Add smoke tests for deterministic ensemble CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run pytest
+        run: pytest

--- a/src/po_core/__init__.py
+++ b/src/po_core/__init__.py
@@ -11,7 +11,10 @@ __version__ = "0.1.0-alpha"
 __author__ = "Flying Pig Project"
 __email__ = "flyingpig0229+github@gmail.com"
 
+from po_core.ensemble import run_ensemble
+
 # Core exports will be added as implementation progresses
 __all__ = [
     "__version__",
+    "run_ensemble",
 ]

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -1,0 +1,50 @@
+"""Deterministic ensemble runner used by CLI smoke tests."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+DEFAULT_PHILOSOPHERS: List[str] = ["aristotle", "nietzsche", "wittgenstein"]
+
+
+def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -> Dict:
+    """Return a deterministic ensemble response for a given prompt.
+
+    This helper keeps outputs stable for tests and documentation by using
+    predictable scores and log messages. No external services or randomness are
+    involved.
+    """
+
+    selected = list(philosophers) if philosophers is not None else DEFAULT_PHILOSOPHERS
+    results = []
+    base_confidence = 0.88
+    for idx, name in enumerate(selected):
+        results.append(
+            {
+                "name": name,
+                "confidence": round(base_confidence - 0.05 * idx, 2),
+                "summary": f"{name.title()} reflects on '{prompt}'.",
+                "tags": ["analysis", "deterministic"],
+            }
+        )
+
+    log = {
+        "prompt": prompt,
+        "philosophers": selected,
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "events": [
+            {"event": "ensemble_started", "philosophers": len(selected)},
+            {
+                "event": "ensemble_completed",
+                "results_recorded": len(results),
+                "status": "ok",
+            },
+        ],
+    }
+
+    return {
+        "prompt": prompt,
+        "philosophers": selected,
+        "results": results,
+        "log": log,
+    }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,15 @@
+import json
+import pytest
+
+
+@pytest.fixture()
+def sample_prompt() -> str:
+    return "What does it mean to live authentically?"
+
+
+@pytest.fixture()
+def load_json_output():
+    def _loader(result) -> dict:
+        return json.loads(result.output.strip())
+
+    return _loader

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,50 @@
+import json
+
+from click.testing import CliRunner
+
+from po_core import __version__
+from po_core.cli import main
+
+
+def test_cli_hello_command():
+    runner = CliRunner()
+    result = runner.invoke(main, ["hello"])
+
+    assert result.exit_code == 0
+    assert "Po_core" in result.output
+
+
+def test_cli_status_command():
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+
+    assert result.exit_code == 0
+    assert "Project Status" in result.output
+
+
+def test_cli_version_command():
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+def test_cli_prompt_command_returns_json(sample_prompt):
+    runner = CliRunner()
+    result = runner.invoke(main, ["prompt", sample_prompt, "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["prompt"] == sample_prompt
+    assert payload["results"]
+
+
+def test_cli_log_command_exposes_log(sample_prompt):
+    runner = CliRunner()
+    result = runner.invoke(main, ["log", sample_prompt])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["prompt"] == sample_prompt
+    assert "events" in payload

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -1,0 +1,20 @@
+from po_core.ensemble import DEFAULT_PHILOSOPHERS, run_ensemble
+
+
+def test_run_ensemble_returns_expected_shape(sample_prompt):
+    result = run_ensemble(sample_prompt)
+
+    assert result["prompt"] == sample_prompt
+    assert result["philosophers"] == DEFAULT_PHILOSOPHERS
+    assert len(result["results"]) == len(DEFAULT_PHILOSOPHERS)
+
+    for entry in result["results"]:
+        assert set(entry) >= {"name", "confidence", "summary", "tags"}
+        assert isinstance(entry["confidence"], float)
+        assert sample_prompt in entry["summary"]
+
+    log = result["log"]
+    assert log["prompt"] == sample_prompt
+    assert log["philosophers"] == DEFAULT_PHILOSOPHERS
+    assert any(event["event"] == "ensemble_started" for event in log["events"])
+    assert any(event.get("results_recorded") == len(DEFAULT_PHILOSOPHERS) for event in log["events"])


### PR DESCRIPTION
## Summary
- add deterministic ensemble helper and expose prompt/log CLI commands
- add smoke tests for CLI commands and ensemble output shape
- introduce CI workflow to run pytest on pushes and pull requests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q -c /dev/null tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cc5118508328b5dada3e2397e849)