### PR TITLE
Add deterministic extraction for unknowns, stakeholders, and deadline features

### DIFF
--- a/docs/spec/features_v1.md
+++ b/docs/spec/features_v1.md
@@ -1,25 +1,49 @@
 # Features v1 Catalog
 
-This document defines input-derived features used by rule engines.
-Features are observations, not recommendations.
+This document defines deterministic, input-derived features used by rule engines.
+Features are **observations only** (no recommendation or ethics judgment).
 
 ## unknowns
-- unknowns_count: int
-  - len(case.unknowns) if list else 0
-- unknowns_items: list[str] (optional)
-  - normalized string list from case.unknowns
+
+- `unknowns_count: int`
+  - `len(case["unknowns"])` when `case["unknowns"]` is a list, otherwise `0`.
+- `unknowns_items: list[str]`
+  - Extract only when `case["unknowns"]` is a list.
+  - For each element: convert to `str`, then `strip()`.
+  - Drop empty strings.
+  - Preserve original input order.
+  - Maximum 10 items (if more than 10, keep first 10).
+  - If missing/empty/non-list: `[]`.
 
 ## stakeholders
-- stakeholders_count: int
-  - len(case.stakeholders) if list else 0
-- stakeholder_roles: list[str] (optional)
-  - normalized list from case.stakeholders[*].role
+
+- `stakeholders_count: int`
+  - `len(case["stakeholders"])` when list, otherwise `0`.
+- `stakeholder_roles: list[str]`
+  - Extract only when `case["stakeholders"]` is a list.
+  - Use only elements that are `dict` and have `role`.
+  - `role` is converted to `str`, then `strip()`.
+  - Drop empty strings.
+  - Remove duplicates while preserving first-seen order.
+  - Maximum 10 items (if more than 10 unique roles, keep first 10).
+  - If missing/empty/non-list: `[]`.
 
 ## deadline
-- deadline_present: bool
-  - deadline exists and non-empty
-- deadline_iso: str|null (optional)
-  - normalized ISO string if parseable
-- days_to_deadline: int|null (recommended)
-  - computed from meta.created_at(now) and deadline_iso
-  - arithmetic only (no judgment thresholds here)
+
+- `deadline_present: bool`
+  - `True` when `case["deadline"]` exists and is non-empty after `str(...).strip()`.
+- `deadline_iso: str | null`
+  - Parsed/normalized deadline string when parseable, else `null`.
+  - Supported input formats:
+    - `YYYY-MM-DD`
+    - ISO 8601 datetime (including trailing `Z`)
+- `days_to_deadline: int | null`
+  - Compute only when `deadline_present` is `True`.
+  - `now` is provided externally from `meta.created_at` as ISO 8601 datetime string (trailing `Z` allowed).
+  - Date-diff rule (UTC basis):
+    - `now_date = date(now)`
+    - `deadline_date = date(deadline)`
+    - `days_to_deadline = (deadline_date - now_date).days`
+  - If `deadline` parsing fails (or `now` is unparsable):
+    - `deadline_iso = null`
+    - `days_to_deadline = null`

