### PR TITLE
Integrate Po_self ensemble pipeline

### DIFF
--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -11,9 +11,11 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from po_core import __author__, __email__, __version__, run_ensemble
+from po_core import __author__, __email__, __version__
+from po_core.po_self import PoSelf
 
 console = Console()
+SAMPLE_PROMPT = "What does it mean to live authentically?"
 
 
 @click.group()
@@ -38,16 +40,34 @@ def _format_prompt_output(data: dict, *, keys: Iterable[str]) -> str:
     return "\n".join(lines)
 
 
+def _render_sample_generation(prompt: str) -> str:
+    response = PoSelf().generate(prompt)
+    attributions = ", ".join(response.philosophers)
+    metrics = ", ".join(f"{k}={v}" for k, v in response.metrics.items())
+    leader = response.consensus_leader or "Unknown"
+    return (
+        f"Prompt: {prompt}\n"
+        f"Consensus Lead: {leader}\n"
+        f"Philosophers: {attributions}\n"
+        f"Metrics: {metrics}\n"
+    )
+
+
 @main.command()
-def hello() -> None:
+@click.option("--sample/--no-sample", default=False, help="Run a Po_self sample generation")
+def hello(sample: bool) -> None:
     """Say hello from Po_core"""
     console.print("[bold blue]🐷🎈 Po_core へようこそ![/bold blue]")
     console.print("Philosophy-Driven AI System - Alpha v0.1.0")
     console.print("\n[italic]A frog in a well may not know the ocean, but it can know the sky.[/italic]")
+    if sample:
+        console.print("\n[dim]Running Po_self sample...[/dim]")
+        console.print(_render_sample_generation(SAMPLE_PROMPT))
 
 
 @main.command()
-def status() -> None:
+@click.option("--sample/--no-sample", default=False, help="Run a Po_self sample generation")
+def status(sample: bool) -> None:
     """Show project status"""
     console.print("[bold]📊 Po_core Project Status[/bold]\n")
     console.print("✅ Philosophical Framework: 100%")
@@ -56,10 +76,14 @@ def status() -> None:
     console.print("🔄 Implementation: 30%")
     console.print("⏳ Testing: 0%")
     console.print("⏳ Visualization: 0%")
+    if sample:
+        console.print("\n[dim]Running Po_self sample...[/dim]")
+        console.print(_render_sample_generation(SAMPLE_PROMPT))
 
 
 @main.command()
-def version() -> None:
+@click.option("--sample/--no-sample", default=False, help="Run a Po_self sample generation")
+def version(sample: bool) -> None:
     """Show version information"""
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column(style="bold cyan")
@@ -74,6 +98,9 @@ def version() -> None:
     console.print("\n")
     console.print(table)
     console.print("\n[dim]A frog in a well may not know the ocean, but it can know the sky.[/dim]")
+    if sample:
+        console.print("\n[dim]Running Po_self sample...[/dim]")
+        console.print(_render_sample_generation(SAMPLE_PROMPT))
 
 
 @main.command()
@@ -88,14 +115,14 @@ def version() -> None:
 def prompt(prompt: str, output_format: str) -> None:
     """Run the deterministic ensemble against a prompt."""
 
-    result = run_ensemble(prompt)
+    response = PoSelf().generate(prompt)
     if output_format.lower() == "json":
-        console.print(json.dumps(result, indent=2))
+        click.echo(json.dumps(response.to_dict(), indent=2))
     else:
         console.print(
             _format_prompt_output(
-                result,
-                keys=["prompt", "philosophers"],
+                response.to_dict(),
+                keys=["prompt", "text", "philosophers"],
             )
         )
 
@@ -105,8 +132,8 @@ def prompt(prompt: str, output_format: str) -> None:
 def log(prompt: str) -> None:
     """Display the audit log for a deterministic ensemble run."""
 
