### PR TITLE
Add Ethics Guardrails v1 (non-interference) with ADR and tests

### DIFF
--- a/docs/adr/0008-ethics-guardrails-v1-non-interference.md
+++ b/docs/adr/0008-ethics-guardrails-v1-non-interference.md
@@ -1,0 +1,45 @@
+# ADR 0008: Ethics Guardrails v1 (Non-interference)
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Context
+Task D / M2 introduces stronger ethics outputs, while preserving recommendation arbitration authority.
+Po_core already centralizes arbitration in `recommendation_v1` + `policy_v1` (ADR 0006).
+This ADR clarifies that ethics is a guardrail layer and must not decide recommendation status.
+
+## Decision
+
+### Non-interference contract
+`src/pocore/engines/ethics_v1.py` may enrich:
+- `ethics.guardrails`
+- `ethics.tradeoffs`
+- `options[*].ethics_review`
+
+It must not alter or arbitrate:
+- `recommendation.status`
+- `recommendation.recommended_option_id`
+- policy thresholds in `policy_v1`
+
+Recommendation decisions remain exclusively in `src/pocore/engines/recommendation_v1.py`.
+
+### Feature reactions (generic path only)
+For non-frozen cases, ethics v1 reacts to features:
+- `unknowns_count > 0`
+  - add guardrails about avoiding assertions on uncertain facts
+  - require explicit assumptions/uncertainty disclosure
+  - add matching concerns in `options[*].ethics_review`
+- `stakeholders_count > 1`
+  - add guardrail for stakeholder impact and consent
+  - add tradeoff: autonomy vs externality/justice
+- `days_to_deadline` in short horizon (`0..7` days)
+  - add tradeoff: speed vs nonmaleficence
+  - add guardrail: do not skip verification under time pressure
+
+Frozen branches for `case_001` and `case_009` remain unchanged.
+
+## Consequences
+- Ethics output becomes auditable and feature-driven without case-specific branching.
+- Recommendation determinism and accountability are preserved by strict separation of concerns.
+- Future ethics expansion should remain rule-based first; if complexity grows,
+  add extension points without violating non-interference.

--- a/scenarios/case_002_expected.json
+++ b/scenarios/case_002_expected.json
@@ -54,11 +54,23 @@
       "ethics_review": {
         "principles_applied": [
           "integrity",
-          "autonomy"
+          "autonomy",
+          "justice"
         ],
-        "tradeoffs": [],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          }
+        ],
         "concerns": [
-          "不確実な事実を断言しない"
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
         ],
         "confidence": "medium"
       },
@@ -126,11 +138,23 @@
       "ethics_review": {
         "principles_applied": [
           "integrity",
-          "autonomy"
+          "autonomy",
+          "justice"
         ],
-        "tradeoffs": [],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          }
+        ],
         "concerns": [
-          "不確実な事実を断言しない"
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
         ],
         "confidence": "medium"
       },
@@ -184,11 +208,23 @@
       "justice",
       "accountability"
     ],
-    "tradeoffs": [],
+    "tradeoffs": [
+      {
+        "tension": "自己決定と外部性/公正の緊張",
+        "between": [
+          "autonomy",
+          "justice"
+        ],
+        "mitigation": "関係者への影響を可視化し、同意可能な進め方を選ぶ",
+        "severity": "medium"
+      }
+    ],
     "guardrails": [
       "不確実な事実を断言しない",
       "意思決定主体をユーザーから奪わない",
-      "推奨には反証と代替案を併記する"
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "関係者への影響と同意を考慮する"
     ],
     "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。"
   },

--- a/scenarios/case_010_expected.json
+++ b/scenarios/case_010_expected.json
@@ -69,7 +69,9 @@
         "principles_applied": [
           "integrity",
           "nonmaleficence",
-          "accountability"
+          "accountability",
+          "justice",
+          "autonomy"
         ],
         "tradeoffs": [
           {
@@ -80,10 +82,20 @@
             ],
             "mitigation": "制約を可視化して破綻条件を先に潰す",
             "severity": "high"
+          },
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
           }
         ],
         "concerns": [
-          "矛盾した制約を無視して断言しない"
+          "矛盾した制約を無視して断言しない",
+          "前提と不確実性を明示する"
         ],
         "confidence": "medium"
       },
