### PR TITLE
Add principles/requirements traceability SoT and CI verification

### DIFF
--- a/docs/spec/principles_v1.md
+++ b/docs/spec/principles_v1.md
@@ -1,0 +1,21 @@
+# Principles v1
+
+Po_core の意思決定支援における思想レイヤーを、機械可読なIDで固定する。
+
+## Principle Catalog
+
+- **P-ACC-001: 説明責任（accountability）**
+  - 判断過程・根拠・不確実性を trace と構造化出力で監査可能にする。
+- **P-INT-001: 誠実性（integrity）**
+  - 不確実な事実を断言せず、限界と反証可能性を明示する。
+- **P-AUT-001: 自律（autonomy）**
+  - 最終決定主体をユーザーに残し、推奨は補助として提示する。
+- **P-NMH-001: 無危害（nonmaleficence）**
+  - 時間圧力や情報不足下でも被害最小化を優先する。
+- **P-JUS-001: 公正/外部性（justice）**
+  - ステークホルダー影響と同意可能性を検討し、外部不利益を抑える。
+
+## Design Intent
+
+- 原則は実装の直接条件分岐ではなく、要件（REQ）とADRを介してコード・テストに反映する。
+- traceability_v1.yaml を SoT とし、Principles → Requirements → ADR/Test/Code の往復参照を維持する。

--- a/docs/spec/requirements_v1.md
+++ b/docs/spec/requirements_v1.md
@@ -1,0 +1,45 @@
+# Requirements v1
+
+思想（Principles）を実装・検証可能な要件IDに落とし込む。
+
+## Requirement Catalog
+
+- **REQ-DET-001: 決定性（determinism）**
+  - 同一 input + seed + now で出力JSONが完全一致すること。
+  - Principles: P-ACC-001, P-INT-001
+
+- **REQ-SCH-001: スキーマ適合（input/output）**
+  - runner は入力・出力を schema v1 で検証すること。
+  - Principles: P-ACC-001, P-INT-001
+
+- **REQ-E2E-001: golden diff E2E 契約**
+  - scenarios の expected JSON との差分で回帰を検知すること。
+  - Principles: P-ACC-001, P-INT-001
+
+- **REQ-FEA-001: feature抽出（unknowns/stakeholders/deadline）**
+  - parse_input は unknowns/stakeholders/deadline を正規化特徴として抽出すること。
+  - Principles: P-ACC-001, P-JUS-001
+
+- **REQ-ARB-001: recommendation裁定（policy_v1）**
+  - recommendation は policy_v1 の裁定ルールで arbitration_code を返すこと。
+  - Principles: P-INT-001, P-AUT-001, P-NMH-001
+
+- **REQ-TRC-001: arbitration_code の trace記録**
+  - compose_output.metrics に arbitration_code を格納すること。
+  - Principles: P-ACC-001
+
+- **REQ-ETH-001: ethics非介入（non-interference）**
+  - ethics は意思決定主体を奪わず、推奨の断言を抑制するガードレールを維持すること。
+  - Principles: P-AUT-001, P-INT-001
+
+- **REQ-ETH-002: ethics ruleset（rule_id + rules_fired）**
+  - ethics ruleset は rule_id で定義され、trace から rules_fired を観測できること。
+  - Principles: P-ACC-001, P-JUS-001, P-NMH-001
+
+- **REQ-TRC-002: trace契約（Trace Contract）**
+  - trace は決定論かつ契約済みフィールド（steps/metrics）を保つこと。
+  - Principles: P-ACC-001
+
+- **REQ-GCV-001: golden coverage（境界条件カバレッジ）**
+  - golden set は主要境界条件（feature/rule/arbitration path）を継続的にカバーすること。
+  - Principles: P-ACC-001, P-JUS-001

