### PR TITLE
Centralize recommendation arbitration policy in policy_v1

### DIFF
--- a/docs/adr/0006-recommendation-arbitration-policy-v1.md
+++ b/docs/adr/0006-recommendation-arbitration-policy-v1.md
@@ -1,0 +1,49 @@
+# ADR 0006: Recommendation Arbitration Policy v1
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Context
+Task B requires that recommendation arbitration rules be centralized and deterministic.
+Previously, thresholds and conflict ordering were implicit in the recommendation engine,
+which risks drift as new scenarios are added.
+
+Po_core already defines responsibility boundaries:
+- parse_input: observation (features extraction)
+- recommendation engine: arbitration decision
+- other engines: supporting outputs only
+
+## Decision
+
+### Policy location
+Introduce `src/pocore/policy_v1.py` as the single source of arbitration thresholds:
+- `UNKNOWN_BLOCK`
+- `UNKNOWN_SOFT`
+- `TIME_PRESSURE_DAYS`
+
+And helper predicates:
+- `should_block_recommendation(features)`
+- `has_time_pressure_with_unknowns(features)`
+
+### Decision authority
+Only `src/pocore/engines/recommendation_v1.py` may import and use `policy_v1.py`.
+Other engines must not import `policy_v1.py` and must not change recommendation status.
+
+### Arbitration order (v1)
+For non-frozen generic cases:
+1. `values_empty == True` ⇒ `no_recommendation` (existing behavior kept)
+2. `constraint_conflict == True` ⇒ existing conflict-first behavior kept
+3. `unknowns_count >= UNKNOWN_BLOCK` ⇒ `no_recommendation`
+4. `days_to_deadline <= TIME_PRESSURE_DAYS` and `unknowns_count > 0`
+   ⇒ allow recommendation but reduce confidence (`low`)
+5. Otherwise ⇒ existing default recommendation path
+
+### Frozen cases contract
+`case_001` and `case_009` remain frozen via explicit branches in recommendation engine.
+Policy refactoring must not change these outputs.
+
+## Consequences
+- Thresholds become explicit and auditable in one file.
+- Unknowns × deadline arbitration is consistent across cases.
+- Future threshold tuning can happen by policy update + tests without spreading literals.
+- Determinism is preserved because policy depends only on injected features.

--- a/src/pocore/engines/recommendation_v1.py
+++ b/src/pocore/engines/recommendation_v1.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from pocore.policy_v1 import has_time_pressure_with_unknowns, should_block_recommendation
+
 
 def recommend(
     case: Dict[str, Any],
@@ -74,6 +76,30 @@ def recommend(
                 }
             ],
             "confidence": "medium",
