### PR TITLE
Add parse_input trace observability metrics for generic cases

### DIFF
--- a/docs/adr/0007-trace-metrics-observability.md
+++ b/docs/adr/0007-trace-metrics-observability.md
@@ -1,0 +1,41 @@
+# ADR 0007: Trace Metrics Observability for parse_input
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Context
+Task C requires observability for input-side uncertainty and stakeholder pressure without
+mixing policy decisions into trace generation.
+
+Po_core already fixes trace determinism via ADR-0003:
+- timestamps are derived from injected `now` (`meta.created_at`) with fixed offsets
+- no wall-clock randomness is allowed
+- frozen golden cases (`case_001`, `case_009`) must remain unchanged
+
+## Decision
+
+### Metrics to add (generic trace only)
+In `src/pocore/tracer.py`, for non-frozen cases (`case_001` / `case_009` 以外),
+`parse_input` step `metrics` includes:
+- `unknowns_count` (int)
+- `stakeholders_count` (int)
+- `days_to_deadline` (int, optional)
+
+### Source of truth
+All values are observational and must come from `features` (from `parse_input`):
+- tracer does not compute recommendation or ethics logic
+- orchestrator remains wiring only
+
+### Null/omission policy
+`days_to_deadline` is **omitted** when feature value is unavailable (`None`).
+We do not emit `null` for this key in trace metrics.
+
+### Frozen golden exception
+`case_001` and `case_009` trace payloads remain frozen and unchanged.
+The new metrics apply only to generic trace branches.
+
+## Consequences
+- parse_input observability increases for debugging/monitoring.
+- Determinism is preserved because metrics are pure values from deterministic features,
+  and trace time behavior remains `now + fixed offset`.
+- Existing frozen contracts remain intact while allowing generic golden evolution.

--- a/scenarios/case_002_expected.json
+++ b/scenarios/case_002_expected.json
@@ -244,7 +244,10 @@
         "summary": "入力を正規化し、特徴量（features）を抽出した",
         "metrics": {
           "options_planned": 2,
-          "questions_planned": 0
+          "questions_planned": 0,
+          "unknowns_count": 3,
+          "stakeholders_count": 4,
+          "days_to_deadline": 16
         }
       },
       {

--- a/scenarios/case_010_expected.json
+++ b/scenarios/case_010_expected.json
@@ -313,6 +313,9 @@
         "metrics": {
           "options_planned": 2,
           "questions_planned": 3,
+          "unknowns_count": 3,
+          "stakeholders_count": 3,
+          "days_to_deadline": 190,
           "constraint_conflict": true
         }
       },