--- a/docs/traceability/traceability_v1.yaml
+++ b/docs/traceability/traceability_v1.yaml
@@ -1,0 +1,162 @@
+version: 1
+principles:
+  - id: P-ACC-001
+    mapped_requirements:
+      - REQ-DET-001
+      - REQ-SCH-001
+      - REQ-E2E-001
+      - REQ-FEA-001
+      - REQ-TRC-001
+      - REQ-ETH-002
+      - REQ-TRC-002
+      - REQ-GCV-001
+  - id: P-INT-001
+    mapped_requirements:
+      - REQ-DET-001
+      - REQ-SCH-001
+      - REQ-E2E-001
+      - REQ-ARB-001
+      - REQ-ETH-001
+  - id: P-AUT-001
+    mapped_requirements:
+      - REQ-ARB-001
+      - REQ-ETH-001
+  - id: P-NMH-001
+    mapped_requirements:
+      - REQ-ARB-001
+      - REQ-ETH-002
+  - id: P-JUS-001
+    mapped_requirements:
+      - REQ-FEA-001
+      - REQ-ETH-002
+      - REQ-GCV-001
+
+requirements:
+  - id: REQ-DET-001
+    principles: [P-ACC-001, P-INT-001]
+    adrs:
+      - docs/adr/0003-trace-contract.md
+      - docs/adr/0007-trace-metrics-observability.md
+    tests:
+      - tests/test_golden_regression.py::test_run_case_is_deterministic
+      - tests/test_trace_schema_contract.py::test_trace_steps_are_chronological
+    code_refs:
+      - kind: module
+        value: src/pocore/orchestrator.py
+      - kind: module
+        value: src/pocore/tracer.py
+
+  - id: REQ-SCH-001
+    principles: [P-ACC-001, P-INT-001]
+    adrs: [docs/adr/0001-output-format.md]
+    tests:
+      - tests/test_input_schema.py::test_each_scenario_matches_input_schema
+      - tests/test_output_schema.py::test_output_schema_validation_for_all_scenarios
+    code_refs:
+      - kind: module
+        value: src/pocore/runner.py
+
+  - id: REQ-E2E-001
+    principles: [P-ACC-001, P-INT-001]
+    adrs: [docs/adr/0002-golden-diff-contract.md]
+    tests:
+      - tests/test_golden_e2e.py::test_scenarios_match_expected_json
+    code_refs:
+      - kind: module
+        value: tests/test_golden_e2e.py
+
+  - id: REQ-FEA-001
+    principles: [P-ACC-001, P-JUS-001]
+    adrs: [docs/adr/0004-input-features.md]
+    tests:
+      - tests/test_features.py::test_extract_features_counts_and_empty_values
+      - tests/test_features.py::test_days_to_deadline_with_date_string
+    code_refs:
+      - kind: module
+        value: src/pocore/parse_input.py
+
+  - id: REQ-ARB-001
+    principles: [P-INT-001, P-AUT-001, P-NMH-001]
+    adrs: [docs/adr/0006-recommendation-arbitration-policy-v1.md]
+    tests:
+      - tests/test_recommendation_policy.py::test_unknowns_at_or_above_unknown_block_returns_no_recommendation
+      - tests/test_arbitration_trace.py::test_trace_compose_output_contains_arbitration_code_for_generic_case
+    code_refs:
+      - kind: module
+        value: src/pocore/policy_v1.py
+      - kind: module
+        value: src/pocore/engines/recommendation_v1.py
+      - kind: arbitration_code
+        value: DEFAULT_RECOMMEND
+      - kind: arbitration_code
+        value: NO_VALUES
+      - kind: arbitration_code
+        value: CONSTRAINT_CONFLICT
+      - kind: arbitration_code
+        value: BLOCK_UNKNOWN
+      - kind: arbitration_code
+        value: TIME_PRESSURE_LOW_CONF
+
+  - id: REQ-TRC-001
+    principles: [P-ACC-001]
+    adrs: [docs/adr/0009-trace-arbitration-path.md]
+    tests:
+      - tests/test_arbitration_trace.py::test_trace_compose_output_contains_arbitration_code_for_generic_case
+    code_refs:
+      - kind: module
+        value: src/pocore/tracer.py
+      - kind: module
+        value: src/pocore/orchestrator.py
+
+  - id: REQ-ETH-001
+    principles: [P-AUT-001, P-INT-001]
+    adrs: [docs/adr/0008-ethics-guardrails-v1-non-interference.md]
+    tests:
+      - tests/test_ethics_non_interference.py::test_ethics_guardrail_does_not_force_recommendation_change
+    code_refs:
+      - kind: module
+        value: src/pocore/engines/ethics_v1.py
+
+  - id: REQ-ETH-002
+    principles: [P-ACC-001, P-JUS-001, P-NMH-001]
+    adrs:
+      - docs/adr/0008-ethics-guardrails-v1-non-interference.md
+      - docs/adr/0007-trace-metrics-observability.md
+    tests:
+      - tests/test_ethics_ruleset.py::test_ethics_ruleset_fires_multiple_rules_from_features
+      - tests/test_trace_metrics.py::test_trace_metrics_include_rules_fired_for_generic_case
+    code_refs:
+      - kind: module
+        value: src/pocore/engines/ethics_v1.py
+      - kind: module
+        value: src/pocore/tracer.py
+      - kind: rule_id
+        value: ETH_CONSTRAINT_CONFLICT_DISCLOSURE
+      - kind: rule_id
+        value: ETH_NO_OVERCLAIM_UNKNOWN
+      - kind: rule_id
+        value: ETH_STAKEHOLDER_CONSENT
+      - kind: rule_id
+        value: ETH_TIME_PRESSURE_SAFETY
+
+  - id: REQ-TRC-002
+    principles: [P-ACC-001]
+    adrs:
+      - docs/adr/0003-trace-contract.md
+      - docs/adr/0007-trace-metrics-observability.md
+    tests:
+      - tests/test_trace_schema_contract.py::test_trace_steps_structure_for_all_scenarios
+      - tests/test_trace_metrics.py::test_trace_metrics_include_counts_for_generic_case
+    code_refs:
+      - kind: module
+        value: src/pocore/tracer.py
+
+  - id: REQ-GCV-001
+    principles: [P-ACC-001, P-JUS-001]
+    adrs: [docs/adr/0002-golden-diff-contract.md]
+    tests:
+      - tests/test_golden_coverage.py::test_golden_cases_cover_recommendation_paths
+      - tests/test_golden_coverage.py::test_golden_cases_cover_rule_firing_patterns
+    code_refs:
+      - kind: module
+        value: tests/test_golden_coverage.py

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACEABILITY_PATH = ROOT / "docs/traceability/traceability_v1.yaml"
+REQUIREMENTS_PATH = ROOT / "docs/spec/requirements_v1.md"
+
+
+def _load_traceability() -> dict[str, Any]:
+    with TRACEABILITY_PATH.open("r", encoding="utf-8") as f:
+        payload = yaml.safe_load(f)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _extract_rule_ids_from_repo() -> set[str]:
+    pattern = re.compile(r'"(ETH_[A-Z0-9_]+)"')
+    rule_ids: set[str] = set()
+    for py_file in (ROOT / "src/pocore").rglob("*.py"):
+        text = py_file.read_text(encoding="utf-8")
+        rule_ids.update(pattern.findall(text))
+    return rule_ids
+
+
+def _extract_arbitration_codes_from_repo() -> set[str]:
+    target = ROOT / "src/pocore/engines/recommendation_v1.py"
+    module = ast.parse(target.read_text(encoding="utf-8"), filename=str(target))
+
+    codes: set[str] = set()
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Tuple):
+            continue
+        if len(node.value.elts) != 2:
+            continue
+        code_node = node.value.elts[1]
+        if isinstance(code_node, ast.Constant) and isinstance(code_node.value, str):
+            if re.fullmatch(r"[A-Z][A-Z0-9_]+", code_node.value):
+                codes.add(code_node.value)
+    return codes
+
+
+def _traceability_code_refs(payload: dict[str, Any], kind: str) -> set[str]:
+    values: set[str] = set()
+    for req in payload.get("requirements", []):
+        for ref in req.get("code_refs", []):
+            if ref.get("kind") == kind:
+                values.add(ref.get("value"))
+    return values
+
+
+def test_traceability_covers_all_rule_ids() -> None:
+    payload = _load_traceability()
+    repo_rule_ids = _extract_rule_ids_from_repo()
+    mapped_rule_ids = _traceability_code_refs(payload, "rule_id")
+    assert repo_rule_ids <= mapped_rule_ids
+
+
+def test_traceability_covers_all_arbitration_codes() -> None:
+    payload = _load_traceability()
+    repo_codes = _extract_arbitration_codes_from_repo()
+    mapped_codes = _traceability_code_refs(payload, "arbitration_code")
+    assert repo_codes <= mapped_codes
+
+
+def test_traceability_adr_refs_exist() -> None:
+    payload = _load_traceability()
+    for req in payload.get("requirements", []):
+        for adr_path in req.get("adrs", []):
+            assert (ROOT / adr_path).is_file(), f"Missing ADR: {adr_path}"
+
+
+def test_traceability_test_file_refs_exist() -> None:
+    payload = _load_traceability()
+    for req in payload.get("requirements", []):
+        for test_ref in req.get("tests", []):
+            rel_path = test_ref.split("::", 1)[0]
+            assert (ROOT / rel_path).is_file(), f"Missing test file: {rel_path}"
+
+
+def test_traceability_includes_all_requirements_ids_from_requirements_doc() -> None:
+    payload = _load_traceability()
+    md_text = REQUIREMENTS_PATH.read_text(encoding="utf-8")
+
+    req_ids_in_doc = set(re.findall(r"\bREQ-[A-Z]+-\d{3}\b", md_text))
+    req_ids_in_yaml = {req["id"] for req in payload.get("requirements", [])}
+
+    assert req_ids_in_doc <= req_ids_in_yaml