+        }
+
+    if should_block_recommendation(feats):
+        return {
+            "status": "no_recommendation",
+            "reason": "重要情報の不足が大きく、現時点での推奨は恣意的になる。",
+            "missing_info": ["重要な不明点の解消"],
+            "next_steps": ["unknownsを優先度順に埋める"],
+            "confidence": "high",
+        }
+
+    if has_time_pressure_with_unknowns(feats):
+        return {
+            "status": "recommended",
+            "recommended_option_id": "opt_1",
+            "reason": "期限が近いため、低リスクな案で前進しつつ不明点を並行して潰す。",
+            "counter": "不明点が残るため、見積もりや期待値にズレが出る。",
+            "alternatives": [
+                {
+                    "option_id": "opt_2",
+                    "when_to_choose": "期限を交渉できる、または追加情報を先に取り切れる場合",
+                }
+            ],
+            "confidence": "low",
         }
 
     return {

--- a/src/pocore/policy_v1.py
+++ b/src/pocore/policy_v1.py
@@ -1,0 +1,28 @@
+"""src/pocore/policy_v1.py — Recommendation arbitration policy constants (v1)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+UNKNOWN_BLOCK = 4
+UNKNOWN_SOFT = 1
+TIME_PRESSURE_DAYS = 7
+
+
+
+def should_block_recommendation(features: Dict[str, Any]) -> bool:
+    """Return True when missing critical information should block recommendation."""
+    unknowns_count = int(features.get("unknowns_count", 0) or 0)
+    return unknowns_count >= UNKNOWN_BLOCK
+
+
+
+def has_time_pressure_with_unknowns(features: Dict[str, Any]) -> bool:
+    """Return True when deadline is near and unknowns remain."""
+    days_to_deadline = features.get("days_to_deadline")
+    unknowns_count = int(features.get("unknowns_count", 0) or 0)
+    return (
+        isinstance(days_to_deadline, int)
+        and days_to_deadline <= TIME_PRESSURE_DAYS
+        and unknowns_count > 0
+    )

--- a/tests/test_recommendation_policy.py
+++ b/tests/test_recommendation_policy.py
@@ -1,0 +1,40 @@
+from pocore.engines.recommendation_v1 import recommend
+from pocore.policy_v1 import TIME_PRESSURE_DAYS, UNKNOWN_BLOCK
+
+
+def test_unknowns_at_or_above_unknown_block_returns_no_recommendation() -> None:
+    result = recommend(
+        case={},
+        short_id="case_custom",
+        features={"unknowns_count": UNKNOWN_BLOCK},
+        options=[],
+    )
+
+    assert result["status"] == "no_recommendation"
+    assert result["confidence"] == "high"
+
+
+def test_deadline_pressure_with_unknowns_reduces_confidence() -> None:
+    result = recommend(
+        case={},
+        short_id="case_custom",
+        features={"unknowns_count": 1, "days_to_deadline": TIME_PRESSURE_DAYS},
+        options=[],
+    )
+
+    assert result["status"] == "recommended"
+    assert result["recommended_option_id"] == "opt_1"
+    assert result["confidence"] == "low"
+
+
+def test_unknowns_zero_uses_default_recommendation() -> None:
+    result = recommend(
+        case={},
+        short_id="case_custom",
+        features={"unknowns_count": 0, "days_to_deadline": 1},
+        options=[],
+    )
+
+    assert result["status"] == "recommended"
+    assert result["recommended_option_id"] == "opt_1"
+    assert result["confidence"] == "medium"


### PR DESCRIPTION
### Motivation
- Consolidate recommendation arbitration thresholds and predicates into a single, auditable place to avoid scattered literals and inconsistent behavior across engines.
- Ensure deterministic, testable arbitration for the recommendation engine, especially for the interaction of `unknowns_count` and `days_to_deadline` while preserving frozen golden cases.
- Make the recommendation engine the single authority for `recommendation.status` decisions so other engines remain feature-only.

### Description
- Add `src/pocore/policy_v1.py` defining thresholds and helpers: `UNKNOWN_BLOCK = 4`, `UNKNOWN_SOFT = 1`, `TIME_PRESSURE_DAYS = 7`, `should_block_recommendation(features)`, and `has_time_pressure_with_unknowns(features)`.
- Update `src/pocore/engines/recommendation_v1.py` to import and use the policy helpers for generic arbitration while keeping the explicit frozen branches for `case_001` and `case_009` unchanged.
- Add an ADR `docs/adr/0006-recommendation-arbitration-policy-v1.md` documenting the policy location, decision authority (recommendation engine only), and the arbitration order.
- Add unit tests `tests/test_recommendation_policy.py` that lock behavior for the unknowns threshold block, near-deadline with unknowns (reduced confidence), and the default recommendation path.

### Testing
- Baseline: ran `pytest -q` before changes and observed `3269 passed, 134 skipped`.
- Targeted run: executed `pytest -q tests/test_recommendation_policy.py tests/test_golden_e2e.py`, resolved a golden mismatch by tuning `UNKNOWN_BLOCK` and reran, producing `15 passed` for that run.
- Final validation: ran full `pytest -q` after adjustments and observed `3272 passed, 134 skipped`, confirming no frozen goldens or schemas were altered and the new policy/tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1b91d85c83289a07091734088438)