### PR TITLE
docs: A〜F完了状態を固定する status/ADR index を追加・README/AGENTS を更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,13 @@ Po_coreは“賢い文章生成”よりも、**決定性（determinism）**・*
 ---
 
 この規約に反する変更は、Po_coreの目的（説明責任と安全な意思決定支援）を破壊する。
+
+---
+
+## 10. 追記事実（E/F反映）
+
+- trace（generic）の `compose_output.metrics` には recommendation の `arbitration_code` が記録される。  
+- ethics は ruleset で運用し、各評価は `rule_id` を持つ。  
+- trace から ethics の `rules_fired`（発火ルール集合）を観測できる。  
+
+※上記は事実追記のみ。既存の凍結契約・禁止事項・責務境界はそのまま有効。

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ pip install po-core-flyingpig
 [Reason-log spec](./04_modules/reason_log) ·
 [Viewer spec](./04_modules/viewer)
 
+## Development Loop (Po_core core)
+
+- `case` を追加/更新したら、まず入力を `features` として観測可能にする。
+- 次に `engines` の rule を更新し、case固有ifではなく feature駆動で振る舞いを拡張する。
+- その結果を golden（期待JSON）へ固定し、CI（`pytest -q`）で契約を検証する。
+- 凍結golden `scenarios/case_001_expected.json` / `scenarios/case_009_expected.json` は変更禁止。
+
 ## Contribution Tracks
 
 ### <a id="ai-track"></a> AI Track

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,17 @@
+# ADR Index
+
+Po_coreで採用済み/提案中のArchitectural Decision Records一覧。
+
+| No. | Title | Status | Key Point |
+|---|---|---|---|
+| 0001 | Output Format Selection (JSON + Markdown) | Accepted | 出力はJSONを契約本体（MUST）、Markdownは人間可読補助（SHOULD）。 |
+| 0002 | Golden Diff Contract | Accepted | canonical JSON完全一致でE2E比較し、golden更新は仕様根拠付きのみ許可。 |
+| 0003 | Trace Contract | Accepted | trace時刻は injected `now` から固定オフセットで生成し、非決定要因を排除。 |
+| 0004 | Input Features Layer | Accepted | case identity分岐を避け、`parse_input` の `features` 正規化でルール分岐する。 |
+| 0005 | Rule Placement Boundaries for unknowns/stakeholders/deadline (v1) | Accepted | 観測（parse_input）と判断（engines）と配線（orchestrator）を厳密分離。 |
+| 0006 | Recommendation Arbitration Policy v1 | Accepted | recommendation裁定閾値を `policy_v1` に集約し、裁定順序を固定。 |
+| 0007 | Trace Metrics Observability for parse_input | Accepted | generic traceに `unknowns/stakeholders/deadline` 観測メトリクスを追加。 |
+| 0008 | Ethics Guardrails v1 (Non-interference) | Accepted | ethicsはガードレール層であり、recommendation裁定を変更しない。 |
+| 0009 | Traceへrecommendation裁定経路を記録する | Accepted | traceの compose_output metrics に `arbitration_code` と policy snapshot を記録。 |
+
+> 現時点で `docs/adr/*.md` に Proposed はなく、すべて Accepted。

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,26 @@
+# Status Snapshot (A〜F)
+
+この文書は、A〜F完了時点の状態を会話コンテキスト非依存で固定するためのスナップショット。
+
+## Completed
+- **A**: 入力正規化として `features` 抽出レイヤを導入し、case固有分岐増殖を抑制した。
+- **B**: recommendation裁定閾値を `policy_v1` に集約し、裁定ロジックを決定論で一元化した。
+- **C**: trace（generic）に `unknowns_count` / `stakeholders_count` / `days_to_deadline` 観測値を追加し、監査性を強化した。
+- **D**: ethics guardrails v1 を拡張しつつ、recommendation裁定への非干渉（非介入）契約を明文化した。
+- **E**: recommendationの裁定経路を `arbitration_code` として保持できるようにし、裁定理由の可観測性を上げた。
+- **F**: ethicsをruleset化し、`rule_id` と `rules_fired` により「どの規則が発火したか」を追跡可能にした。
+
+## Contracts
+- **凍結golden**: `scenarios/case_001_expected.json` / `scenarios/case_009_expected.json` は凍結契約（改変禁止）。
+- **決定性**: 同一入力 + 同一 `seed` + 同一 `now` + 同一バージョンで出力JSON完全一致（wall-clock/乱数禁止）。
+- **golden更新手順**: 仕様根拠（ADR/SRS）を先に固定し、決定論パラメータで生成→保存→`pytest -q` 全通を確認する。
+- **責務境界**:
+  - `features` は観測のみ（判断を入れない）
+  - `engines` はルール判定と生成
+  - `recommendation` は最終裁定の単独責務
+  - `ethics` はガードレール/トレードオフ提示（裁定はしない）
+
+## Next
+- **G（追加golden 2本）**:
+  1. `unknowns × deadline` の組み合わせで、時間圧があるが未知情報が残るケースの裁定境界を固定する。
+  2. stakeholders外部性（利害関係者複数）で、責任/倫理の観測とrule発火を固定する。


### PR DESCRIPTION
### Motivation
- A〜F で決まった設計・契約をリポジトリ内に不変の形で固定し、今後の作業が会話コンテキストに依存しないようにすることを目的としています。 
- 凍結golden の保持・決定性契約・責務境界などの現状事実を明文化して運用上の誤解や逸脱を防ぐ意図があります.

### Description
- `docs/status.md` を新規追加し、A〜F の完了要点（各1行）、主要Contracts（凍結golden／決定性／golden更新手順／責務境界）および Next（G：追加golden 2本）の狙いを固定しました。 
- `docs/adr/index.md` を新規追加して `docs/adr/*.md` を一覧化（番号・タイトル・Status・要点）し、現時点で全件 Accepted であることを明示しました。 
- `README.md` に最小追記で開発ループ（case → feature → rule → golden → CI）を3〜6行で追加し、凍結golden（`scenarios/case_001_expected.json` / `scenarios/case_009_expected.json`）の禁止を明記しました。 
- `AGENTS.md` に E/F で増えた事実のみ短く追記し、`trace.compose_output.metrics` に `arbitration_code` を記録すること、ethics が `rule_id` を持つ ruleset で動作し `rules_fired` を観測できることを追加しました（既存の禁止事項・契約は不変）。 
- 変更ファイル一覧: `docs/status.md` (new), `docs/adr/index.md` (new), `README.md` (modified), `AGENTS.md` (modified).

### Testing
- 自動テストとして `pytest -q` を実行し、全体で `3283 passed, 134 skipped` を確認して成功しました. 
- 既存の凍結golden（`scenarios/case_001_expected.json`, `scenarios/case_009_expected.json`）は一切変更しておらず、テストの弱体化やスキーマ緩和も行っていません. 
- 変更はドキュメントのみのため実装用ユニットを追加しておらず、既存のテスト群が問題ないことを以て検証としています.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8183d8a4832889a7e8589e802f36)