### PR TITLE
Fix global timeout behavior in run_philosophers

### DIFF
--- a/tests/unit/test_party_machine_timeout_behavior.py
+++ b/tests/unit/test_party_machine_timeout_behavior.py
@@ -1,0 +1,55 @@
+import time
+from dataclasses import dataclass
+
+from po_core.domain.proposal import Proposal
+from po_core.party_machine import run_philosophers
+
+
+@dataclass
+class _SleepyPhilosopher:
+    name: str
+    sleep_s: float
+
+    def propose(self, ctx, intent, tensors, memory):
+        time.sleep(self.sleep_s)
+        return [
+            Proposal(
+                proposal_id=f"{self.name}-p1",
+                action_type="answer",
+                content=f"proposal from {self.name}",
+                confidence=0.5,
+                assumption_tags=[],
+                risk_tags=[],
+                extra={},
+            )
+        ]
+
+
+def test_run_philosophers_uses_global_timeout_window():
+    philosophers = [
+        _SleepyPhilosopher(name="slow-a", sleep_s=0.35),
+        _SleepyPhilosopher(name="slow-b", sleep_s=0.35),
+        _SleepyPhilosopher(name="fast", sleep_s=0.01),
+    ]
+
+    start = time.perf_counter()
+    proposals, results = run_philosophers(
+        philosophers,
+        ctx=None,
+        intent=None,
+        tensors=None,
+        memory=None,
+        max_workers=3,
+        timeout_s=0.1,
+    )
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.25
+
+    by_id = {r.philosopher_id: r for r in results}
+    assert by_id["slow-a"].timed_out is True
+    assert by_id["slow-b"].timed_out is True
+    assert by_id["fast"].ok is True
+
+    assert len(proposals) == 1
+    assert proposals[0].extra["_po_core"]["author"] == "fast"


### PR DESCRIPTION
### Motivation
- Prevent wall-clock blowup when many philosophers are slow by replacing per-future sequential `result(timeout=...)` waits with a single global timeout window. 
- Ensure timed-out philosophers are recorded and completed proposals are still collected within the global timeout, preserving fairness and latency guarantees. 

### Description
- Replaced per-future sequential waiting with `concurrent.futures.wait(..., timeout=timeout_s)` and collect finished vs unfinished futures in a single window. 
- Mark unfinished futures as timed out, cancel them, and record `RunResult.timed_out=True`, while preserving input ordering by collecting results/proposals by submission index. 
- Shutdown the ThreadPoolExecutor non-blocking (`shutdown(wait=False, cancel_futures=True)`) to avoid blocking the caller after the global timeout. 
- Added a focused regression test `tests/unit/test_party_machine_timeout_behavior.py` that simulates slow and fast philosophers to assert global timeout behavior and bookkeeping. 
- Files changed: `src/po_core/party_machine.py` and new test `tests/unit/test_party_machine_timeout_behavior.py`. 

### Testing
- Ran the new focused test: `PYTHONPATH=src pytest -q tests/unit/test_party_machine_timeout_behavior.py` which passed. 
- Ran the existing party-machine unit tests (non-slow subset) to ensure no regressions: `PYTHONPATH=src pytest -q tests/unit/test_party_machine.py -k 'not slow'` which passed (38 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a67599c188328be0b81ff2aa9c052)