-    run_data = run_ensemble(prompt)
-    console.print(json.dumps(run_data["log"], indent=2))
+    run_data = PoSelf().generate(prompt)
+    click.echo(json.dumps(run_data.log, indent=2))
 
 
 if __name__ == "__main__":

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -1,32 +1,162 @@
 """Deterministic ensemble runner used by CLI smoke tests."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional
+
+from po_core import philosophers
+from po_core.philosophers.base import Philosopher
 
 DEFAULT_PHILOSOPHERS: List[str] = ["aristotle", "nietzsche", "wittgenstein"]
 
 
-def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -> Dict:
-    """Return a deterministic ensemble response for a given prompt.
+PHILOSOPHER_REGISTRY: Dict[str, type[Philosopher]] = {
+    "arendt": philosophers.Arendt,
+    "aristotle": philosophers.Aristotle,
+    "badiou": philosophers.Badiou,
+    "confucius": philosophers.Confucius,
+    "deleuze": philosophers.Deleuze,
+    "derrida": philosophers.Derrida,
+    "dewey": philosophers.Dewey,
+    "heidegger": philosophers.Heidegger,
+    "jung": philosophers.Jung,
+    "kierkegaard": philosophers.Kierkegaard,
+    "lacan": philosophers.Lacan,
+    "levinas": philosophers.Levinas,
+    "merleau_ponty": philosophers.MerleauPonty,
+    "nietzsche": philosophers.Nietzsche,
+    "peirce": philosophers.Peirce,
+    "sartre": philosophers.Sartre,
+    "wabi_sabi": philosophers.WabiSabi,
+    "watsuji": philosophers.Watsuji,
+    "wittgenstein": philosophers.Wittgenstein,
+    "zhuangzi": philosophers.Zhuangzi,
+}
 
-    This helper keeps outputs stable for tests and documentation by using
-    predictable scores and log messages. No external services or randomness are
-    involved.
-    """
+
+@dataclass
+class PhilosopherTensor:
+    """Structured view of a philosopher's contribution."""
+
+    name: str
+    reasoning: str
+    perspective: str
+    freedom_pressure: float
+    semantic_delta: float
+    blocked_tensor: float
+    tension: str | None = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "reasoning": self.reasoning,
+            "perspective": self.perspective,
+            "tension": self.tension,
+            "freedom_pressure": self.freedom_pressure,
+            "semantic_delta": self.semantic_delta,
+            "blocked_tensor": self.blocked_tensor,
+        }
+
+
+@dataclass
+class EnsembleMetrics:
+    """Aggregate ensemble metrics."""
+
+    freedom_pressure: float
+    semantic_delta: float
+    blocked_tensor: float
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            "freedom_pressure": self.freedom_pressure,
+            "semantic_delta": self.semantic_delta,
+            "blocked_tensor": self.blocked_tensor,
+        }
+
+
+def _tokenize(text: str) -> List[str]:
+    tokens: List[str] = []
+    for raw in text.split():
+        cleaned = raw.strip(".,!?\"'()[]{}:;`").lower()
+        if cleaned:
+            tokens.append(cleaned)
+    return tokens
+
+
+def _compute_freedom_pressure(reasoning: str) -> float:
+    tokens = _tokenize(reasoning)
+    if not tokens:
+        return 0.35
+    unique_ratio = len(set(tokens)) / len(tokens)
+    return round(0.35 + 0.65 * unique_ratio, 2)
+
+
+def _compute_semantic_delta(prompt: str, reasoning: str) -> float:
+    prompt_tokens = set(_tokenize(prompt))
+    reasoning_tokens = set(_tokenize(reasoning))
+    if not prompt_tokens or not reasoning_tokens:
+        return 1.0
+    overlap = len(prompt_tokens & reasoning_tokens)
+    coverage = overlap / len(prompt_tokens)
+    return round(1 - coverage, 2)
+
+
+def _compute_blocked_tensor(freedom_pressure: float, semantic_delta: float) -> float:
+    return round(max(0.0, (1 - freedom_pressure) * 0.5 + semantic_delta * 0.5), 2)
+
+
+def _load_philosophers(names: Iterable[str]) -> List[Philosopher]:
+    loaded: List[Philosopher] = []
+    for name in names:
+        key = name.lower()
+        if key not in PHILOSOPHER_REGISTRY:
+            raise ValueError(f"Unknown philosopher: {name}")
+        loaded.append(PHILOSOPHER_REGISTRY[key]())
+    return loaded
+
+
+def _aggregate_metrics(tensors: List[PhilosopherTensor]) -> EnsembleMetrics:
+    if not tensors:
+        return EnsembleMetrics(0.0, 0.0, 0.0)
+
+    freedom_avg = round(sum(t.freedom_pressure for t in tensors) / len(tensors), 2)
+    delta_avg = round(sum(t.semantic_delta for t in tensors) / len(tensors), 2)
+    blocked_avg = round(sum(t.blocked_tensor for t in tensors) / len(tensors), 2)
+    return EnsembleMetrics(freedom_avg, delta_avg, blocked_avg)
+
+
+def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -> Dict:
+    """Return a structured ensemble response for a given prompt."""
 
     selected = list(philosophers) if philosophers is not None else DEFAULT_PHILOSOPHERS