@@ -157,7 +169,9 @@
         "principles_applied": [
           "integrity",
           "nonmaleficence",
-          "accountability"
+          "accountability",
+          "justice",
+          "autonomy"
         ],
         "tradeoffs": [
           {
@@ -168,10 +182,20 @@
             ],
             "mitigation": "制約を可視化して破綻条件を先に潰す",
             "severity": "high"
+          },
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
           }
         ],
         "concerns": [
-          "矛盾した制約を無視して断言しない"
+          "矛盾した制約を無視して断言しない",
+          "前提と不確実性を明示する"
         ],
         "confidence": "medium"
       },
@@ -229,12 +253,23 @@
         ],
         "mitigation": "期限・実験・ガードレールで両立を狙う",
         "severity": "medium"
+      },
+      {
+        "tension": "自己決定と外部性/公正の緊張",
+        "between": [
+          "autonomy",
+          "justice"
+        ],
+        "mitigation": "関係者への影響を可視化し、同意可能な進め方を選ぶ",
+        "severity": "medium"
       }
     ],
     "guardrails": [
       "不確実な事実を断言しない",
       "意思決定主体をユーザーから奪わない",
-      "推奨には反証と代替案を併記する"
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "関係者への影響と同意を考慮する"
     ],
     "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。"
   },

--- a/tests/test_ethics_guardrails.py
+++ b/tests/test_ethics_guardrails.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pocore.engines import ethics_v1
+
+
+def test_ethics_guardrails_v1_feature_reactions_for_generic_case() -> None:
+    case = {"case_id": "case_777_generic"}
+    features = {
+        "constraint_conflict": False,
+        "unknowns_count": 2,
+        "stakeholders_count": 3,
+        "days_to_deadline": 3,
+    }
+    options = [
+        {"option_id": "opt_1", "label": "A"},
+        {"option_id": "opt_2", "label": "B"},
+    ]
+
+    reviewed_options, summary = ethics_v1.apply(
+        case,
+        short_id="case_777",
+        features=features,
+        options=options,
+    )
+
+    assert "前提と不確実性を明示する" in summary["guardrails"]
+    assert "関係者への影響と同意を考慮する" in summary["guardrails"]
+    assert "時間圧力下でも検証を省略しない" in summary["guardrails"]
+
+    tensions = {item["tension"] for item in summary["tradeoffs"]}
+    assert "自己決定と外部性/公正の緊張" in tensions
+    assert "速度と安全（nonmaleficence）の緊張" in tensions
+
+    for option in reviewed_options:
+        review = option["ethics_review"]
+        assert "前提と不確実性を明示する" in review["concerns"]
+        assert "justice" in review["principles_applied"]
+        assert "autonomy" in review["principles_applied"]
+        assert "nonmaleficence" in review["principles_applied"]
+
+
+def test_ethics_guardrails_v1_only_applies_to_generic_path() -> None:
+    options = [{"option_id": "opt_1"}, {"option_id": "opt_2"}]
+
+    _, summary = ethics_v1.apply(
+        {"case_id": "case_001_job_change"},
+        short_id="case_001",
+        features={"unknowns_count": 9, "stakeholders_count": 9, "days_to_deadline": 1},
+        options=options,
+    )
+
+    assert "関係者への影響と同意を考慮する" not in summary["guardrails"]
+    assert "時間圧力下でも検証を省略しない" not in summary["guardrails"]

