### PR TITLE
Fail fast on import errors for enabled philosophers

### DIFF
--- a/src/po_core/philosophers/registry.py
+++ b/src/po_core/philosophers/registry.py
@@ -255,6 +255,10 @@ class PhilosopherRegistry:
                 if self._cache:
                     self._instances[pid] = ph
             except Exception as e:
+                if spec.enabled:
+                    raise RuntimeError(
+                        f"failed_to_load_enabled_philosopher:{pid}"
+                    ) from e
                 errors.append(
                     LoadError(pid, spec.module, spec.symbol, type(e).__name__)
                 )

--- a/tests/test_registry_import_strictness.py
+++ b/tests/test_registry_import_strictness.py
@@ -1,0 +1,43 @@
+from po_core.philosophers.manifest import PhilosopherSpec
+from po_core.philosophers.registry import PhilosopherRegistry
+
+
+def test_load_raises_for_enabled_spec_import_failure() -> None:
+    registry = PhilosopherRegistry(
+        specs=[
+            PhilosopherSpec(
+                philosopher_id="enabled_broken",
+                module="po_core.philosophers.__missing_enabled__",
+                symbol="Missing",
+                enabled=True,
+            )
+        ],
+        cache_instances=False,
+    )
+
+    try:
+        registry.load(["enabled_broken"])
+        assert False, "RuntimeError was not raised"
+    except RuntimeError as exc:
+        assert "failed_to_load_enabled_philosopher:enabled_broken" in str(exc)
+
+
+def test_load_collects_error_for_disabled_spec_import_failure() -> None:
+    registry = PhilosopherRegistry(
+        specs=[
+            PhilosopherSpec(
+                philosopher_id="disabled_broken",
+                module="po_core.philosophers.__missing_disabled__",
+                symbol="Missing",
+                enabled=False,
+            )
+        ],
+        cache_instances=False,
+    )
+
+    loaded, errors = registry.load(["disabled_broken"])
+
+    assert loaded == []
+    assert len(errors) == 1
+    assert errors[0].philosopher_id == "disabled_broken"
+    assert errors[0].error == "ModuleNotFoundError"


### PR DESCRIPTION
### Motivation
- Ensure import/load failures for enabled philosophers are not silently swallowed so CI can detect configuration or code issues promptly.

### Description
- In `PhilosopherRegistry.load()` added an exception-path check that raises `RuntimeError` when `spec.enabled` is `True`, with message `failed_to_load_enabled_philosopher:{pid}`; disabled specs keep the existing `errors` accumulation behavior.
- Added `tests/test_registry_import_strictness.py` that directly calls `load()` to verify that an enabled broken spec raises and a disabled broken spec is collected as a `LoadError`.
- Changes are minimal and limited to `src/po_core/philosophers/registry.py` and the new test file `tests/test_registry_import_strictness.py`.

### Testing
- Ran `PYTHONPATH=src python -m pytest -q tests/test_registry_import_strictness.py` and both tests passed.
- The regression tests are self-contained and do not require external dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a80a10b4c83289b535bb4acb717e5)