-    results = []
-    base_confidence = 0.88
-    for idx, name in enumerate(selected):
-        results.append(
-            {
-                "name": name,
-                "confidence": round(base_confidence - 0.05 * idx, 2),
-                "summary": f"{name.title()} reflects on '{prompt}'.",
-                "tags": ["analysis", "deterministic"],
-            }
+    thinkers = _load_philosophers(selected)
+
+    tensors: List[PhilosopherTensor] = []
+    for thinker in thinkers:
+        reasoning_result = thinker.reason(prompt)
+        reasoning_text = str(reasoning_result.get("reasoning", ""))
+        perspective = str(reasoning_result.get("perspective", ""))
+        tension = reasoning_result.get("tension")
+
+        freedom_pressure = _compute_freedom_pressure(reasoning_text)
+        semantic_delta = _compute_semantic_delta(prompt, reasoning_text)
+        blocked_tensor = _compute_blocked_tensor(freedom_pressure, semantic_delta)
+
+        tensors.append(
+            PhilosopherTensor(
+                name=thinker.name,
+                reasoning=reasoning_text,
+                perspective=perspective,
+                tension=tension,
+                freedom_pressure=freedom_pressure,
+                semantic_delta=semantic_delta,
+                blocked_tensor=blocked_tensor,
+            )
         )
+
+    aggregate = _aggregate_metrics(tensors)
+    ranked = sorted(tensors, key=lambda tensor: tensor.freedom_pressure, reverse=True)
 
     log = {
         "prompt": prompt,
@@ -36,15 +166,22 @@ def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -
             {"event": "ensemble_started", "philosophers": len(selected)},
             {
                 "event": "ensemble_completed",
-                "results_recorded": len(results),
-                "status": "ok",
+                "results_recorded": len(tensors),
+                "status": "ok" if tensors else "empty",
             },
         ],
     }
 
