### PR TITLE
Implement Po_trace logging and CLI controls

### DIFF
--- a/docs/api/po_trace.md
+++ b/docs/api/po_trace.md
@@ -1,0 +1,68 @@
+# Po_trace Audit Logging
+
+Po_trace records the reasoning lifecycle for ensemble and Po_self runs. The schema is deterministic and can be exported to the console or a file for later inspection.
+
+## Trace schema
+
+A Po_trace JSON document contains:
+
+- `prompt`: Original request text.
+- `created_at`: UTC timestamp when the trace object was instantiated.
+- `level`: Trace detail level (`concise`, `verbose`, `debug`).
+- `events`: Chronological events with timestamps and metadata.
+- `attributions`: Per-philosopher contribution weights.
+- `emissions` (verbose/debug only): Content that was surfaced per channel or philosopher.
+- `reasons` (verbose/debug only): Why the content was emitted.
+- `rejections` (debug only): Suppressed or rejected content with rationales.
+
+Example (verbose):
+
+```json
+{
+  "prompt": "What is wisdom?",
+  "created_at": "2024-05-01T12:00:00Z",
+  "level": "verbose",
+  "events": [
+    {"event": "ensemble_started", "timestamp": "2024-05-01T12:00:00Z", "metadata": {"philosophers": 3}},
+    {"event": "ensemble_completed", "timestamp": "2024-05-01T12:00:01Z", "metadata": {"results_recorded": 3, "status": "ok"}}
+  ],
+  "attributions": [
+    {"philosopher": "aristotle", "weight": 1.0, "note": "Deterministic weighting for demo run."}
+  ],
+  "emissions": [
+    {"philosopher": "aristotle", "channel": "analysis", "content": "Aristotle reflects on 'What is wisdom?'."}
+  ],
+  "reasons": [
+    {"philosopher": "aristotle", "channel": "analysis", "reason": "Weighted perspective 1 with confidence 0.88."}
+  ]
+}
+```
+
+## Using Po_trace programmatically
+
+Use `run_ensemble` or `run_po_self` to generate traced runs:
+
+```python
+from po_core.ensemble import run_ensemble
+from po_core.po_self import run_po_self
+
+ensemble_result = run_ensemble("What is truth?", trace_level="verbose", trace_output="logs/ensemble.json")
+po_self_result = run_po_self("What is truth?", trace_level="debug")
+```
+
+Both helpers return a `trace` key containing the JSON-ready log. When `trace_output` is set, the trace is also written to the given path.
+
+## CLI usage
+
+- Inspect the ensemble with trace options:
+  ```bash
+  po-core prompt "What is truth?" --trace-level verbose --trace-output trace.json
+  ```
+- Show only the trace for a prompt:
+  ```bash
+  po-core log "What is truth?" --trace-level debug
+  ```
+- Preview or inspect a stored trace file:
+  ```bash
+  python -m po_core.po_trace --trace-level debug --from-file trace.json
+  ```

--- a/src/po_core/__init__.py
+++ b/src/po_core/__init__.py
@@ -12,9 +12,11 @@ __author__ = "Flying Pig Project"
 __email__ = "flyingpig0229+github@gmail.com"
 
 from po_core.ensemble import run_ensemble
+from po_core.po_self import run_po_self
 
 # Core exports will be added as implementation progresses
 __all__ = [
     "__version__",
     "run_ensemble",
+    "run_po_self",
 ]

--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.table import Table
 
 from po_core import __author__, __email__, __version__, run_ensemble
+from po_core.po_trace import TraceLevel
 
 console = Console()
 
@@ -85,10 +86,22 @@ def version() -> None:
     default="json",
     help="Choose between text or JSON output.",
 )
