### PR TITLE
PR-6: env-gated API key auth and configurable CORS for /generate

### DIFF
--- a/tests/test_api_auth_cors.py
+++ b/tests/test_api_auth_cors.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+class _FakeResponse(dict):
+    pass
+
+
+def _load_api_module(monkeypatch, api_key: str = "", cors_origins: str = ""):
+    monkeypatch.setenv("PO_CORE_API_KEY", api_key)
+    monkeypatch.setenv("PO_CORE_CORS_ORIGINS", cors_origins)
+    import po_core.app.api as api_module
+
+    return importlib.reload(api_module)
+
+
+def test_generate_requires_api_key_when_secure_mode_enabled(monkeypatch):
+    api = _load_api_module(monkeypatch, api_key="secret")
+    async def _fake_async_run(user_input):
+        return _FakeResponse(ok=True)
+
+    monkeypatch.setattr(api, "async_run", _fake_async_run)
+
+    client = TestClient(api.app)
+    response = client.post("/generate", json={"user_input": "hello"})
+
+    assert response.status_code == 403
+
+
+def test_generate_accepts_valid_bearer_api_key(monkeypatch):
+    api = _load_api_module(monkeypatch, api_key="secret")
+    async def _fake_async_run(user_input):
+        return _FakeResponse(ok=True)
+
+    monkeypatch.setattr(api, "async_run", _fake_async_run)
+
+    client = TestClient(api.app)
+    response = client.post(
+        "/generate",
+        json={"user_input": "hello"},
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code != 403
+
+
+def test_options_preflight_not_blocked_in_secure_mode(monkeypatch):
+    api = _load_api_module(monkeypatch, api_key="secret", cors_origins="https://example.com")
+    async def _fake_async_run(user_input):
+        return _FakeResponse(ok=True)
+
+    monkeypatch.setattr(api, "async_run", _fake_async_run)
+
+    client = TestClient(api.app)
+    response = client.options(
+        "/generate",
+        headers={
+            "Origin": "https://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code != 403


### PR DESCRIPTION
### Motivation
- Reduce risk from the currently fully-open CORS and unauthenticated `/generate` endpoint by enabling an opt-in “secure mode” driven by environment variables while preserving backward compatibility.
- Secure mode should only be enforced when an environment variable is present so existing deployments without env vars keep current behaviour.

### Description
- Add env-driven secure mode to `src/po_core/app/api.py` that enforces an API key for `/generate` only when `PO_CORE_API_KEY` is set and non-empty.
- Accept API keys via either `X-API-Key` header or `Authorization: Bearer <key>` and return `403` on missing/incorrect key when secure mode is active, while leaving behaviour unchanged when `PO_CORE_API_KEY` is unset/empty.
- Add CORS control via `PO_CORE_CORS_ORIGINS` parsed as a comma-separated list (split+strip+drop empties); when unset the legacy `[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a86e97dcc8328aba49bfec9bff306)