--- a/src/pocore/tracer.py
+++ b/src/pocore/tracer.py
@@ -88,7 +88,11 @@ def build_trace(
     parse_metrics: Dict[str, Any] = {
         "options_planned": options_count,
         "questions_planned": questions_count,
+        "unknowns_count": int(feats.get("unknowns_count", 0)),
+        "stakeholders_count": int(feats.get("stakeholders_count", 0)),
     }
+    if feats.get("days_to_deadline") is not None:
+        parse_metrics["days_to_deadline"] = int(feats["days_to_deadline"])
     if conflict:
         parse_metrics["constraint_conflict"] = True
 

--- a/tests/test_trace_metrics.py
+++ b/tests/test_trace_metrics.py
@@ -1,0 +1,113 @@
+from pocore.tracer import build_trace
+
+
+def _parse_step(trace: dict) -> dict:
+    return next(step for step in trace["steps"] if step["name"] == "parse_input")
+
+
+def test_build_trace_generic_parse_input_metrics_include_observability_values():
+    trace = build_trace(
+        short_id="case_123",
+        created_at="2026-02-22T00:00:00Z",
+        options_count=2,
+        questions_count=1,
+        features={
+            "unknowns_count": 3,
+            "stakeholders_count": 2,
+            "days_to_deadline": 5,
+            "constraint_conflict": True,
+        },
+    )
+
+    metrics = _parse_step(trace)["metrics"]
+    assert metrics["unknowns_count"] == 3
+    assert metrics["stakeholders_count"] == 2
+    assert metrics["days_to_deadline"] == 5
+    assert metrics["constraint_conflict"] is True
+
+
+def test_build_trace_generic_omits_days_to_deadline_when_unknown():
+    trace = build_trace(
+        short_id="case_124",
+        created_at="2026-02-22T00:00:00Z",
+        options_count=1,
+        questions_count=0,
+        features={"unknowns_count": 1, "stakeholders_count": 0, "days_to_deadline": None},
+    )
+
+    metrics = _parse_step(trace)["metrics"]
+    assert metrics["unknowns_count"] == 1
+    assert metrics["stakeholders_count"] == 0
+    assert "days_to_deadline" not in metrics
+
+
+def test_build_trace_frozen_case_001_and_009_steps_unchanged():
+    created_at = "2026-02-22T00:00:00Z"
+
+    trace_001 = build_trace(
+        short_id="case_001",
+        created_at=created_at,
+        options_count=99,
+        questions_count=99,
+        features={
+            "unknowns_count": 999,
+            "stakeholders_count": 999,
+            "days_to_deadline": 999,
+            "constraint_conflict": True,
+        },
+    )
+    assert trace_001["steps"] == [
+        {
+            "name": "parse_input",
+            "started_at": "2026-02-22T00:00:00Z",
+            "ended_at": "2026-02-22T00:00:01Z",
+            "summary": "入力を正規化し、不明点を抽出した",
+        },
+        {
+            "name": "generate_options",
+            "started_at": "2026-02-22T00:00:01Z",
+            "ended_at": "2026-02-22T00:00:02Z",
+            "summary": "2案を生成した",
+            "metrics": {"options": 99},
+        },
+        {
+            "name": "compose_output",
+            "started_at": "2026-02-22T00:00:02Z",
+            "ended_at": "2026-02-22T00:00:03Z",
+            "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        },
+    ]
+
+    trace_009 = build_trace(
+        short_id="case_009",
+        created_at=created_at,
+        options_count=99,
+        questions_count=99,
+        features={
+            "unknowns_count": 999,
+            "stakeholders_count": 999,
+            "days_to_deadline": 999,
+            "constraint_conflict": True,
+        },
+    )
+    assert trace_009["steps"] == [
+        {
+            "name": "parse_input",
+            "started_at": "2026-02-22T00:00:00Z",
+            "ended_at": "2026-02-22T00:00:01Z",
+            "summary": "valuesが空であることを検出した",
+        },
+        {
+            "name": "question_layer",
+            "started_at": "2026-02-22T00:00:01Z",
+            "ended_at": "2026-02-22T00:00:02Z",
+            "summary": "軸を作るための質問を生成した",
+            "metrics": {"questions": 99},
+        },
+        {
+            "name": "compose_output",
+            "started_at": "2026-02-22T00:00:02Z",
+            "ended_at": "2026-02-22T00:00:03Z",
+            "summary": "推奨を保留し、次ステップを提示した",
+        },
+    ]


### PR DESCRIPTION
### Motivation
- Provide observability for input-side uncertainty and stakeholder pressure by surfacing `unknowns_count`, `stakeholders_count`, and `days_to_deadline` in the `parse_input` trace metrics for generic cases.
- Keep determinism and responsibility boundaries: metrics must come from `features` and frozen golden cases (`case_001`/`case_009`) must remain unchanged.
- Record the design decision and omission policy for `days_to_deadline` in an ADR so future changes remain auditable.

### Description
- Updated `src/pocore/tracer.py` to include `unknowns_count` and `stakeholders_count` in `parse_input.metrics` and to add `days_to_deadline` only when the feature value is present (omitted when `None`).
- Added ADR `docs/adr/0007-trace-metrics-observability.md` documenting metric scope, source (`features`), determinism (`now + offset`), frozen-golden exception, and the omission policy for `days_to_deadline`.
- Added unit tests `tests/test_trace_metrics.py` to verify generic metrics appear, `days_to_deadline` omission behavior, and that `case_001`/`case_009` frozen traces are unchanged.
- Regenerated non-frozen goldens deterministically and updated `scenarios/case_002_expected.json` and `scenarios/case_010_expected.json` to reflect the new metrics produced by the pipeline.

### Testing
- Baseline run: `pytest -q` before changes passed with `3272 passed, 134 skipped`.
- Iteration check: `pytest -q tests/test_trace_metrics.py tests/test_golden_e2e.py` used to validate behavior; initial mismatch on non-frozen goldens was detected as expected and resolved by regenerating those goldens deterministically via `run_case_file(..., now=..., seed=0)`.
- Final run: `pytest -q` after updates passed with `3275 passed, 134 skipped` (full suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2bf78ee0832897b67c463ea1e3bd)