### PR DESCRIPTION
### Motivation

- 固有の思想（Principles）→要件（REQ）→ADR/テスト/コード参照のトレーサビリティを単一の SoT (traceability_v1.yaml) で固定して CI で保証するため。 
- ethics の `rule_id` や recommendation の `arbitration_code` の追加漏れや ADR/test の参照破綻を自動検出することで説明責任（accountability）と安全性を担保するため。

### Description

- 追加: `docs/spec/principles_v1.md` に原則 ID（P-ACC-001 / P-INT-001 / P-AUT-001 / P-NMH-001 / P-JUS-001）を定義。 
- 追加: `docs/spec/requirements_v1.md` に要件 ID（REQ-DET-001 等）を定義し Principles に紐付け。 
- 追加: `docs/traceability/traceability_v1.yaml` を SoT として作成し、Principles→Requirements→ADR/tests/code_refs（`rule_id` / `arbitration_code` / module 等）を明示。 
- 追加: `tests/test_traceability.py` を実装し、リポジトリ内の `ETH_*` ルール、`recommendation_v1.py` の arbitration codes、YAML 内 ADR/test ファイル参照、および `requirements_v1.md` の REQ IDs が `traceability_v1.yaml` に含まれることを CI で検証するロジックを追加（AST と正規表現を利用）。 この変更は凍結golden（`case_001_expected.json`, `case_009_expected.json`）を触っていません。

### Testing

- 実行: `pytest -q tests/test_traceability.py` — 結果: `5 passed`（全て成功）。
- 実行: `pytest -q` — 結果: `3298 passed, 134 skipped`（全通相当、スキップは既存のlegacy/移行範囲に起因）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce14ad0f88328aaadc4e221ce6d57)