-def prompt(prompt: str, output_format: str) -> None:
-    """Run the deterministic ensemble against a prompt."""
+@click.option(
+    "--trace-level",
+    type=click.Choice([member.value for member in TraceLevel]),
+    default=TraceLevel.CONCISE.value,
+    show_default=True,
+    help="Detail level for Po_trace logging.",
+)
+@click.option(
+    "--trace-output",
+    type=click.Path(dir_okay=False, writable=True, path_type=str),
+    help="Optional file path to persist the trace JSON.",
+)
+def prompt(prompt: str, output_format: str, trace_level: str, trace_output: str | None) -> None:
+    """Run the deterministic ensemble against a prompt with trace logging."""
 
-    result = run_ensemble(prompt)
+    result = run_ensemble(prompt, trace_level=trace_level, trace_output=trace_output)
     if output_format.lower() == "json":
         console.print(json.dumps(result, indent=2))
     else:
@@ -102,11 +115,23 @@ def prompt(prompt: str, output_format: str) -> None:
 
 @main.command()
 @click.argument("prompt")
-def log(prompt: str) -> None:
+@click.option(
+    "--trace-level",
+    type=click.Choice([member.value for member in TraceLevel]),
+    default=TraceLevel.VERBOSE.value,
+    show_default=True,
+    help="Detail level for Po_trace logging.",
+)
+@click.option(
+    "--trace-output",
+    type=click.Path(dir_okay=False, writable=True, path_type=str),
+    help="Optional file path to persist the trace JSON.",
+)
+def log(prompt: str, trace_level: str, trace_output: str | None) -> None:
     """Display the audit log for a deterministic ensemble run."""
 
-    run_data = run_ensemble(prompt)
-    console.print(json.dumps(run_data["log"], indent=2))
+    run_data = run_ensemble(prompt, trace_level=trace_level, trace_output=trace_output)
+    console.print(json.dumps(run_data["trace"], indent=2))
 
 
 if __name__ == "__main__":

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -1,13 +1,20 @@
 """Deterministic ensemble runner used by CLI smoke tests."""
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Dict, Iterable, List, Optional
+
+from po_core.po_trace import PoTrace, TraceLevel
 
 DEFAULT_PHILOSOPHERS: List[str] = ["aristotle", "nietzsche", "wittgenstein"]
 
 
-def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -> Dict:
+def run_ensemble(
+    prompt: str,
+    *,
+    philosophers: Optional[Iterable[str]] = None,
+    trace_level: str = TraceLevel.CONCISE.value,
+    trace_output: Optional[str] = None,
+) -> Dict:
     """Return a deterministic ensemble response for a given prompt.
 
     This helper keeps outputs stable for tests and documentation by using
@@ -16,35 +23,50 @@ def run_ensemble(prompt: str, *, philosophers: Optional[Iterable[str]] = None) -
     """
 
     selected = list(philosophers) if philosophers is not None else DEFAULT_PHILOSOPHERS
+    tracer = PoTrace(prompt=prompt)
+    tracer.record_event("ensemble_started", philosophers=len(selected))
+
     results = []
     base_confidence = 0.88
+    trace_level_enum = TraceLevel(trace_level)
+
     for idx, name in enumerate(selected):
+        confidence = round(base_confidence - 0.05 * idx, 2)
+        summary = f"{name.title()} reflects on '{prompt}'."
         results.append(
             {
                 "name": name,
-                "confidence": round(base_confidence - 0.05 * idx, 2),
-                "summary": f"{name.title()} reflects on '{prompt}'.",
+                "confidence": confidence,
+                "summary": summary,
                 "tags": ["analysis", "deterministic"],
             }
         )
 
