### PR TITLE
Add Po_self three-philosopher prototype with tracing

### DIFF
--- a/examples/basic/cli_po_self_example.sh
+++ b/examples/basic/cli_po_self_example.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Demonstrate the Po_self CLI path with tensor output and tracing.
+
+PROMPT="Does innovation flourish more through cooperation or competition?"
+LOG_PATH="examples/basic/cli_trace.ndjson"
+
+python -m po_core.cli po-self "$PROMPT" --show-tensors --log-file "$LOG_PATH" --ndjson

--- a/examples/basic/run_three_philosophers.py
+++ b/examples/basic/run_three_philosophers.py
@@ -1,0 +1,30 @@
+"""Example: run Po_self three-philosopher ensemble with tracing."""
+from pathlib import Path
+
+from po_core.po_self import PoSelfEnsemble
+from po_core.po_trace import PoTraceLogger
+
+
+def main() -> None:
+    prompt = "Should we seek authenticity or comfort when facing uncertainty?"
+    ensemble = PoSelfEnsemble()
+    result = ensemble.infer(prompt)
+
+    logger = PoTraceLogger(path=Path("examples/basic/po_trace_example.ndjson"), ndjson=True)
+    logger.record_prompt(prompt)
+    logger.record_tensors(result)
+    logger.record_contributions(
+        f"{tensor.name}: {tensor.description} -> {tensor.value}" for tensor in result.philosopher_tensors
+    )
+    log_path = logger.save()
+
+    print("Prompt:", prompt)
+    print("Composite tensor value:", result.composite_tensor.value if result.composite_tensor else "n/a")
+    print("Tensor details:")
+    for tensor in result.philosopher_tensors:
+        print(f" - {tensor.name}: {tensor.value} ({tensor.description})")
+    print("Trace saved to", log_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/po_core/po_self/__init__.py
+++ b/src/po_core/po_self/__init__.py
@@ -1,0 +1,13 @@
+"""Core Po_self tensor ensemble featuring philosophical contributors."""
+from .ensemble import PoSelfEnsemble, TensorEnsembleResult
+from .philosophers import DerridaPhilosopher, JungPhilosopher, SartrePhilosopher
+from .tensor import TensorState
+
+__all__ = [
+    "PoSelfEnsemble",
+    "TensorEnsembleResult",
+    "TensorState",
+    "DerridaPhilosopher",
+    "JungPhilosopher",
+    "SartrePhilosopher",
+]

--- a/src/po_core/po_self/ensemble.py
+++ b/src/po_core/po_self/ensemble.py
@@ -1,0 +1,77 @@
+"""Three-philosopher Po_self ensemble implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from .philosophers import DerridaPhilosopher, JungPhilosopher, Philosopher, SartrePhilosopher
+from .tensor import TensorState
+
+
+@dataclass
+class TensorEnsembleResult:
+    """Container for tensor outputs and metadata."""
+
+    prompt: str
+    base_tensor: TensorState
+    philosopher_tensors: List[TensorState] = field(default_factory=list)
+    composite_tensor: Optional[TensorState] = None
+
+    def to_dict(self) -> Dict:
+        return {
+            "prompt": self.prompt,
+            "base_tensor": self.base_tensor.to_dict(),
+            "philosopher_tensors": [tensor.to_dict() for tensor in self.philosopher_tensors],
+            "composite_tensor": self.composite_tensor.to_dict() if self.composite_tensor else None,
+        }
+
+
+class PoSelfEnsemble:
+    """Minimal deterministic ensemble across Sartre, Jung, and Derrida."""
+
+    def __init__(self, philosophers: Optional[Iterable[Philosopher]] = None) -> None:
+        self.philosophers: List[Philosopher] = list(philosophers) if philosophers else [
+            SartrePhilosopher(),
+            JungPhilosopher(),
+            DerridaPhilosopher(),
+        ]
+
+    def infer(self, prompt: str) -> TensorEnsembleResult:
+        """Run the ensemble and return tensor outputs."""
+
+        word_count = len(prompt.split())
+        base_tensor = TensorState(
+            name="prompt",
+            value=prompt,
+            description="Normalized prompt tensor",
+            metadata={"word_count": word_count},
+        )
+
+        philosopher_tensors: List[TensorState] = []
+        weighted_sum = 0.0
+        total_weight = 0.0
+
+        for philosopher in self.philosophers:
+            tensor = philosopher.evaluate(prompt, base_tensor)
+            philosopher_tensors.append(tensor)
+            weight = tensor.metadata.get("weight", 0.0)
+            weighted_sum += tensor.value * weight
+            total_weight += weight
+
+        composite_value = round(weighted_sum / total_weight, 3) if total_weight else 0.0
+        composite_tensor = TensorState(
+            name="ensemble",
+            value=composite_value,
+            description="Weighted philosophical agreement score",
+            metadata={
+                "weights": {tensor.name: tensor.metadata.get("weight", 0.0) for tensor in philosopher_tensors},
+                "contributors": [tensor.name for tensor in philosopher_tensors],
+            },
+        )
+
+        return TensorEnsembleResult(
+            prompt=prompt,
+            base_tensor=base_tensor,
+            philosopher_tensors=philosopher_tensors,
+            composite_tensor=composite_tensor,
+        )

--- a/src/po_core/po_self/philosophers.py
+++ b/src/po_core/po_self/philosophers.py
@@ -1,0 +1,71 @@
+"""Philosopher tensor emitters for the Po_self ensemble."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .tensor import TensorState
+
+
+@dataclass
+class Philosopher:
+    """Base philosopher interface."""
+
+    name: str
+    focus: str
+
+    def evaluate(self, prompt: str, base_tensor: TensorState) -> TensorState:
+        raise NotImplementedError
+
+
+class SartrePhilosopher(Philosopher):
+    """Existential weight based on choice density."""
+
+    def __init__(self) -> None:
+        super().__init__(name="sartre", focus="freedom")
+
+    def evaluate(self, prompt: str, base_tensor: TensorState) -> TensorState:
+        words = len(prompt.split())
+        choices = prompt.count(" or ") + 1
+        intensity = min(1.0, choices / max(1, words))
+        value = round(intensity * (0.6 + (words % 5) * 0.05), 3)
+        return TensorState(
+            name=self.name,
+            value=value,
+            description="Existential tension between options and commitment.",
+            metadata={"choices": choices, "word_count": words, "weight": 0.37},
+        )
+
+
+class JungPhilosopher(Philosopher):
+    """Archetypal resonance derived from imagery density."""
+
+    def __init__(self) -> None:
+        super().__init__(name="jung", focus="archetypes")
+
+    def evaluate(self, prompt: str, base_tensor: TensorState) -> TensorState:
+        symbols = sum(1 for token in prompt.split() if token.istitle())
+        resonance = round(min(1.0, symbols / (base_tensor.metadata["word_count"] or 1)), 3)
+        return TensorState(
+            name=self.name,
+            value=resonance,
+            description="Archetypal symbols resonating within the prompt.",
+            metadata={"symbols": symbols, "weight": 0.33},
+        )
+
+
+class DerridaPhilosopher(Philosopher):
+    """Deconstructive drift measured via contrast markers."""
+
+    def __init__(self) -> None:
+        super().__init__(name="derrida", focus="différance")
+
+    def evaluate(self, prompt: str, base_tensor: TensorState) -> TensorState:
+        binary_pairs = prompt.count(" vs ") + prompt.count(" versus ")
+        punctuation = sum(prompt.count(ch) for ch in ["?", "!"])
+        trace = round(min(1.0, (binary_pairs + punctuation) / (1 + base_tensor.metadata["word_count"])), 3)
+        return TensorState(
+            name=self.name,
+            value=trace,
+            description="Instability detected in textual oppositions.",
+            metadata={"binary_pairs": binary_pairs, "punctuation": punctuation, "weight": 0.3},
+        )

--- a/src/po_core/po_self/tensor.py
+++ b/src/po_core/po_self/tensor.py
@@ -1,0 +1,25 @@
+"""Minimal deterministic tensor representations for Po_self."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class TensorState:
+    """Represents a single tensor output from a philosopher or ensemble."""
+
+    name: str
+    value: Any
+    description: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable view of the tensor."""
+
+        return {
+            "name": self.name,
+            "value": self.value,
+            "description": self.description,
+            "metadata": self.metadata,
+        }

--- a/src/po_core/po_trace/__init__.py
+++ b/src/po_core/po_trace/__init__.py
@@ -1,0 +1,4 @@
+"""Structured tracing utilities for Po_core runs."""
+from .logger import PoTraceLogger
+
+__all__ = ["PoTraceLogger"]

--- a/src/po_core/po_trace/logger.py
+++ b/src/po_core/po_trace/logger.py
@@ -1,0 +1,60 @@
+"""Structured Po_trace logger producing JSON/NDJSON outputs."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from po_core.po_self import TensorEnsembleResult
+
+
+@dataclass
+class TraceEvent:
+    timestamp: str
+    kind: str
+    payload: Dict[str, Any]
+
+
+class PoTraceLogger:
+    """Persist ensemble traces to disk in JSON or NDJSON form."""
+
+    def __init__(self, path: Optional[Path] = None, *, ndjson: bool = True) -> None:
+        self.path = path or Path("po_trace_run.ndjson" if ndjson else "po_trace_run.json")
+        self.ndjson = ndjson
+        self.events: list[TraceEvent] = []
+
+    def record_prompt(self, prompt: str) -> None:
+        self._append("prompt", {"prompt": prompt})
+
+    def record_tensors(self, result: TensorEnsembleResult) -> None:
+        self._append(
+            "tensor_states",
+            {
+                "base_tensor": result.base_tensor.to_dict(),
+                "philosopher_tensors": [tensor.to_dict() for tensor in result.philosopher_tensors],
+                "composite_tensor": result.composite_tensor.to_dict() if result.composite_tensor else None,
+            },
+        )
+
+    def record_contributions(self, notes: Iterable[str]) -> None:
+        self._append("contributions", {"notes": list(notes)})
+
+    def save(self) -> Path:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.ndjson:
+            content = "\n".join(json.dumps(asdict(event)) for event in self.events)
+            self.path.write_text(content + "\n", encoding="utf-8")
+        else:
+            self.path.write_text(json.dumps([asdict(event) for event in self.events], indent=2), encoding="utf-8")
+        return self.path
+
+    def _append(self, kind: str, payload: Dict[str, Any]) -> None:
+        self.events.append(
+            TraceEvent(
+                timestamp=datetime.utcnow().isoformat() + "Z",
+                kind=kind,
+                payload=payload,
+            )
+        )


### PR DESCRIPTION
## Summary
- implement a minimal Po_self tensor ensemble for Sartre, Jung, and Derrida with deterministic outputs
- add Po_trace logger support and a new `po-self` CLI command for running the ensemble with optional tensor display and logging
- include basic examples for scripted and CLI usage that capture trace output

## Testing
- PYTHONPATH=src python -m po_core.cli po-self "Should I explore the unknown or stay grounded?" --show-tensors --log-file /workspace/Po_core/examples/basic/test_trace.ndjson --ndjson


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925359097b88328890bd7e7f66be913)