### PR TITLE
Add philosopher unit tests for Heidegger and Sartre

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 
+from po_core.philosophers.heidegger import Heidegger
+from po_core.philosophers.sartre import Sartre
 
 @pytest.fixture()
 def sample_prompt() -> str:
@@ -13,3 +15,31 @@ def load_json_output():
         return json.loads(result.output.strip())
 
     return _loader
+
+
+@pytest.fixture()
+def heidegger():
+    return Heidegger()
+
+
+@pytest.fixture()
+def sartre():
+    return Sartre()
+
+
+@pytest.fixture()
+def philosopher_prompts():
+    """Common prompts used across philosopher tests."""
+
+    long_prompt = " ".join([
+        "Freedom presses on every decision we make, even when we pretend otherwise.",
+        "I was once convinced my path was fixed, but tomorrow I will choose again.",
+        "In this moment, I feel the weight of time and responsibility intertwining."
+    ])
+
+    return {
+        "basic": "I choose my own path now, and I will shape tomorrow.",
+        "empty": "",
+        "long": long_prompt,
+        "inauthentic": "Everyone says I must do this because that's just how life is."
+    }

--- a/tests/unit/test_philosophers/test_heidegger.py
+++ b/tests/unit/test_philosophers/test_heidegger.py
@@ -1,0 +1,60 @@
+import pytest
+
+from po_core.philosophers.heidegger import Heidegger
+
+
+@pytest.fixture()
+def heidegger_instance(heidegger):
+    return heidegger
+
+
+def test_reason_returns_expected_structure(heidegger_instance, philosopher_prompts):
+    result = heidegger_instance.reason(philosopher_prompts["basic"])
+
+    assert set(result.keys()) >= {
+        "reasoning",
+        "perspective",
+        "key_concepts",
+        "questions",
+        "temporal_dimension",
+        "authenticity_check",
+        "metadata",
+    }
+    assert result["perspective"] == "Phenomenological / Existential"
+    assert result["metadata"]["philosopher"] == "Martin Heidegger"
+    assert result["metadata"]["approach"] == "Being and Time analysis"
+
+
+def test_temporality_detection(heidegger_instance):
+    prompt = "I was lost in the past, but I will find meaning tomorrow while I am choosing now."
+    result = heidegger_instance.reason(prompt)
+
+    temporality = result["temporal_dimension"]
+    assert temporality["past_present"] is True
+    assert temporality["future_oriented"] is True
+    assert temporality["present_focused"] is True
+    assert temporality["temporal_awareness"] == "Multi-temporal"
+
+
+def test_authenticity_and_concepts_default(heidegger_instance, philosopher_prompts):
+    empty_prompt = philosopher_prompts["empty"]
+    result = heidegger_instance.reason(empty_prompt)
+
+    assert "Being-in-the-world" in result["key_concepts"]
+    assert "What is the mode of being here?" in result["questions"]
+    assert result["authenticity_check"] == "Neutral - requires deeper analysis"
+
+
+def test_inauthentic_mode_detection(heidegger_instance, philosopher_prompts):
+    result = heidegger_instance.reason(philosopher_prompts["inauthentic"])
+
+    assert result["authenticity_check"] == "Shows signs of 'Das Man' (they-self)"
+    assert result["key_concepts"]
+
+
+def test_handles_long_prompt(heidegger_instance, philosopher_prompts):
+    result = heidegger_instance.reason(philosopher_prompts["long"])
+
+    assert isinstance(result["reasoning"], str)
+    assert len(result["reasoning"]) > 0
+    assert isinstance(result["temporal_dimension"], dict)

--- a/tests/unit/test_philosophers/test_sartre.py
+++ b/tests/unit/test_philosophers/test_sartre.py
@@ -1,0 +1,61 @@
+import pytest
+
+from po_core.philosophers.sartre import Sartre
+
+
+@pytest.fixture()
+def sartre_instance(sartre):
+    return sartre
+
+
+def test_reason_returns_expected_structure(sartre_instance, philosopher_prompts):
+    result = sartre_instance.reason(philosopher_prompts["basic"])
+
+    assert set(result.keys()) >= {
+        "reasoning",
+        "perspective",
+        "freedom_assessment",
+        "responsibility_check",
+        "bad_faith_indicators",
+        "mode_of_being",
+        "engagement_level",
+        "anguish_present",
+        "metadata",
+    }
+    assert result["perspective"] == "Existentialist"
+    assert result["metadata"]["philosopher"] == "Jean-Paul Sartre"
+    assert result["metadata"]["approach"] == "Existentialist analysis"
+
+
+def test_freedom_and_responsibility_detection(sartre_instance):
+    prompt = "I choose to act and feel responsible for the consequences of my freedom."
+    result = sartre_instance.reason(prompt)
+
+    assert result["freedom_assessment"]["level"] == "High"
+    assert result["responsibility_check"]["level"] == "High"
+    assert result["mode_of_being"].startswith("For-itself")
+
+
+def test_bad_faith_detection(sartre_instance, philosopher_prompts):
+    prompt = "They made me do it; I had no choice and was supposed to follow the rules."
+    result = sartre_instance.reason(prompt)
+
+    indicators = result["bad_faith_indicators"]
+    assert any("denying agency" in item for item in indicators)
+    assert any("Role-playing" in item for item in indicators)
+
+
+def test_edge_case_empty_prompt(sartre_instance, philosopher_prompts):
+    result = sartre_instance.reason(philosopher_prompts["empty"])
+
+    assert result["freedom_assessment"]["level"] == "Medium"
+    assert result["responsibility_check"]["level"] == "Low"
+    assert "No obvious bad faith detected" in result["bad_faith_indicators"][0]
+
+
+def test_long_prompt_handles_multiple_signals(sartre_instance, philosopher_prompts):
+    result = sartre_instance.reason(philosopher_prompts["long"])
+
+    assert result["freedom_assessment"]["level"] != "Low"
+    assert isinstance(result["reasoning"], str)
+    assert len(result["reasoning"]) > 0


### PR DESCRIPTION
## Summary
- add shared philosopher fixtures for Heidegger and Sartre tests
- implement Heidegger and Sartre reasoning unit tests covering structure, logic, and edge cases
- organize philosopher-focused tests under tests/unit/test_philosophers

## Testing
- PYTHONPATH=src pytest -q -c /dev/null tests/unit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257dad597c8328851cb5691d58dd20)