+    consensus_text = ranked[0].reasoning if ranked else ""
+
     return {
         "prompt": prompt,
         "philosophers": selected,
-        "results": results,
+        "responses": [tensor.to_dict() for tensor in tensors],
+        "aggregate": aggregate.to_dict(),
+        "consensus": {
+            "leader": ranked[0].name if ranked else None,
+            "text": consensus_text,
+        },
         "log": log,
     }

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -4,17 +4,79 @@ Po_self: Philosophical Ensemble Module
 The core reasoning engine that integrates multiple philosophers
 as interacting tensors.
 """
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
 
 import click
 from rich.console import Console
 
+from po_core.ensemble import DEFAULT_PHILOSOPHERS, run_ensemble
+
 console = Console()
+
+
+@dataclass
+class PoSelfResponse:
+    """Structured response returned by Po_self.generate."""
+
+    prompt: str
+    text: str
+    metrics: Dict[str, float]
+    philosophers: List[str]
+    consensus_leader: Optional[str]
+    responses: List[Dict[str, object]]
+    log: Dict[str, object]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "prompt": self.prompt,
+            "text": self.text,
+            "metrics": self.metrics,
+            "philosophers": self.philosophers,
+            "consensus_leader": self.consensus_leader,
+            "responses": self.responses,
+            "log": self.log,
+        }
+
+
+class PoSelf:
+    """Coordinate philosopher tensors and expose a deterministic generate API."""
+
+    def __init__(self, *, philosophers: Optional[Iterable[str]] = None) -> None:
+        self.philosophers = list(philosophers) if philosophers is not None else DEFAULT_PHILOSOPHERS
+
+    def generate(self, prompt: str) -> PoSelfResponse:
+        """Run the ensemble and emit a structured response."""
+
+        ensemble_result = run_ensemble(prompt, philosophers=self.philosophers)
+        responses = ensemble_result.get("responses", [])
+        aggregate = ensemble_result.get("aggregate", {})
+        consensus = ensemble_result.get("consensus", {})
+
+        text = consensus.get("text") or " ".join(r.get("reasoning", "") for r in responses)
+        metrics: Dict[str, float] = {
+            "freedom_pressure": float(aggregate.get("freedom_pressure", 0.0)),
+            "semantic_delta": float(aggregate.get("semantic_delta", 0.0)),
+            "blocked_tensor": float(aggregate.get("blocked_tensor", 0.0)),
+        }
+
+        return PoSelfResponse(
+            prompt=prompt,
+            text=text,
+            metrics=metrics,
+            philosophers=self.philosophers,
+            consensus_leader=consensus.get("leader"),
+            responses=responses,
+            log=ensemble_result.get("log", {}),
+        )
 
 
 def cli() -> None:
     """Po_self CLI entry point"""
     console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+    console.print("Type `po-core prompt \"What is meaning?\"` to explore the ensemble.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,7 +37,7 @@ def test_cli_prompt_command_returns_json(sample_prompt):
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["prompt"] == sample_prompt
-    assert payload["results"]
+    assert payload["responses"]
 
 
 def test_cli_log_command_exposes_log(sample_prompt):
@@ -48,3 +48,11 @@ def test_cli_log_command_exposes_log(sample_prompt):
     payload = json.loads(result.output)
     assert payload["prompt"] == sample_prompt
     assert "events" in payload
+
+
+def test_cli_sample_flags_show_attribution():
+    runner = CliRunner()
+    result = runner.invoke(main, ["hello", "--sample"])
+
+    assert result.exit_code == 0
+    assert "Consensus Lead" in result.output

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -1,3 +1,5 @@
+import pytest
+
 from po_core.ensemble import DEFAULT_PHILOSOPHERS, run_ensemble
 
 
@@ -6,15 +8,37 @@ def test_run_ensemble_returns_expected_shape(sample_prompt):
 
     assert result["prompt"] == sample_prompt
     assert result["philosophers"] == DEFAULT_PHILOSOPHERS
-    assert len(result["results"]) == len(DEFAULT_PHILOSOPHERS)
+    assert len(result["responses"]) == len(DEFAULT_PHILOSOPHERS)
 
-    for entry in result["results"]:
-        assert set(entry) >= {"name", "confidence", "summary", "tags"}
-        assert isinstance(entry["confidence"], float)
-        assert sample_prompt in entry["summary"]
+    for entry in result["responses"]:
+        assert set(entry) >= {"name", "reasoning", "freedom_pressure", "semantic_delta", "blocked_tensor"}
+        assert isinstance(entry["freedom_pressure"], float)
+        assert isinstance(entry["semantic_delta"], float)
+        assert isinstance(entry["blocked_tensor"], float)
 
     log = result["log"]
     assert log["prompt"] == sample_prompt
     assert log["philosophers"] == DEFAULT_PHILOSOPHERS
     assert any(event["event"] == "ensemble_started" for event in log["events"])
     assert any(event.get("results_recorded") == len(DEFAULT_PHILOSOPHERS) for event in log["events"])
+
+
+def test_run_ensemble_orders_and_aggregates(sample_prompt):
+    result = run_ensemble(sample_prompt)
+
+    names = [entry["name"] for entry in result["responses"]]
+    assert names == [
+        "Aristotle (Ἀριστοτέλης)",
+        "Friedrich Nietzsche",
+        "Ludwig Wittgenstein",
+    ]
+
+    aggregate = result["aggregate"]
+    computed_freedom = round(sum(entry["freedom_pressure"] for entry in result["responses"]) / len(result["responses"]), 2)
+    computed_delta = round(sum(entry["semantic_delta"] for entry in result["responses"]) / len(result["responses"]), 2)
+    computed_blocked = round(sum(entry["blocked_tensor"] for entry in result["responses"]) / len(result["responses"]), 2)
+
+    assert aggregate["freedom_pressure"] == computed_freedom == pytest.approx(0.82)
+    assert aggregate["semantic_delta"] == computed_delta == pytest.approx(0.76)
+    assert aggregate["blocked_tensor"] == computed_blocked == pytest.approx(0.47)
+    assert result["consensus"]["leader"] == names[0]

--- a/tests/unit/test_po_self.py
+++ b/tests/unit/test_po_self.py
@@ -1,0 +1,21 @@
+from po_core.po_self import PoSelf
+
+
+def test_po_self_generate_returns_structured_response(sample_prompt):
+    response = PoSelf().generate(sample_prompt)
+
+    assert response.prompt == sample_prompt
+    assert response.consensus_leader == "Aristotle (Ἀριστοτέλης)"
+    assert response.metrics["freedom_pressure"] == 0.82
+    assert response.metrics["semantic_delta"] == 0.76
+    assert response.metrics["blocked_tensor"] == 0.47
+    assert response.responses
+    assert response.log["prompt"] == sample_prompt
+
+
+def test_po_self_respects_custom_philosophers(sample_prompt):
+    response = PoSelf(philosophers=["wittgenstein"]).generate(sample_prompt)
+
+    assert response.philosophers == ["wittgenstein"]
+    assert response.consensus_leader == "Ludwig Wittgenstein"
+    assert len(response.responses) == 1


### PR DESCRIPTION
## Summary
- orchestrate philosopher modules through a structured ensemble pipeline with aggregate metrics
- expose Po_self generation responses to the CLI with optional sample runs and JSON-safe output
- add deterministic tests for ensemble ordering, metrics aggregation, and Po_self responses

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --override-ini addopts= -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252613935083288d07c028c6fd9185)