--- a/src/pocore/orchestrator.py
+++ b/src/pocore/orchestrator.py
@@ -44,7 +44,7 @@ def run_case(
     title = str(case.get("title", ""))
 
     # 1. parse_input → features
-    parsed = parse_input.parse(case, case_path=case_path)
+    parsed = parse_input.parse(case, case_path=case_path, now=created_at)
     short_id = parsed.short_id
     features = parsed.features
 

--- a/src/pocore/parse_input.py
+++ b/src/pocore/parse_input.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .utils import case_short_id, detect_constraint_conflict
+from .utils import case_short_id, detect_constraint_conflict, parse_deadline_iso, parse_iso_datetime
 
 
 @dataclass(frozen=True)
@@ -28,7 +28,54 @@ class ParsedInput:
     features: Dict[str, Any]
 
 
-def extract_features(case: Dict[str, Any]) -> Dict[str, Any]:
+def _extract_unknowns_items(unknowns: Any) -> list[str]:
+    if not isinstance(unknowns, list):
+        return []
+    items: list[str] = []
+    for item in unknowns:
+        normalized = str(item).strip()
+        if normalized:
+            items.append(normalized)
+        if len(items) >= 10:
+            break
+    return items
+
+
+def _extract_stakeholder_roles(stakeholders: Any) -> list[str]:
+    if not isinstance(stakeholders, list):
+        return []
+    roles: list[str] = []
+    seen: set[str] = set()
+    for item in stakeholders:
+        if not isinstance(item, dict) or "role" not in item:
+            continue
+        role = str(item.get("role")).strip()
+        if not role or role in seen:
+            continue
+        seen.add(role)
+        roles.append(role)
+        if len(roles) >= 10:
+            break
+    return roles
+
+
+def _extract_deadline_features(deadline: Any, now: Optional[str]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {"deadline_iso": None, "days_to_deadline": None}
+    deadline_present = deadline is not None and str(deadline).strip() != ""
+    if not deadline_present:
+        return result
+
+    deadline_iso, deadline_date = parse_deadline_iso(deadline)
+    now_dt = parse_iso_datetime(now)
+    if deadline_iso is None or deadline_date is None or now_dt is None:
+        return result
+
+    result["deadline_iso"] = deadline_iso
+    result["days_to_deadline"] = (deadline_date - now_dt.date()).days
+    return result
+
+
+def extract_features(case: Dict[str, Any], *, now: Optional[str] = None) -> Dict[str, Any]:
     """Derive feature flags from case dict for engine dispatch."""
     values = case.get("values", [])
     constraints = case.get("constraints", [])
@@ -44,15 +91,21 @@ def extract_features(case: Dict[str, Any]) -> Dict[str, Any]:
             len(stakeholders) if isinstance(stakeholders, list) else 0
         ),
         "deadline_present": (deadline is not None and str(deadline).strip() != ""),
+        "unknowns_items": _extract_unknowns_items(unknowns),
+        "stakeholder_roles": _extract_stakeholder_roles(stakeholders),
     }
+
+    features.update(_extract_deadline_features(deadline, now))
 
     features.update(detect_constraint_conflict(case))
     return features
 
 
-def parse(case: Dict[str, Any], *, case_path: Optional[Path] = None) -> ParsedInput:
+def parse(
+    case: Dict[str, Any], *, case_path: Optional[Path] = None, now: Optional[str] = None
+) -> ParsedInput:
     """Parse a case dict into a ParsedInput with features."""
     cid = str(case.get("case_id", "case_unknown"))
     short = case_short_id(cid, case_path=case_path)
-    feats = extract_features(case)
+    feats = extract_features(case, now=now)
     return ParsedInput(case=case, short_id=short, features=feats)


### PR DESCRIPTION
### Motivation

- Clarify and lock a deterministic feature contract for `unknowns`, `stakeholders`, and `deadline` so engines consume stable, testable observations rather than ad-hoc input shapes. 
- Prevent divergence and non-determinism in downstream logic by codifying parsing/limits and wiring `now` through the pipeline for reproducible date arithmetic.

### Description

- Add deterministic datetime/date helpers `parse_iso_datetime` and `parse_deadline_iso` in `src/pocore/utils.py` to uniformly parse `YYYY-MM-DD` and ISO-8601 datetimes (including trailing `Z`).
- Extend `src/pocore/parse_input.py` with `unknowns_items`, `stakeholder_roles`, and deadline extraction (`deadline_iso`, `days_to_deadline`) plus helper extractors and make `parse(..., now=...)` accept injected `now` for deterministic date-diff computation.
- Wire the orchestrator to pass normalized `created_at` into `parse_input.parse(...)` by changing the call in `src/pocore/orchestrator.py` to `parse(..., now=created_at)` so `days_to_deadline` is stable.
- Add and update the specification and tests by editing `docs/spec/features_v1.md` to document the rules (string-normalize, strip, drop empties, dedup first-seen, preserve order, max 10) and expanding `tests/test_features.py` with normalization, dedup/limit, and deadline parsing/date-diff coverage.

### Testing

- Ran `pytest -q tests/test_features.py` which completed successfully (`9 passed`).
- Ran full test suite with `pytest -q` which completed with all tests passing (`3269 passed, 134 skipped`).
- Verified that frozen golden files were not modified and no golden/e2e test was weakened as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1515a5848328b0a9209907cc499b)