-    log = {
-        "prompt": prompt,
-        "philosophers": selected,
-        "created_at": datetime.utcnow().isoformat() + "Z",
-        "events": [
-            {"event": "ensemble_started", "philosophers": len(selected)},
-            {
-                "event": "ensemble_completed",
-                "results_recorded": len(results),
-                "status": "ok",
-            },
-        ],
-    }
+        tracer.record_emission(name, summary)
+        tracer.log_reason(
+            name,
+            reason=f"Weighted perspective {idx + 1} with confidence {confidence}.",
+        )
+        tracer.log_rejection(
+            name,
+            content=f"{name.title()} withheld speculation about '{prompt}'.",
+            rationale="Speculative content intentionally suppressed to keep reasoning auditable.",
+        )
+        tracer.attribute(
+            name,
+            weight=round(confidence / base_confidence, 2),
+            note="Deterministic weighting for demo run.",
+        )
+
+    tracer.record_event("ensemble_completed", results_recorded=len(results), status="ok")
+
+    trace_data = tracer.to_dict(level=trace_level_enum)
+    tracer.export(trace_output, level=trace_level_enum)
 
     return {
         "prompt": prompt,
         "philosophers": selected,
         "results": results,
-        "log": log,
+        "trace": trace_data,
+        "log": trace_data,
     }

--- a/src/po_core/po_self.py
+++ b/src/po_core/po_self.py
@@ -4,17 +4,91 @@ Po_self: Philosophical Ensemble Module
 The core reasoning engine that integrates multiple philosophers
 as interacting tensors.
 """
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
 
 import click
 from rich.console import Console
 
+from po_core.po_trace import PoTrace, TraceLevel
+
 console = Console()
 
 
-def cli() -> None:
+DEFAULT_CHANNELS: List[str] = ["analysis", "counterpoint"]
+
+
+def run_po_self(
+    prompt: str,
+    *,
+    trace_level: str = TraceLevel.CONCISE.value,
+    trace_output: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Deterministic Po_self reasoning flow that emits and suppresses content."""
+
+    tracer = PoTrace(prompt=prompt)
+    tracer.record_event("po_self_started", channels=len(DEFAULT_CHANNELS))
+    level_enum = TraceLevel(trace_level)
+
+    emitted = []
+    suppressed = []
+
+    for channel in DEFAULT_CHANNELS:
+        content = f"[{channel}] Reflecting on '{prompt}' with structured reasoning."
+        tracer.record_emission(channel, content, channel=channel)
+        tracer.log_reason(channel, f"Baseline {channel} pass over the prompt.", channel=channel)
+        tracer.attribute(channel, weight=0.5, note="Equal channel weighting for deterministic flow.")
+        emitted.append({"channel": channel, "content": content})
+
+        suppressed_content = (
+            f"[{channel}] Speculative extension about '{prompt}' intentionally held back."
+        )
+        tracer.log_rejection(
+            channel,
+            content=suppressed_content,
+            rationale="Speculative expansion suppressed for safety preview.",
+        )
+        suppressed.append({"channel": channel, "content": suppressed_content})
+
+    tracer.record_event("po_self_completed", emitted=len(emitted), suppressed=len(suppressed))
+
+    trace_data = tracer.to_dict(level=level_enum)
+    tracer.export(trace_output, level=level_enum)
+
+    return {
+        "prompt": prompt,
+        "emitted": emitted,
+        "suppressed": suppressed,
+        "trace": trace_data,
+    }
+
+
+@click.command()
+@click.argument("prompt")
+@click.option(
+    "--trace-level",
+    type=click.Choice([member.value for member in TraceLevel]),
+    default=TraceLevel.CONCISE.value,
+    show_default=True,
+    help="Detail level for Po_trace output.",
+)
+@click.option(
+    "--trace-output",
+    type=click.Path(dir_okay=False, writable=True, path_type=str),
+    help="Optional file path to persist the trace JSON.",
+)
+def cli(prompt: str, trace_level: str, trace_output: Optional[str]) -> None:
     """Po_self CLI entry point"""
