### PR TITLE
Add deterministic arbitration path telemetry to trace compose_output

### DIFF
--- a/docs/adr/0009-trace-arbitration-path.md
+++ b/docs/adr/0009-trace-arbitration-path.md
@@ -1,0 +1,44 @@
+# ADR 0009: Traceへrecommendation裁定経路を記録する
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Context
+Po_coreは recommendation の最終裁定（推奨/保留）を返すが、
+これまで generic trace からは「どの裁定ルールで分岐したか」を直接読めなかった。
+
+監査性の観点では、以下を最小コストで可視化したい。
+- recommendationエンジンの裁定経路（例: `BLOCK_UNKNOWN`）
+- 裁定の基準値（policy constants）のスナップショット
+
+同時に、ADR-0003 の deterministic contract と、凍結golden（case_001/case_009）を守る必要がある。
+
+## Decision
+
+### 1. recommendationエンジンは裁定コードを返す
+`src/pocore/engines/recommendation_v1.py` において、
+推薦本文に加えて `arbitration_code` を返す補助関数を導入する。
+
+代表コード:
+- `NO_VALUES`
+- `BLOCK_UNKNOWN`
+- `TIME_PRESSURE_LOW_CONF`
+- `DEFAULT_RECOMMEND`
+- `CONSTRAINT_CONFLICT`
+
+### 2. orchestratorは裁定コードをtraceに配線する
+`src/pocore/orchestrator.py` で recommendation の裁定コードを受け取り、
+`tracer.build_trace(...)` に渡す。
+
+### 3. tracerのgeneric compose_output metricsに記録する
+`src/pocore/tracer.py` の generic 分岐で `compose_output.metrics` に以下を出力する。
+- `arbitration_code`
+- `policy_snapshot`（`UNKNOWN_BLOCK`, `TIME_PRESSURE_DAYS`）
+
+凍結分岐（`case_001`, `case_009`）は従来通り変更しない。
+
+## Consequences
+- recommendation裁定の説明責任が trace で読み取れる。
+- policy定数の差分監査が可能になる。
+- 出力の決定性は維持される（値は pure rules + fixed constants 由来）。
+- 凍結golden契約を破らずに observability を拡張できる。

--- a/scenarios/case_002_expected.json
+++ b/scenarios/case_002_expected.json
@@ -299,7 +299,14 @@
         "name": "compose_output",
         "started_at": "2026-02-22T00:00:02Z",
         "ended_at": "2026-02-22T00:00:03Z",
-        "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        "metrics": {
+          "arbitration_code": "DEFAULT_RECOMMEND",
+          "policy_snapshot": {
+            "UNKNOWN_BLOCK": 4,
+            "TIME_PRESSURE_DAYS": 7
+          }
+        }
       }
     ]
   }

--- a/scenarios/case_010_expected.json
+++ b/scenarios/case_010_expected.json
@@ -376,7 +376,14 @@
         "name": "compose_output",
         "started_at": "2026-02-22T00:00:03Z",
         "ended_at": "2026-02-22T00:00:04Z",
-        "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        "metrics": {
+          "arbitration_code": "CONSTRAINT_CONFLICT",
+          "policy_snapshot": {
+            "UNKNOWN_BLOCK": 4,
+            "TIME_PRESSURE_DAYS": 7
+          }
+        }
       }
     ]
   }

