### PR TITLE
Add deterministic ensemble and CLI tests

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,7 +2,7 @@ import json
 
 from click.testing import CliRunner
 
-from po_core import __version__
+from po_core import __author__, __email__, __version__
 from po_core.cli import main
 
 
@@ -12,6 +12,7 @@ def test_cli_hello_command():
 
     assert result.exit_code == 0
     assert "Po_core" in result.output
+    assert "Welcome" not in result.output  # ensure original greeting kept
 
 
 def test_cli_status_command():
@@ -19,7 +20,9 @@ def test_cli_status_command():
     result = runner.invoke(main, ["status"])
 
     assert result.exit_code == 0
-    assert "Project Status" in result.output
+    assert "Po_core Project Status" in result.output
+    for check in ["Philosophical Framework", "Documentation", "Implementation", "Testing"]:
+        assert check in result.output
 
 
 def test_cli_version_command():
@@ -28,6 +31,8 @@ def test_cli_version_command():
 
     assert result.exit_code == 0
     assert __version__ in result.output
+    assert __author__ in result.output
+    assert __email__ in result.output
 
 
 def test_cli_prompt_command_returns_json(sample_prompt):
@@ -37,14 +42,24 @@ def test_cli_prompt_command_returns_json(sample_prompt):
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["prompt"] == sample_prompt
-    assert payload["results"]
+    assert payload["philosophers"]
+    assert len(payload["results"]) == len(payload["philosophers"])
 
 
-def test_cli_log_command_exposes_log(sample_prompt):
+def test_cli_prompt_command_returns_text(sample_prompt):
+    runner = CliRunner()
+    result = runner.invoke(main, ["prompt", sample_prompt, "--format", "text"])
+
+    assert result.exit_code == 0
+    assert "Prompt:" in result.output
+    assert sample_prompt in result.output
+
+
+def test_cli_log_command_exposes_log(sample_prompt, load_json_output):
     runner = CliRunner()
     result = runner.invoke(main, ["log", sample_prompt])
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = load_json_output(result)
     assert payload["prompt"] == sample_prompt
-    assert "events" in payload
+    assert payload["events"][0]["event"] == "ensemble_started"

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+import pytest
+
 from po_core.ensemble import DEFAULT_PHILOSOPHERS, run_ensemble
 
 
@@ -18,3 +22,51 @@ def test_run_ensemble_returns_expected_shape(sample_prompt):
     assert log["philosophers"] == DEFAULT_PHILOSOPHERS
     assert any(event["event"] == "ensemble_started" for event in log["events"])
     assert any(event.get("results_recorded") == len(DEFAULT_PHILOSOPHERS) for event in log["events"])
+
+
+@pytest.mark.unit
+def test_run_ensemble_is_deterministic_and_ordered(sample_prompt):
+    result = run_ensemble(sample_prompt)
+
+    names = [entry["name"] for entry in result["results"]]
+    assert names == DEFAULT_PHILOSOPHERS
+
+    expected_confidences = [0.88, 0.83, 0.78]
+    confidences = [entry["confidence"] for entry in result["results"]]
+    assert confidences == expected_confidences
+
+
+@pytest.mark.unit
+def test_run_ensemble_respects_custom_philosopher_order(sample_prompt):
+    custom = ["a", "b", "c", "d"]
+
+    result = run_ensemble(sample_prompt, philosophers=custom)
+
+    assert [entry["name"] for entry in result["results"]] == custom
+    assert result["philosophers"] == custom
+    assert result["log"]["philosophers"] == custom
+
+
+@pytest.mark.unit
+def test_run_ensemble_log_schema(sample_prompt):
+    result = run_ensemble(sample_prompt)
+
+    log = result["log"]
+    assert set(log) == {"prompt", "philosophers", "created_at", "events"}
+    assert log["philosophers"] == DEFAULT_PHILOSOPHERS
+
+    assert log["created_at"].endswith("Z")
+    # Confirm timestamp is ISO-8601 compatible (strip the trailing Z for parsing)
+    datetime.fromisoformat(log["created_at"].rstrip("Z"))
+
+    assert len(log["events"]) == 2
+    start_event, completed_event = log["events"]
+    assert start_event == {
+        "event": "ensemble_started",
+        "philosophers": len(DEFAULT_PHILOSOPHERS),
+    }
+    assert completed_event == {
+        "event": "ensemble_completed",
+        "results_recorded": len(DEFAULT_PHILOSOPHERS),
+        "status": "ok",
+    }


### PR DESCRIPTION
## Summary
- add deterministic ensemble tests to validate ordering, confidence values, custom philosopher lists, and log schema
- expand CLI smoke tests for hello, status, version, prompt (text/json), and log commands

## Testing
- PYTHONPATH=src pytest tests/unit -q -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e05f2cec8328a684165577e7a58e)