--- a/tests/test_ethics_non_interference.py
+++ b/tests/test_ethics_non_interference.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from pocore.runner import run_case_file
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CASE_PATH = ROOT / "scenarios" / "case_010.yaml"
+
+
+def test_ethics_changes_do_not_change_recommendation(monkeypatch) -> None:
+    baseline = run_case_file(
+        CASE_PATH,
+        seed=0,
+        deterministic=True,
+        now="2026-02-22T00:00:00Z",
+    )
+
+    def _fake_apply(
+        case: Dict[str, Any],
+        *,
+        short_id: str,
+        features: Optional[Dict[str, Any]],
+        options: List[Dict[str, Any]],
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        for opt in options:
+            opt["ethics_review"] = {
+                "principles_applied": ["integrity", "justice", "nonmaleficence"],
+                "tradeoffs": [
+                    {
+                        "tension": "倫理の緊張を最大化したダミー",
+                        "between": ["autonomy", "justice"],
+                        "mitigation": "倫理説明を増やす",
+                        "severity": "high",
+                    }
+                ],
+                "concerns": [
+                    "この倫理レビューはrecommendationへ介入しない",
+                    "ダミーの倫理懸念",
+                ],
+                "confidence": "low",
+            }
+        return options, {
+            "principles_used": ["integrity", "autonomy", "nonmaleficence", "justice", "accountability"],
+            "tradeoffs": [
+                {
+                    "tension": "ダミー倫理トレードオフ",
+                    "between": ["autonomy", "justice"],
+                    "mitigation": "説明責任で緩和",
+                    "severity": "high",
+                }
+            ],
+            "guardrails": ["倫理出力は推奨裁定に介入しない"],
+            "notes": "monkeypatch for non-interference test",
+        }
+
+    monkeypatch.setattr("pocore.orchestrator.ethics_v1.apply", _fake_apply)
+
+    patched = run_case_file(
+        CASE_PATH,
+        seed=0,
+        deterministic=True,
+        now="2026-02-22T00:00:00Z",
+    )
+
+    assert patched["recommendation"] == baseline["recommendation"]


### PR DESCRIPTION
### Motivation
- Introduce a minimal, feature-driven ethics guardrails layer that enriches `ethics` outputs without altering recommendation arbitration, preserving determinism and the frozen golden contract for `case_001` and `case_009`.
- Make ethics outputs auditable and reactive to observable features (`unknowns_count`, `stakeholders_count`, `days_to_deadline`) so behavior scales without case-specific branching.

### Description
- Implemented feature-driven enhancements in `src/pocore/engines/ethics_v1.py` to append `guardrails`, `tradeoffs`, and `options[*].ethics_review` when `unknowns_count > 0`, `stakeholders_count > 1`, or `days_to_deadline` is in `0..7`, while keeping `case_001` and `case_009` frozen branches unchanged and not touching recommendation logic.
- Added helper functions `_append_unique` and `_is_short_deadline` and composed summary-level `tradeoffs` and `guardrails` for the generic path in `ethics_v1`.
- Added ADR `docs/adr/0008-ethics-guardrails-v1-non-interference.md` documenting the non-interference contract and which features ethics reacts to.
- Added tests `tests/test_ethics_guardrails.py` (direct engine behavior) and `tests/test_ethics_non_interference.py` (monkeypatch-based non-interference assertion), and updated non-frozen goldens `scenarios/case_002_expected.json` and `scenarios/case_010_expected.json` to reflect the new ethics output while leaving `case_001_expected.json` and `case_009_expected.json` untouched.

### Testing
- Ran focused unit tests `pytest -q tests/test_ethics_guardrails.py tests/test_ethics_non_interference.py` which passed against the modified engine implementation.
- During golden verification `pytest -q tests/test_golden_e2e.py` two non-frozen expected files (`case_002` and `case_010`) initially mismatched and were deterministically regenerated via the runner to reflect the new ethics output, keeping the frozen goldens unchanged.
- Ran full test suite with `pytest -q` on the modified repository and observed all tests passing: `3278 passed, 134 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2e3f03dc8328a1e9f63d5d66f0ed)