--- a/src/pocore/engines/recommendation_v1.py
+++ b/src/pocore/engines/recommendation_v1.py
@@ -2,9 +2,135 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from pocore.policy_v1 import has_time_pressure_with_unknowns, should_block_recommendation
+
+
+def arbitrate_recommendation(
+    case: Dict[str, Any],
+    *,
+    short_id: str,
+    features: Optional[Dict[str, Any]],
+    options: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], str]:
+    """Produce recommendation payload with deterministic arbitration code."""
+
+    if short_id == "case_001":
+        return (
+            {
+                "status": "recommended",
+                "recommended_option_id": "opt_1",
+                "reason": (
+                    "重要不明点が残ったまま転職を断言するより、"
+                    "期限付きで情報収集し基準で決断する方が誠実で後悔を減らしやすい。"
+                ),
+                "counter": "期限を守れないと先延ばしになり、機会損失が増える。",
+                "alternatives": [
+                    {
+                        "option_id": "opt_2",
+                        "when_to_choose": "転職先が情報開示に消極的で、安定を優先したい場合",
+                    }
+                ],
+                "confidence": "medium",
+            },
+            "DEFAULT_RECOMMEND",
+        )
+
+    if short_id == "case_009":
+        return (
+            {
+                "status": "no_recommendation",
+                "reason": (
+                    "価値観と目的が未確定なため、推奨は恣意的になる。まず問いで軸を作る。"
+                ),
+                "missing_info": ["学び直しの目的", "リスク許容量", "支援の有無"],
+                "next_steps": [
+                    "q1〜q4に答えて価値の優先順位を仮決めする",
+                    "候補校3つの費用と出口を集める",
+                ],
+                "confidence": "high",
+            },
+            "NO_VALUES",
+        )
+
+    # ── Generic: feature-driven ───────────────────────────────────────────
+    feats = features or {}
+
+    if feats.get("values_empty") is True:
+        return (
+            {
+                "status": "no_recommendation",
+                "reason": "価値観（評価軸）が未確定なため、推奨は恣意的になる。",
+                "missing_info": ["価値の優先順位"],
+                "next_steps": ["価値の優先順位を仮決めする"],
+                "confidence": "high",
+            },
+            "NO_VALUES",
+        )
+
+    if feats.get("constraint_conflict") is True:
+        return (
+            {
+                "status": "recommended",
+                "recommended_option_id": "opt_1",
+                "reason": (
+                    "制約が矛盾している状態では、どの案も破綻しやすい。"
+                    "まず制約を再設計してから進めるべき。"
+                ),
+                "counter": "制約の調整ができない場合、目標（期限/投入時間）を下げる必要がある。",
+                "alternatives": [
+                    {
+                        "option_id": "opt_2",
+                        "when_to_choose": "期限目標を下げ、週5時間で検証に縮退したい場合",
+                    }
+                ],
+                "confidence": "medium",
+            },
+            "CONSTRAINT_CONFLICT",
+        )
+
+    if should_block_recommendation(feats):
+        return (
+            {
+                "status": "no_recommendation",
+                "reason": "重要情報の不足が大きく、現時点での推奨は恣意的になる。",
+                "missing_info": ["重要な不明点の解消"],
+                "next_steps": ["unknownsを優先度順に埋める"],
+                "confidence": "high",
+            },
+            "BLOCK_UNKNOWN",
+        )
+
+    if has_time_pressure_with_unknowns(feats):
+        return (
+            {
+                "status": "recommended",
+                "recommended_option_id": "opt_1",
+                "reason": "期限が近いため、低リスクな案で前進しつつ不明点を並行して潰す。",
+                "counter": "不明点が残るため、見積もりや期待値にズレが出る。",
+                "alternatives": [
+                    {
+                        "option_id": "opt_2",
+                        "when_to_choose": "期限を交渉できる、または追加情報を先に取り切れる場合",
+                    }
+                ],
+                "confidence": "low",
+            },
+            "TIME_PRESSURE_LOW_CONF",
+        )
+
+    return (
+        {
+            "status": "recommended",
+            "recommended_option_id": "opt_1",
+            "reason": "害を抑えつつ前進できるため。",
+            "counter": "遅いと感じる可能性がある。",
+            "alternatives": [{"option_id": "opt_2", "when_to_choose": "不明点が多い場合"}],
+            "confidence": "medium",
+        },
+        "DEFAULT_RECOMMEND",
+    )
 
 
 def recommend(
@@ -14,99 +140,12 @@ def recommend(
     features: Optional[Dict[str, Any]],
     options: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Produce a recommendation or no_recommendation."""
+    """Backward-compatible recommendation payload only."""
 
-    if short_id == "case_001":
-        return {
-            "status": "recommended",
-            "recommended_option_id": "opt_1",
-            "reason": (
-                "重要不明点が残ったまま転職を断言するより、"
-                "期限付きで情報収集し基準で決断する方が誠実で後悔を減らしやすい。"
-            ),
-            "counter": "期限を守れないと先延ばしになり、機会損失が増える。",
-            "alternatives": [
-                {
-                    "option_id": "opt_2",
-                    "when_to_choose": "転職先が情報開示に消極的で、安定を優先したい場合",
-                }
-            ],
-            "confidence": "medium",
-        }
-
-    if short_id == "case_009":
-        return {
-            "status": "no_recommendation",
-            "reason": (
-                "価値観と目的が未確定なため、推奨は恣意的になる。まず問いで軸を作る。"
-            ),
-            "missing_info": ["学び直しの目的", "リスク許容量", "支援の有無"],
-            "next_steps": [
-                "q1〜q4に答えて価値の優先順位を仮決めする",
-                "候補校3つの費用と出口を集める",
-            ],
-            "confidence": "high",
-        }
-
-    # ── Generic: feature-driven ───────────────────────────────────────────
-    feats = features or {}
-
-    if feats.get("values_empty") is True:
-        return {
-            "status": "no_recommendation",
-            "reason": "価値観（評価軸）が未確定なため、推奨は恣意的になる。",
-            "missing_info": ["価値の優先順位"],
-            "next_steps": ["価値の優先順位を仮決めする"],
-            "confidence": "high",
-        }
-
-    if feats.get("constraint_conflict") is True:
-        return {
-            "status": "recommended",
-            "recommended_option_id": "opt_1",
-            "reason": (
-                "制約が矛盾している状態では、どの案も破綻しやすい。"
-                "まず制約を再設計してから進めるべき。"
-            ),
-            "counter": "制約の調整ができない場合、目標（期限/投入時間）を下げる必要がある。",
-            "alternatives": [
-                {
-                    "option_id": "opt_2",
-                    "when_to_choose": "期限目標を下げ、週5時間で検証に縮退したい場合",
-                }
-            ],
-            "confidence": "medium",
-        }
-
-    if should_block_recommendation(feats):
-        return {
-            "status": "no_recommendation",
-            "reason": "重要情報の不足が大きく、現時点での推奨は恣意的になる。",
-            "missing_info": ["重要な不明点の解消"],
-            "next_steps": ["unknownsを優先度順に埋める"],
-            "confidence": "high",
-        }
-
-    if has_time_pressure_with_unknowns(feats):
-        return {
-            "status": "recommended",
-            "recommended_option_id": "opt_1",
-            "reason": "期限が近いため、低リスクな案で前進しつつ不明点を並行して潰す。",
-            "counter": "不明点が残るため、見積もりや期待値にズレが出る。",
-            "alternatives": [
-                {
-                    "option_id": "opt_2",
-                    "when_to_choose": "期限を交渉できる、または追加情報を先に取り切れる場合",
-                }
-            ],
-            "confidence": "low",
-        }
-
-    return {
-        "status": "recommended",
-        "recommended_option_id": "opt_1",
-        "reason": "害を抑えつつ前進できるため。",
-        "counter": "遅いと感じる可能性がある。",
-        "alternatives": [{"option_id": "opt_2", "when_to_choose": "不明点が多い場合"}],
-        "confidence": "medium",
-    }
+    recommendation, _ = arbitrate_recommendation(
+        case,
+        short_id=short_id,
+        features=features,
+        options=options,
+    )
+    return recommendation

--- a/src/pocore/orchestrator.py
+++ b/src/pocore/orchestrator.py
@@ -23,6 +23,7 @@ from .engines import (
     uncertainty_v1,
 )
 from .tracer import build_trace
+from .policy_v1 import TIME_PRESSURE_DAYS, UNKNOWN_BLOCK
 from .utils import deterministic_run_id, input_digest, normalize_now
 
 POCORE_VERSION = "0.1.0"
@@ -65,7 +66,7 @@ def run_case(
         case, short_id=short_id, features=features, options=options
     )
     questions = question_v1.generate(case, short_id=short_id, features=features)
-    recommendation = recommendation_v1.recommend(
+    recommendation, arbitration_code = recommendation_v1.arbitrate_recommendation(
         case, short_id=short_id, features=features, options=options
     )
     uncertainty = uncertainty_v1.summarize(case, short_id=short_id, features=features)
@@ -77,6 +78,11 @@ def run_case(
         options_count=len(options),
         questions_count=len(questions),
         features=features,
+        arbitration_code=arbitration_code,
+        policy_snapshot={
+            "UNKNOWN_BLOCK": UNKNOWN_BLOCK,
+            "TIME_PRESSURE_DAYS": TIME_PRESSURE_DAYS,
+        },
     )
 
     return {

--- a/src/pocore/tracer.py
+++ b/src/pocore/tracer.py
@@ -25,6 +25,8 @@ def build_trace(
     options_count: int = 0,
     questions_count: int = 0,
     features: Optional[Dict[str, Any]] = None,
+    arbitration_code: Optional[str] = None,
+    policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a deterministic trace for a pipeline run."""
 
@@ -126,13 +128,21 @@ def build_trace(
         )
         t += 1
 
-    steps.append(
-        {
-            "name": "compose_output",
-            "started_at": add_seconds(created_at, t),
-            "ended_at": add_seconds(created_at, t + 1),
-            "summary": "推奨・反証・代替案を含む出力を組み立てた",
-        }
-    )
+    compose_metrics: Dict[str, Any] = {}
+    if arbitration_code:
+        compose_metrics["arbitration_code"] = arbitration_code
+    if policy_snapshot:
+        compose_metrics["policy_snapshot"] = dict(policy_snapshot)
+
+    compose_step: Dict[str, Any] = {
+        "name": "compose_output",
+        "started_at": add_seconds(created_at, t),
+        "ended_at": add_seconds(created_at, t + 1),
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+    }
+    if compose_metrics:
+        compose_step["metrics"] = compose_metrics
+
+    steps.append(compose_step)
 
     return {"version": "1.0", "steps": steps}

--- a/tests/test_arbitration_trace.py
+++ b/tests/test_arbitration_trace.py
@@ -1,0 +1,53 @@
+from pocore.orchestrator import run_case
+
+
+def _compose_metrics(output: dict) -> dict:
+    compose_step = next(step for step in output["trace"]["steps"] if step["name"] == "compose_output")
+    return compose_step.get("metrics", {})
+
+
+def test_trace_compose_output_includes_arbitration_code_and_policy_snapshot_for_generic_case() -> None:
+    case = {
+        "case_id": "case_custom_arbitration",
+        "title": "arbitration trace check",
+        "dilemma": "test",
+        "values": ["safety"],
+        "unknowns": ["要件未確定", "工数見積もり不足", "依存先SLA不明", "運用体制未定"],
+        "stakeholders": [{"role": "team"}],
+        "deadline": "2026-03-01",
+        "constraints": [],
+    }
+
+    output = run_case(
+        case,
+        now="2026-02-22T00:00:00Z",
+        seed=0,
+        deterministic=True,
+    )
+
+    metrics = _compose_metrics(output)
+    assert metrics["arbitration_code"] == "BLOCK_UNKNOWN"
+    assert metrics["policy_snapshot"] == {
+        "UNKNOWN_BLOCK": 4,
+        "TIME_PRESSURE_DAYS": 7,
+    }
+
+
+def test_trace_compose_output_arbitration_metrics_not_added_to_frozen_case() -> None:
+    case = {
+        "case_id": "case_001",
+        "title": "frozen",
+        "dilemma": "frozen",
+        "values": ["v"],
+        "context": {},
+    }
+
+    output = run_case(
+        case,
+        now="2026-02-22T00:00:00Z",
+        seed=0,
+        deterministic=True,
+    )
+
+    compose_step = next(step for step in output["trace"]["steps"] if step["name"] == "compose_output")
+    assert "metrics" not in compose_step


### PR DESCRIPTION
### Motivation
- Make the recommendation engine's arbitration route observable in the pipeline trace for auditability while preserving determinism and frozen golden contracts.
- Surface the policy constants snapshot used for arbitration so policy diffs can be audited alongside the trace.
- Avoid weakening schemas/tests or changing frozen golden cases (`case_001` / `case_009`).

### Description
- Introduced `arbitrate_recommendation()` in `src/pocore/engines/recommendation_v1.py` that returns a tuple of (recommendation payload, `arbitration_code`) and preserved `recommend()` for backward compatibility.
- Wired the orchestrator to receive `arbitration_code` and pass it plus a small `policy_snapshot` (`UNKNOWN_BLOCK`, `TIME_PRESSURE_DAYS`) into `tracer.build_trace()` in `src/pocore/orchestrator.py`.
- Extended generic trace generation in `src/pocore/tracer.py` so the `compose_output` step includes `metrics` containing `arbitration_code` and `policy_snapshot`; frozen branches for `case_001` and `case_009` remain unchanged.
- Added `tests/test_arbitration_trace.py` to lock expected behavior for a generic case (asserts `BLOCK_UNKNOWN` + policy snapshot) and to assert frozen cases do not gain extra `compose_output.metrics`.
- Added ADR `docs/adr/0009-trace-arbitration-path.md` documenting the decision and determinism constraints.
- Updated non-frozen golden expected outputs to reflect the new generic trace metrics: `scenarios/case_002_expected.json` and `scenarios/case_010_expected.json`.

### Testing
- Ran focused tests including `tests/test_arbitration_trace.py`, `tests/test_recommendation_policy.py`, `tests/test_trace_metrics.py`, and `tests/test_golden_e2e.py`, which passed after updating the affected non-frozen golden files.
- Ran the full test suite with `pytest -q`, resulting in: `3280 passed, 134 skipped` (all active tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5e1234188328a6770a408882820c)