### PR TITLE
Add golden outputs for case_003 and case_006 (deadline/unknowns & stakeholders)

### DIFF
--- a/scenarios/case_003_expected.json
+++ b/scenarios/case_003_expected.json
@@ -1,0 +1,321 @@
+{
+  "meta": {
+    "schema_version": "1.0",
+    "pocore_version": "0.1.0",
+    "run_id": "case_003_expected_stub_compact_v1",
+    "created_at": "2026-02-22T00:40:00Z",
+    "seed": 0,
+    "deterministic": true,
+    "generator": {
+      "name": "generator_stub",
+      "version": "0.1.0",
+      "mode": "stub"
+    }
+  },
+  "case_ref": {
+    "case_id": "case_003_caregiving",
+    "title": "家族介護：親のケアをどう設計するか",
+    "input_digest": "f0a73b45edb392745beec2b33fa0b0d71306e38c0e11b8763e8d6a9d76ca7dcc"
+  },
+  "options": [
+    {
+      "option_id": "opt_1",
+      "title": "案A：段階的に進める",
+      "description": "最小コストで試し、学びながら前進する。",
+      "action_plan": [
+        {
+          "step": "最小実験を設計して実施する"
+        }
+      ],
+      "pros": [
+        "失敗コストを抑えられる"
+      ],
+      "cons": [
+        "進行が遅く感じる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "検証不足",
+          "severity": "medium",
+          "mitigation": "検証項目を明文化する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "1-2 weeks",
+        "confidence": "medium"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "justice"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "親",
+            "role": "当事者",
+            "impact": "生活の質・安全・尊厳に直結"
+          },
+          {
+            "name": "自分",
+            "role": "意思決定主体（支援者）",
+            "impact": "時間・お金・精神負荷に影響"
+          },
+          {
+            "name": "兄弟姉妹（いる場合）",
+            "role": "協力者候補",
+            "impact": "負担分担・合意形成に影響"
+          },
+          {
+            "name": "ケアマネ/介護事業者",
+            "role": "実行者",
+            "impact": "プランの品質に影響"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    },
+    {
+      "option_id": "opt_2",
+      "title": "案B：情報収集してから決める",
+      "description": "重要な不明点を埋めてから判断する。",
+      "action_plan": [
+        {
+          "step": "不足情報を3〜5項目に絞って集める"
+        }
+      ],
+      "pros": [
+        "判断精度が上がる"
+      ],
+      "cons": [
+        "機会損失が起きる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "先延ばし",
+          "severity": "low",
+          "mitigation": "期限と判断条件を設定する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "3-5 days",
+        "confidence": "high"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "justice"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "親",
+            "role": "当事者",
+            "impact": "生活の質・安全・尊厳に直結"
+          },
+          {
+            "name": "自分",
+            "role": "意思決定主体（支援者）",
+            "impact": "時間・お金・精神負荷に影響"
+          },
+          {
+            "name": "兄弟姉妹（いる場合）",
+            "role": "協力者候補",
+            "impact": "負担分担・合意形成に影響"
+          },
+          {
+            "name": "ケアマネ/介護事業者",
+            "role": "実行者",
+            "impact": "プランの品質に影響"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    }
+  ],
+  "recommendation": {
+    "status": "recommended",
+    "recommended_option_id": "opt_1",
+    "reason": "害を抑えつつ前進できるため。",
+    "counter": "遅いと感じる可能性がある。",
+    "alternatives": [
+      {
+        "option_id": "opt_2",
+        "when_to_choose": "不明点が多い場合"
+      }
+    ],
+    "confidence": "medium"
+  },
+  "ethics": {
+    "principles_used": [
+      "integrity",
+      "autonomy",
+      "nonmaleficence",
+      "justice",
+      "accountability"
+    ],
+    "tradeoffs": [
+      {
+        "tension": "自己決定と外部性/公正の緊張",
+        "between": [
+          "autonomy",
+          "justice"
+        ],
+        "mitigation": "関係者への影響を可視化し、同意可能な進め方を選ぶ",
+        "severity": "medium"
+      }
+    ],
+    "guardrails": [
+      "不確実な事実を断言しない",
+      "意思決定主体をユーザーから奪わない",
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "関係者への影響と同意を考慮する"
+    ],
+    "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。"
+  },
+  "responsibility": {
+    "decision_owner": "user",
+    "stakeholders": [
+      {
+        "name": "親",
+        "role": "当事者",
+        "impact": "生活の質・安全・尊厳に直結"
+      },
+      {
+        "name": "自分",
+        "role": "意思決定主体（支援者）",
+        "impact": "時間・お金・精神負荷に影響"
+      },
+      {
+        "name": "兄弟姉妹（いる場合）",
+        "role": "協力者候補",
+        "impact": "負担分担・合意形成に影響"
+      },
+      {
+        "name": "ケアマネ/介護事業者",
+        "role": "実行者",
+        "impact": "プランの品質に影響"
+      }
+    ],
+    "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは説明可能な判断材料を整理する。",
+    "consent_considerations": []
+  },
+  "questions": [],
+  "uncertainty": {
+    "overall_level": "medium",
+    "reasons": [
+      "重要情報が未確定"
+    ],
+    "assumptions": [
+      "提示された制約が正しい"
+    ],
+    "known_unknowns": [
+      "医師の見立て（進行予測、必要ケアレベル）",
+      "利用可能なサービス枠・施設の空き",
+      "兄弟姉妹の協力度合い"
+    ]
+  },
+  "trace": {
+    "version": "1.0",
+    "steps": [
+      {
+        "name": "parse_input",
+        "started_at": "2026-02-22T00:40:00Z",
+        "ended_at": "2026-02-22T00:40:01Z",
+        "summary": "入力を正規化し、特徴量（features）を抽出した",
+        "metrics": {
+          "options_planned": 2,
+          "questions_planned": 0,
+          "unknowns_count": 3,
+          "stakeholders_count": 4,
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
+          "days_to_deadline": 38
+        }
+      },
+      {
+        "name": "generate_options",
+        "started_at": "2026-02-22T00:40:01Z",
+        "ended_at": "2026-02-22T00:40:02Z",
+        "summary": "特徴量に基づいて選択肢を生成した",
+        "metrics": {
+          "options": 2
+        }
+      },
+      {
+        "name": "compose_output",
+        "started_at": "2026-02-22T00:40:02Z",
+        "ended_at": "2026-02-22T00:40:03Z",
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        "metrics": {
+          "arbitration_code": "DEFAULT_RECOMMEND",
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
+          "policy_snapshot": {
+            "UNKNOWN_BLOCK": 4,
+            "TIME_PRESSURE_DAYS": 7
+          }
+        }
+      }
+    ]
+  }
+}

--- a/scenarios/case_006_expected.json
+++ b/scenarios/case_006_expected.json
@@ -1,0 +1,338 @@
+{
+  "meta": {
+    "schema_version": "1.0",
+    "pocore_version": "0.1.0",
+    "run_id": "case_006_expected_stub_compact_v1",
+    "created_at": "2026-02-22T00:40:00Z",
+    "seed": 0,
+    "deterministic": true,
+    "generator": {
+      "name": "generator_stub",
+      "version": "0.1.0",
+      "mode": "stub"
+    }
+  },
+  "case_ref": {
+    "case_id": "case_006_data_leak_response",
+    "title": "インシデント対応：データ漏えい疑いの初動",
+    "input_digest": "44ad5d25d91f5c912500d72d69f0a7cb66b99b52dc4b981e25dd0f8ed8d97a6f"
+  },
+  "options": [
+    {
+      "option_id": "opt_1",
+      "title": "案A：段階的に進める",
+      "description": "最小コストで試し、学びながら前進する。",
+      "action_plan": [
+        {
+          "step": "最小実験を設計して実施する"
+        }
+      ],
+      "pros": [
+        "失敗コストを抑えられる"
+      ],
+      "cons": [
+        "進行が遅く感じる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "検証不足",
+          "severity": "medium",
+          "mitigation": "検証項目を明文化する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "1-2 weeks",
+        "confidence": "medium"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "justice",
+          "nonmaleficence"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          },
+          {
+            "tension": "速度と安全の緊張",
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "時間圧力下でも最小限の検証を維持する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "ユーザー",
+            "role": "被害者候補",
+            "impact": "プライバシー・金銭被害リスク"
+          },
+          {
+            "name": "自社（経営・法務・広報・開発）",
+            "role": "対応主体",
+            "impact": "信用・法的リスク・運用負荷"
+          },
+          {
+            "name": "規制当局/監督機関",
+            "role": "通知先",
+            "impact": "手続き不備で制裁の可能性"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    },
+    {
+      "option_id": "opt_2",
+      "title": "案B：情報収集してから決める",
+      "description": "重要な不明点を埋めてから判断する。",
+      "action_plan": [
+        {
+          "step": "不足情報を3〜5項目に絞って集める"
+        }
+      ],
+      "pros": [
+        "判断精度が上がる"
+      ],
+      "cons": [
+        "機会損失が起きる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "先延ばし",
+          "severity": "low",
+          "mitigation": "期限と判断条件を設定する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "3-5 days",
+        "confidence": "high"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "justice",
+          "nonmaleficence"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "自己決定と外部性/公正の緊張",
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium"
+          },
+          {
+            "tension": "速度と安全の緊張",
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "時間圧力下でも最小限の検証を維持する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "ユーザー",
+            "role": "被害者候補",
+            "impact": "プライバシー・金銭被害リスク"
+          },
+          {
+            "name": "自社（経営・法務・広報・開発）",
+            "role": "対応主体",
+            "impact": "信用・法的リスク・運用負荷"
+          },
+          {
+            "name": "規制当局/監督機関",
+            "role": "通知先",
+            "impact": "手続き不備で制裁の可能性"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    }
+  ],
+  "recommendation": {
+    "status": "recommended",
+    "recommended_option_id": "opt_1",
+    "reason": "期限が近いため、低リスクな案で前進しつつ不明点を並行して潰す。",
+    "counter": "不明点が残るため、見積もりや期待値にズレが出る。",
+    "alternatives": [
+      {
+        "option_id": "opt_2",
+        "when_to_choose": "期限を交渉できる、または追加情報を先に取り切れる場合"
+      }
+    ],
+    "confidence": "low"
+  },
+  "ethics": {
+    "principles_used": [
+      "integrity",
+      "autonomy",
+      "nonmaleficence",
+      "justice",
+      "accountability"
+    ],
+    "tradeoffs": [
+      {
+        "tension": "自己決定と外部性/公正の緊張",
+        "between": [
+          "autonomy",
+          "justice"
+        ],
+        "mitigation": "関係者への影響を可視化し、同意可能な進め方を選ぶ",
+        "severity": "medium"
+      },
+      {
+        "tension": "速度と安全（nonmaleficence）の緊張",
+        "between": [
+          "autonomy",
+          "nonmaleficence"
+        ],
+        "mitigation": "時間制約下でも検証を省略しない",
+        "severity": "medium"
+      }
+    ],
+    "guardrails": [
+      "不確実な事実を断言しない",
+      "意思決定主体をユーザーから奪わない",
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "関係者への影響と同意を考慮する",
+      "時間圧力下でも検証を省略しない"
+    ],
+    "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。"
+  },
+  "responsibility": {
+    "decision_owner": "user",
+    "stakeholders": [
+      {
+        "name": "ユーザー",
+        "role": "被害者候補",
+        "impact": "プライバシー・金銭被害リスク"
+      },
+      {
+        "name": "自社（経営・法務・広報・開発）",
+        "role": "対応主体",
+        "impact": "信用・法的リスク・運用負荷"
+      },
+      {
+        "name": "規制当局/監督機関",
+        "role": "通知先",
+        "impact": "手続き不備で制裁の可能性"
+      }
+    ],
+    "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは説明可能な判断材料を整理する。",
+    "consent_considerations": []
+  },
+  "questions": [],
+  "uncertainty": {
+    "overall_level": "medium",
+    "reasons": [
+      "重要情報が未確定"
+    ],
+    "assumptions": [
+      "提示された制約が正しい"
+    ],
+    "known_unknowns": [
+      "実際に外部閲覧があったか（ログ分析）",
+      "漏えい範囲（対象ユーザー数、項目）",
+      "再発防止に必要な改修範囲"
+    ]
+  },
+  "trace": {
+    "version": "1.0",
+    "steps": [
+      {
+        "name": "parse_input",
+        "started_at": "2026-02-22T00:40:00Z",
+        "ended_at": "2026-02-22T00:40:01Z",
+        "summary": "入力を正規化し、特徴量（features）を抽出した",
+        "metrics": {
+          "options_planned": 2,
+          "questions_planned": 0,
+          "unknowns_count": 3,
+          "stakeholders_count": 3,
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT",
+            "ETH_TIME_PRESSURE_SAFETY"
+          ],
+          "days_to_deadline": 2
+        }
+      },
+      {
+        "name": "generate_options",
+        "started_at": "2026-02-22T00:40:01Z",
+        "ended_at": "2026-02-22T00:40:02Z",
+        "summary": "特徴量に基づいて選択肢を生成した",
+        "metrics": {
+          "options": 2
+        }
+      },
+      {
+        "name": "compose_output",
+        "started_at": "2026-02-22T00:40:02Z",
+        "ended_at": "2026-02-22T00:40:03Z",
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        "metrics": {
+          "arbitration_code": "TIME_PRESSURE_LOW_CONF",
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT",
+            "ETH_TIME_PRESSURE_SAFETY"
+          ],
+          "policy_snapshot": {
+            "UNKNOWN_BLOCK": 4,
+            "TIME_PRESSURE_DAYS": 7
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Add two new executable golden scenarios to cover a short-deadline + high-unknowns boundary and a high-stakeholder externality boundary for E2E regression testing. 
- Ensure new cases are produced deterministically from the runner so new goldens remain executable specifications and do not weaken tests or schemas.

### Description
- Enumerated missing `*_expected.json` for `case_002`..`case_010` and selected `case_006` (deadline pressure + unknowns) and `case_003` (highest stakeholders count) per the priority rules. 
- Generated outputs via `run_case_file(..., seed=0, deterministic=True, now="2026-02-22T00:40:00Z")` and saved the runner output as golden files without hand-editing. 
- Added `scenarios/case_003_expected.json` and `scenarios/case_006_expected.json` and did not modify frozen goldens `scenarios/case_001_expected.json` or `scenarios/case_009_expected.json`.

### Testing
- Ran the deterministic generation that produced the two expected files using the public runner `run_case_file` with fixed `seed` and `now`. 
- Ran the full test suite with `pytest -q`, which completed successfully with `3291 passed, 134 skipped`.
- Verified the new expected files are present as `scenarios/case_003_expected.json` and `scenarios/case_006_expected.json` and do not weaken any schema or tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c819647748328b4db9a8c8325d857)