### PR TITLE
Refactor ethics into deterministic ruleset and expose fired rules in trace

### DIFF
--- a/scenarios/case_002_expected.json
+++ b/scenarios/case_002_expected.json
@@ -283,6 +283,10 @@
           "questions_planned": 0,
           "unknowns_count": 3,
           "stakeholders_count": 4,
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
           "days_to_deadline": 16
         }
       },
@@ -302,6 +306,10 @@
         "summary": "推奨・反証・代替案を含む出力を組み立てた",
         "metrics": {
           "arbitration_code": "DEFAULT_RECOMMEND",
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
           "policy_snapshot": {
             "UNKNOWN_BLOCK": 4,
             "TIME_PRESSURE_DAYS": 7

--- a/scenarios/case_010_expected.json
+++ b/scenarios/case_010_expected.json
@@ -350,6 +350,11 @@
           "questions_planned": 3,
           "unknowns_count": 3,
           "stakeholders_count": 3,
+          "rules_fired": [
+            "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
           "days_to_deadline": 190,
           "constraint_conflict": true
         }
@@ -379,6 +384,11 @@
         "summary": "推奨・反証・代替案を含む出力を組み立てた",
         "metrics": {
           "arbitration_code": "CONSTRAINT_CONFLICT",
+          "rules_fired": [
+            "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
           "policy_snapshot": {
             "UNKNOWN_BLOCK": 4,
             "TIME_PRESSURE_DAYS": 7

--- a/src/pocore/orchestrator.py
+++ b/src/pocore/orchestrator.py
@@ -62,6 +62,7 @@ def run_case(
     options, ethics_summary = ethics_v1.apply(
         case, short_id=short_id, features=features, options=options
     )
+    ethics_rules_fired = ethics_v1.rules_fired_for(short_id=short_id, features=features)
     options, responsibility_summary = responsibility_v1.apply(
         case, short_id=short_id, features=features, options=options
     )
@@ -78,6 +79,7 @@ def run_case(
         options_count=len(options),
         questions_count=len(questions),
         features=features,
+        rules_fired=ethics_rules_fired,
         arbitration_code=arbitration_code,
         policy_snapshot={
             "UNKNOWN_BLOCK": UNKNOWN_BLOCK,

--- a/src/pocore/tracer.py
+++ b/src/pocore/tracer.py
@@ -25,6 +25,7 @@ def build_trace(
     options_count: int = 0,
     questions_count: int = 0,
     features: Optional[Dict[str, Any]] = None,
+    rules_fired: Optional[list[str]] = None,
     arbitration_code: Optional[str] = None,
     policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -93,6 +94,8 @@ def build_trace(
         "unknowns_count": int(feats.get("unknowns_count", 0)),
         "stakeholders_count": int(feats.get("stakeholders_count", 0)),
     }
+    if rules_fired:
+        parse_metrics["rules_fired"] = list(rules_fired)
     if feats.get("days_to_deadline") is not None:
         parse_metrics["days_to_deadline"] = int(feats["days_to_deadline"])
     if conflict:
@@ -131,6 +134,8 @@ def build_trace(
     compose_metrics: Dict[str, Any] = {}
     if arbitration_code:
         compose_metrics["arbitration_code"] = arbitration_code
+    if rules_fired:
+        compose_metrics["rules_fired"] = list(rules_fired)
     if policy_snapshot:
         compose_metrics["policy_snapshot"] = dict(policy_snapshot)
 

--- a/tests/test_ethics_ruleset.py
+++ b/tests/test_ethics_ruleset.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pocore.engines import ethics_v1
+
+
+def test_ethics_ruleset_fires_multiple_rules_from_features() -> None:
+    rules = ethics_v1.rules_fired_for(
+        short_id="case_777",
+        features={
+            "constraint_conflict": True,
+            "unknowns_count": 2,
+            "stakeholders_count": 3,
+            "days_to_deadline": 5,
+        },
+    )
+
+    assert rules == [
+        "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+        "ETH_NO_OVERCLAIM_UNKNOWN",
+        "ETH_STAKEHOLDER_CONSENT",
+        "ETH_TIME_PRESSURE_SAFETY",
+    ]
+
+
+def test_ethics_ruleset_fires_only_applicable_rules() -> None:
+    rules = ethics_v1.rules_fired_for(
+        short_id="case_778",
+        features={
+            "constraint_conflict": False,
+            "unknowns_count": 0,
+            "stakeholders_count": 2,
+            "days_to_deadline": None,
+        },
+    )
+
+    assert rules == ["ETH_STAKEHOLDER_CONSENT"]

--- a/tests/test_trace_metrics.py
+++ b/tests/test_trace_metrics.py
@@ -17,6 +17,10 @@ def test_build_trace_generic_parse_input_metrics_include_observability_values():
             "days_to_deadline": 5,
             "constraint_conflict": True,
         },
+        rules_fired=[
+            "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+        ],
     )
 
     metrics = _parse_step(trace)["metrics"]
@@ -24,6 +28,10 @@ def test_build_trace_generic_parse_input_metrics_include_observability_values():
     assert metrics["stakeholders_count"] == 2
     assert metrics["days_to_deadline"] == 5
     assert metrics["constraint_conflict"] is True
+    assert metrics["rules_fired"] == [
+        "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+        "ETH_NO_OVERCLAIM_UNKNOWN",
+    ]
 
 
 def test_build_trace_generic_omits_days_to_deadline_when_unknown():
@@ -39,6 +47,22 @@ def test_build_trace_generic_omits_days_to_deadline_when_unknown():
     assert metrics["unknowns_count"] == 1
     assert metrics["stakeholders_count"] == 0
     assert "days_to_deadline" not in metrics
+
+
+def test_build_trace_generic_compose_output_metrics_include_rules_fired() -> None:
+    trace = build_trace(
+        short_id="case_125",
+        created_at="2026-02-22T00:00:00Z",
+        options_count=2,
+        questions_count=0,
+        features={"unknowns_count": 0, "stakeholders_count": 0},
+        rules_fired=["ETH_STAKEHOLDER_CONSENT"],
+        arbitration_code="REC_A",
+    )
+
+    compose_step = next(step for step in trace["steps"] if step["name"] == "compose_output")
+    assert compose_step["metrics"]["rules_fired"] == ["ETH_STAKEHOLDER_CONSENT"]
+    assert compose_step["metrics"]["arbitration_code"] == "REC_A"
 
 
 def test_build_trace_frozen_case_001_and_009_steps_unchanged():


### PR DESCRIPTION
### Motivation
- Prevent proliferation of case-specific branching by converting M2 ethics logic into a small, deterministic ruleset with stable `rule_id`s and fixed evaluation order.  
- Improve accountability and observability by recording which ethics rules fired so auditors can see why particular guardrails applied.  
- Preserve existing contracts: frozen goldens for `case_001` / `case_009` remain unchanged and `ethics` must not interfere with recommendation arbitration.

### Description
- Introduced deterministic rule IDs and ordered evaluation in `src/pocore/engines/ethics_v1.py` via `rules_fired_for()` and internal `_collect_rules_fired()` and kept the prior special-case behavior for `case_001` / `case_009`.  
- Used the fired-rule set inside the generic `apply()` path (boolean flags derived from the fired rules) so the engine logic is feature-driven rather than case-driven.  
- Plumbed `rules_fired` through `src/pocore/orchestrator.py` into the trace builder and extended `src/pocore/tracer.py` to include `rules_fired` in `parse_input` and `compose_output` `metrics`, while preserving frozen traces for `case_001` and `case_009`.  
- Tests and artifacts: added `tests/test_ethics_ruleset.py`, extended `tests/test_trace_metrics.py`, and regenerated non-frozen goldens `scenarios/case_002_expected.json` and `scenarios/case_010_expected.json` via the deterministic runner to include the new trace metrics.

### Testing
- Ran focused contract/unit tests `pytest -q tests/test_ethics_ruleset.py tests/test_ethics_guardrails.py tests/test_trace_metrics.py tests/test_ethics_non_interference.py` and all these passed.  
- Golden E2E checks flagged two non-frozen expected files (`case_002`, `case_010`) which were intentionally regenerated by running the deterministic `run_case_file()` and then re-tested; the golden E2E subset passed after updating those non-frozen goldens.  
- Full test run (`pytest -q`) shows all functional/contract tests passing except one environment-sensitive benchmark `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` which failed intermittently in this container; functional/behavioral tests and new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c76d5ea508328b9b8fbf5fce1e08e)