### PR TITLE
Disable AI slots and dummy by default in manifest; add selection regression tests

### DIFF
--- a/src/po_core/philosophers/manifest.py
+++ b/src/po_core/philosophers/manifest.py
@@ -79,6 +79,7 @@ SPECS: List[PhilosopherSpec] = [
         "DummyPhilosopher",
         risk_level=0,
         weight=2.0,
+        enabled=False,
         tags=(TAG_COMPLIANCE, TAG_CLARIFY),
         cost=1,
     ),
@@ -451,7 +452,7 @@ SPECS: List[PhilosopherSpec] = [
         "ClaudeAnthropic",
         risk_level=0,
         weight=1.3,
-        enabled=True,  # Slot 40
+        enabled=False,  # Slot 40
         tags=(TAG_COMPLIANCE, TAG_CLARIFY, TAG_CRITIC, TAG_AI_SYNTHESIS),
         cost=2,
     ),
@@ -461,7 +462,7 @@ SPECS: List[PhilosopherSpec] = [
         "GrokXAI",
         risk_level=2,
         weight=1.1,
-        enabled=True,  # Slot 41
+        enabled=False,  # Slot 41
         tags=(TAG_REDTEAM, TAG_CRITIC, TAG_AI_SYNTHESIS),
         cost=2,
     ),
@@ -471,7 +472,7 @@ SPECS: List[PhilosopherSpec] = [
         "GPTChatGPT",
         risk_level=1,
         weight=1.2,
-        enabled=True,  # Slot 42
+        enabled=False,  # Slot 42
         tags=(TAG_GENERAL, TAG_CLARIFY, TAG_AI_SYNTHESIS),
         cost=2,
     ),
@@ -481,7 +482,7 @@ SPECS: List[PhilosopherSpec] = [
         "GeminiGoogle",
         risk_level=1,
         weight=1.1,
-        enabled=True,  # Slot 43
+        enabled=False,  # Slot 43
         tags=(TAG_PLANNER, TAG_CRITIC, TAG_AI_SYNTHESIS),
         cost=2,
     ),

--- a/tests/unit/test_selection_manifest_and_dummy.py
+++ b/tests/unit/test_selection_manifest_and_dummy.py
@@ -1,0 +1,18 @@
+from po_core.domain.safety_mode import SafetyMode
+from po_core.philosophers.registry import PhilosopherRegistry
+
+AI_IDS = {"claude_anthropic", "gpt_chatgpt", "gemini_google", "grok_xai"}
+
+
+def test_normal_selection_excludes_ai_slots_by_default():
+    selection = PhilosopherRegistry(cache_instances=False).select(SafetyMode.NORMAL)
+
+    assert AI_IDS.isdisjoint(selection.selected_ids)
+    assert len(selection.selected_ids) == 39
+
+
+def test_critical_selection_never_picks_dummy_by_default_manifest():
+    selection = PhilosopherRegistry(cache_instances=False).select(SafetyMode.CRITICAL)
+
+    assert selection.selected_ids == ["confucius"]
+    assert "dummy" not in selection.selected_ids


### PR DESCRIPTION
### Motivation
- Align `src/po_core/philosophers/manifest.py` with its comments so experimental AI slots are not selected by default and the system preserves the intended human-39 behavior. 
- Prevent the `dummy` entry from becoming the sole production responder in `CRITICAL` mode to avoid returning a placeholder answer in critical situations.

### Description
- Set `enabled=False` for `dummy` and the four AI slots (`claude_anthropic`, `grok_xai`, `gpt_chatgpt`, `gemini_google`) in `src/po_core/philosophers/manifest.py` so they are excluded from default selection. 
- Added a focused regression test `tests/unit/test_selection_manifest_and_dummy.py` that asserts `NORMAL` selection excludes AI slots and yields 39 selected ids, and that `CRITICAL` selection does not pick `dummy` (expected `confucius`).
- Kept changes minimal and confined to the manifest and one dedicated test file; no other refactors or formatting changes were made.

### Testing
- Executed the new unit tests with the repository test configuration by running `PYTHONPATH=src pytest -q tests/unit/test_selection_manifest_and_dummy.py`.
- Result: `2 passed` (both tests passed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a657ef1548328973af4760690aaec)