### PR TITLE
Add Makefile for unified development commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: install install-dev format lint typecheck test coverage security docs help
+
+install:
+	pip install -r requirements.txt
+
+install-dev:
+	pip install -r requirements-dev.txt
+
+format:
+	black src tests
+	isort src tests
+
+lint:
+	flake8 src tests
+	pylint src tests
+
+typecheck:
+	mypy src tests
+
+test:
+	pytest
+
+coverage:
+	pytest --cov=po_core --cov-report=term-missing
+
+security:
+	bandit -r src
+	safety check -r requirements.txt
+
+docs:
+	sphinx-build -b html docs docs/_build/html
+
+help:
+	@echo "Available commands:"
+	@echo "  make install       Install production dependencies"
+	@echo "  make install-dev   Install development dependencies"
+	@echo "  make format        Run black and isort"
+	@echo "  make lint          Run flake8 and pylint"
+	@echo "  make typecheck     Run mypy"
+	@echo "  make test          Run pytest"
+	@echo "  make coverage      Run pytest with coverage output"
+	@echo "  make security      Run bandit and safety checks"
+	@echo "  make docs          Build Sphinx documentation"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@
 [Viewer spec](./blob/main/docs/viewer/README.md)
 
 ## Contribution Tracks
+
+### 開発者向け: Makefile 主要コマンド一覧
+- `make install-dev`: 開発用依存関係をまとめてセットアップ
+- `make format`, `make lint`, `make typecheck`, `make test`: CI 相当の最小セット
+- `make coverage`: カバレッジ付きテスト（po_core を対象）
+- `make security`: bandit と safety によるセキュリティチェック
+- `make docs`: Sphinx ドキュメントを HTML ビルド
+
 ### <a id="ai-track"></a>👩‍💻 AI Track
 Start with `/04_modules` and CLI. Labels: `ai-easy`, `good first issue`
 


### PR DESCRIPTION
## Summary
- add a repository Makefile covering install, formatting, linting, testing, coverage, docs, and security commands
- document the key Makefile targets in the README for easier onboarding

## Testing
- make help
- make test *(fails: pytest config expects pytest-cov; pip install of pytest-cov from requirements-dev.txt was blocked by proxy/403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f09138d483288046898a689c6528)