-    console.print("[bold magenta]🧠 Po_self - Philosophical Ensemble[/bold magenta]")
-    console.print("Implementation coming soon...")
+
+    console.print("[bold magenta]\n🧠 Po_self - Philosophical Ensemble\n[/bold magenta]")
+    result = run_po_self(prompt, trace_level=trace_level, trace_output=trace_output)
+    console.print("[bold]Emitted Channels:[/bold]")
+    for item in result["emitted"]:
+        console.print(f"- {item['channel']}: {item['content']}")
+
+    console.print("\n[dim]Suppressed content recorded in trace.[/dim]")
+    console.print_json(data=result["trace"])
 
 
 if __name__ == "__main__":

--- a/src/po_core/po_trace.py
+++ b/src/po_core/po_trace.py
@@ -4,17 +4,238 @@ Po_trace: Reasoning Audit Log Module
 Tracks and logs the complete reasoning process,
 including what was said and what was not said.
 """
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import json
 
 import click
 from rich.console import Console
+from rich.table import Table
 
 console = Console()
 
 
-def cli() -> None:
-    """Po_trace CLI entry point"""
-    console.print("[bold green]🔍 Po_trace - Reasoning Audit Log[/bold green]")
-    console.print("Implementation coming soon...")
+class TraceLevel(str, Enum):
+    """Levels of trace detail supported by the audit log."""
+
+    CONCISE = "concise"
+    VERBOSE = "verbose"
+    DEBUG = "debug"
+
+
+@dataclass
+class ReasonLog:
+    """Explanation for why a piece of content was emitted."""
+
+    philosopher: str
+    reason: str
+    channel: str = "analysis"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "philosopher": self.philosopher,
+            "reason": self.reason,
+            "channel": self.channel,
+        }
+
+
+@dataclass
+class RejectionLog:
+    """Record of content that was suppressed or rejected."""
+
+    philosopher: str
+    content: str
+    rationale: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "philosopher": self.philosopher,
+            "content": self.content,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass
+class PhilosopherAttribution:
+    """Contribution weight for a philosopher."""
+
+    philosopher: str
+    weight: float
+    note: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "philosopher": self.philosopher,
+            "weight": round(self.weight, 2),
+            "note": self.note,
+        }
+
+
+@dataclass
+class TraceEvent:
+    """Generic trace event with timestamped metadata."""
+
+    event: str
+    metadata: Dict[str, Any]
+    timestamp: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event": self.event,
+            "timestamp": self.timestamp,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class PoTrace:
+    """Audit log container capturing emitted and suppressed reasoning."""
+
+    prompt: str
+    created_at: str = field(
+        default_factory=lambda: datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    )
+    events: List[TraceEvent] = field(default_factory=list)
+    reasons: List[ReasonLog] = field(default_factory=list)
+    rejections: List[RejectionLog] = field(default_factory=list)
+    attributions: List[PhilosopherAttribution] = field(default_factory=list)
+    emissions: List[Dict[str, Any]] = field(default_factory=list)
+
+    def record_event(self, event: str, **metadata: Any) -> None:
+        timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+        self.events.append(TraceEvent(event=event, metadata=metadata, timestamp=timestamp))
+
+    def log_reason(self, philosopher: str, reason: str, *, channel: str = "analysis") -> None:
+        self.reasons.append(ReasonLog(philosopher=philosopher, reason=reason, channel=channel))
+
+    def log_rejection(self, philosopher: str, content: str, rationale: str) -> None:
+        self.rejections.append(
+            RejectionLog(philosopher=philosopher, content=content, rationale=rationale)
+        )
+
+    def attribute(self, philosopher: str, weight: float, note: str) -> None:
+        self.attributions.append(
+            PhilosopherAttribution(philosopher=philosopher, weight=weight, note=note)
+        )
+
+    def record_emission(self, philosopher: str, content: str, *, channel: str = "analysis") -> None:
+        self.emissions.append(
+            {
+                "philosopher": philosopher,
+                "channel": channel,
+                "content": content,
+            }
+        )
+
+    def to_dict(self, level: TraceLevel = TraceLevel.CONCISE) -> Dict[str, Any]:
+        base: Dict[str, Any] = {
+            "prompt": self.prompt,
+            "created_at": self.created_at,
+            "level": level.value,
+            "events": [event.to_dict() for event in self.events],
+            "attributions": [attr.to_dict() for attr in self.attributions],
+        }
+
+        if level in {TraceLevel.VERBOSE, TraceLevel.DEBUG}:
+            base.update(
+                {
+                    "emissions": list(self.emissions),
+                    "reasons": [reason.to_dict() for reason in self.reasons],
+                }
+            )
+
+        if level == TraceLevel.DEBUG:
+            base.update({"rejections": [rej.to_dict() for rej in self.rejections]})
+
+        return base
+
+    def export(self, destination: Optional[str], level: TraceLevel = TraceLevel.CONCISE) -> None:
+        """Persist the trace to a file if a destination is provided."""
+
+        if not destination:
+            return
+
+        path = Path(destination)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(level=level), indent=2))
+
+
+@click.command()
+@click.option(
+    "--trace-level",
+    type=click.Choice([member.value for member in TraceLevel]),
+    default=TraceLevel.CONCISE.value,
+    show_default=True,
+    help="Level of detail to show (concise, verbose, debug).",
+)
+@click.option(
+    "--from-file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    help="Inspect a saved Po_trace JSON file instead of running a trace.",
+)
+@click.option(
+    "--summary/--no-summary",
+    default=True,
+    show_default=True,
+    help="Show the attribution summary table.",
+)
+@click.argument("prompt", required=False)
+def cli(trace_level: str, from_file: Optional[Path], summary: bool, prompt: Optional[str]) -> None:
+    """Po_trace CLI entry point.
+
+    When given a PROMPT, a placeholder deterministic trace is generated. If
+    --from-file is supplied, the CLI will render the stored trace instead.
+    """
+
+    selected_level = TraceLevel(trace_level)
+
+    if from_file:
+        trace_data = json.loads(from_file.read_text())
+    else:
+        demo_trace = PoTrace(prompt or "demo")
+        demo_trace.record_event("trace_preview_started", source="cli")
+        demo_trace.attribute("preview_philosopher", 1.0, "Full contribution")
+        demo_trace.record_emission("preview_philosopher", f"Reflection on '{prompt or 'demo'}'.")
+        demo_trace.log_rejection(
+            "preview_philosopher",
+            content="Omitted speculative aside.",
+            rationale="Kept the preview concise.",
+        )
+        demo_trace.record_event("trace_preview_finished", status="ok")
+        trace_data = demo_trace.to_dict(level=selected_level)
+
+    console.print("[bold green]\n🔍 Po_trace - Reasoning Audit Log\n")
+    console.print(f"Level: [bold]{selected_level.value}[/bold]")
+
+    if summary:
+        _render_summary(trace_data)
+
+    console.print("\n[dim]Full trace JSON:[/dim]")
+    console.print_json(data=trace_data)
+
+
+def _render_summary(trace_data: Dict[str, Any]) -> None:
+    """Render a compact summary of attributions."""
+
+    table = Table(title="Philosopher Attribution", show_lines=True)
+    table.add_column("Philosopher", justify="left")
+    table.add_column("Weight", justify="center")
+    table.add_column("Note", justify="left")
+
+    for attribution in trace_data.get("attributions", []):
+        table.add_row(
+            attribution.get("philosopher", ""),
+            str(attribution.get("weight", "")),
+            attribution.get("note", ""),
+        )
+
+    console.print(table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Po_trace data classes, event recording, and CLI preview for reasoning audit logs
- integrate tracing into deterministic ensemble and Po_self flows with configurable detail levels and file export
- expose trace options through the Po_core CLI and document schema/usage in docs/api/po_trace.md

## Testing
- python -m compileall src


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925386f42048328b5d69ae7f6a446c4)