### PR TITLE
Remove case_001/009 short_id special-casing; add scenario_profile feature and regenerate goldens

### DIFF
--- a/docs/adr/0010-scenario-profile-for-former-frozen-cases.md
+++ b/docs/adr/0010-scenario-profile-for-former-frozen-cases.md
@@ -1,0 +1,26 @@
+# ADR-0010: case_001/case_009 の short_id 特例を scenario_profile feature へ移管
+
+- Status: Accepted
+- Date: 2026-02-23
+- Supersedes: ADR-0004/0006/0007/0008/0009 における「case_001/case_009 は short_id 分岐で固定」記述
+
+## Context
+
+従来は `case_001` / `case_009` を `short_id` で直接分岐し、出力を固定していた。
+この方式は「ファイル名/ID依存の永久特例」であり、features→rules の設計原則に反する。
+
+## Decision
+
+- 入力 `extensions.scenario_profile` を仕様上の明示シグナルとして利用する。
+- `parse_input.extract_features()` で `features.scenario_profile` を抽出する。
+- 各 engine / tracer の特例は `short_id` ではなく `features.scenario_profile` で分岐する。
+  - `job_change_transition_v1`（旧 case_001 特例相当）
+  - `values_clarification_v1`（旧 case_009 特例相当）
+- `case_001.yaml` / `case_009.yaml` は上記 profile を明示する。
+
+## Consequences
+
+- 「ファイル名依存」から「入力仕様として明示」へ移行できる。
+- 同じ profile を持つ新規ケースでも同ルールを再利用可能になる。
+- `case_001` / `case_009` の出力は regenerate により再固定し、golden diff で監視する。
+- CI では `case_001/009` 向け `short_id` 直分岐の再導入を禁止するテストを追加する。

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -13,5 +13,6 @@ Po_coreで採用済み/提案中のArchitectural Decision Records一覧。
 | 0007 | Trace Metrics Observability for parse_input | Accepted | generic traceに `unknowns/stakeholders/deadline` 観測メトリクスを追加。 |
 | 0008 | Ethics Guardrails v1 (Non-interference) | Accepted | ethicsはガードレール層であり、recommendation裁定を変更しない。 |
 | 0009 | Traceへrecommendation裁定経路を記録する | Accepted | traceの compose_output metrics に `arbitration_code` と policy snapshot を記録。 |
+| 0010 | case_001/case_009 short_id特例の撤去とscenario_profile移行 | Accepted | 永久特例を `extensions.scenario_profile`→`features` に移し、rulesで吸収する。 |
 
 > 現時点で `docs/adr/*.md` に Proposed はなく、すべて Accepted。

--- a/regenerate_golden.py
+++ b/regenerate_golden.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Regenerate golden expected JSON files from scenario YAML deterministically."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pocore.runner import run_case_file
+
+
+def regenerate(yaml_path: Path, *, seed: int, now: str, deterministic: bool) -> Path:
+    output = run_case_file(yaml_path, seed=seed, now=now, deterministic=deterministic)
+    expected_path = yaml_path.with_name(f"{yaml_path.stem}_expected.json")
+    expected_path.write_text(
+        json.dumps(output, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return expected_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cases", nargs="+", type=Path, help="Path(s) to scenario yaml files")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--now", default="2026-02-22T00:00:00Z")
+    parser.add_argument("--deterministic", action="store_true", default=True)
+    args = parser.parse_args()
+
+    for case_path in args.cases:
+        regenerated = regenerate(
+            case_path,
+            seed=args.seed,
+            now=args.now,
+            deterministic=args.deterministic,
+        )
+        print(f"regenerated: {regenerated}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/case_001.yaml
+++ b/scenarios/case_001.yaml
@@ -39,3 +39,5 @@ unknowns:
   - "スタートアップの資金繰り（ランウェイ）"
   - "評価制度と成果期待（具体KPI）"
   - "現職の異動・職務変更で成長機会が得られる可能性"
+extensions:
+  scenario_profile: "job_change_transition_v1"

--- a/scenarios/case_001_expected.json
+++ b/scenarios/case_001_expected.json
@@ -15,7 +15,7 @@
   "case_ref": {
     "case_id": "case_001_job_change",
     "title": "転職：安定企業→スタートアップに行くべきか",
-    "input_digest": "661451d09fcaf3debbd8dd3ea015184b77278d14cffa2ad0351e601ec569d2ce"
+    "input_digest": "cd0544892cd255b2f977362b25768e288e88cae5bf82a022f3752caa8754be99"
   },
   "options": [
     {

--- a/scenarios/case_009.yaml
+++ b/scenarios/case_009.yaml
@@ -19,3 +19,5 @@ unknowns:
   - "学び直しの目的（何を得たいのか）"
   - "許容できるリスク量"
   - "支援の有無（家族・貯金・奨学金）"
+extensions:
+  scenario_profile: "values_clarification_v1"

--- a/scenarios/case_009_expected.json
+++ b/scenarios/case_009_expected.json
@@ -15,7 +15,7 @@
   "case_ref": {
     "case_id": "case_009_unclear_values",
     "title": "価値観が不明：進路選択の前に問いを立てる",
-    "input_digest": "8328fb154a4c7565d0095c45061b8aca302222f47e49c2624943e88e1fe1941f"
+    "input_digest": "37bef0b6bd8327e2ec92dab6ab4e22618f183da5aded9dca01abdadb07d5075c"
   },
   "options": [
     {

--- a/src/pocore/engines/ethics_v1.py
+++ b/src/pocore/engines/ethics_v1.py
@@ -11,6 +11,13 @@ ETH_NO_OVERCLAIM_UNKNOWN = "ETH_NO_OVERCLAIM_UNKNOWN"
 ETH_STAKEHOLDER_CONSENT = "ETH_STAKEHOLDER_CONSENT"
 ETH_TIME_PRESSURE_SAFETY = "ETH_TIME_PRESSURE_SAFETY"
 
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
+
 
 def _append_unique(items: List[str], value: str) -> None:
     if value not in items:
@@ -24,7 +31,7 @@ def _is_short_deadline(days_to_deadline: Any) -> bool:
 
 
 def _collect_rules_fired(*, short_id: str, features: Optional[Dict[str, Any]]) -> List[str]:
-    if short_id in ("case_001", "case_009"):
+    if _has_profile(features, PROFILE_CASE_001) or _has_profile(features, PROFILE_CASE_009):
         return []
 
     feats = features or {}
@@ -72,7 +79,7 @@ def apply(
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Apply ethics review to options; return (options, ethics_summary)."""
 
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         for opt in options:
             if opt.get("option_id") == "opt_1":
                 opt["ethics_review"] = {
@@ -125,7 +132,7 @@ def apply(
         }
         return options, summary
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         for opt in options:
             if opt.get("option_id") == "opt_1":
                 opt["ethics_review"] = {

--- a/src/pocore/engines/generator_stub.py
+++ b/src/pocore/engines/generator_stub.py
@@ -5,7 +5,8 @@ src/pocore/engines/generator_stub.py
 Option generator (stub).
 
 Design:
-- Frozen outputs for golden cases (case_001, case_009).
+- Profile outputs for scenario_profile-based contracts (job_change_transition_v1,
+  values_clarification_v1).
 - Generic path uses features (constraint_conflict, values_empty, etc.).
 - ethics_review / responsibility_review are placeholder; filled by later engines.
 """
@@ -13,6 +14,13 @@ Design:
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
 
 
 def _ph_ethics() -> Dict[str, Any]:
@@ -51,7 +59,7 @@ def generate_options(
     """Generate 2 option stubs for the given case."""
 
     # ── Frozen golden contracts ───────────────────────────────────────────
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         return [
             {
                 "option_id": "opt_1",
@@ -128,7 +136,7 @@ def generate_options(
             },
         ]
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         return [
             {
                 "option_id": "opt_1",

--- a/src/pocore/engines/question_v1.py
+++ b/src/pocore/engines/question_v1.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
+
 
 def generate(
     case: Dict[str, Any],
@@ -13,7 +20,7 @@ def generate(
 ) -> List[Dict[str, Any]]:
     """Generate clarifying questions (max 5)."""
 
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         return [
             {
                 "question_id": "q1",
@@ -33,7 +40,7 @@ def generate(
             },
         ]
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         return [
             {
                 "question_id": "q1",

--- a/src/pocore/engines/recommendation_v1.py
+++ b/src/pocore/engines/recommendation_v1.py
@@ -6,6 +6,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pocore.policy_v1 import has_time_pressure_with_unknowns, should_block_recommendation
 
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
+
 
 def arbitrate_recommendation(
     case: Dict[str, Any],
@@ -16,7 +23,7 @@ def arbitrate_recommendation(
 ) -> Tuple[Dict[str, Any], str]:
     """Produce recommendation payload with deterministic arbitration code."""
 
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         return (
             {
                 "status": "recommended",
@@ -37,7 +44,7 @@ def arbitrate_recommendation(
             "DEFAULT_RECOMMEND",
         )
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         return (
             {
                 "status": "no_recommendation",

--- a/src/pocore/engines/responsibility_v1.py
+++ b/src/pocore/engines/responsibility_v1.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
+
 
 def _map_stakeholders(case: Dict[str, Any]) -> List[Dict[str, Any]]:
     st = case.get("stakeholders", [])
@@ -31,7 +38,7 @@ def apply(
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Apply responsibility review to options; return (options, responsibility_summary)."""
 
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         for opt in options:
             if opt.get("option_id") == "opt_1":
                 opt["responsibility_review"] = {
@@ -104,7 +111,7 @@ def apply(
         }
         return options, summary
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         for opt in options:
             if opt.get("option_id") == "opt_1":
                 opt["responsibility_review"] = {

--- a/src/pocore/engines/uncertainty_v1.py
+++ b/src/pocore/engines/uncertainty_v1.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
+
 
 def summarize(
     case: Dict[str, Any],
@@ -13,7 +20,7 @@ def summarize(
 ) -> Dict[str, Any]:
     """Produce an uncertainty summary for the case."""
 
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         return {
             "overall_level": "medium",
             "reasons": ["転職先の重要情報が未確定"],
@@ -21,7 +28,7 @@ def summarize(
             "known_unknowns": ["稼働実態", "文化"],
         }
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         return {
             "overall_level": "high",
             "reasons": ["価値観と目的が未確定"],

--- a/src/pocore/parse_input.py
+++ b/src/pocore/parse_input.py
@@ -82,6 +82,14 @@ def extract_features(case: Dict[str, Any], *, now: Optional[str] = None) -> Dict
     unknowns = case.get("unknowns", [])
     stakeholders = case.get("stakeholders", [])
     deadline = case.get("deadline")
+    extensions = case.get("extensions")
+    scenario_profile = None
+    if isinstance(extensions, dict):
+        raw_profile = extensions.get("scenario_profile")
+        if isinstance(raw_profile, str):
+            normalized = raw_profile.strip()
+            if normalized:
+                scenario_profile = normalized
 
     features: Dict[str, Any] = {
         "values_empty": isinstance(values, list) and len(values) == 0,
@@ -93,6 +101,7 @@ def extract_features(case: Dict[str, Any], *, now: Optional[str] = None) -> Dict
         "deadline_present": (deadline is not None and str(deadline).strip() != ""),
         "unknowns_items": _extract_unknowns_items(unknowns),
         "stakeholder_roles": _extract_stakeholder_roles(stakeholders),
+        "scenario_profile": scenario_profile,
     }
 
     features.update(_extract_deadline_features(deadline, now))

--- a/src/pocore/tracer.py
+++ b/src/pocore/tracer.py
@@ -8,7 +8,7 @@ Contract (ADR-0003):
 - All timestamps derived from injected `created_at` with fixed offsets.
 - No wall-clock time.
 - Step names from output_schema_v1.json enum.
-- Existing golden cases use frozen trace structures.
+- Profile-based scenarios can pin trace structures without case_id coupling.
 """
 
 from __future__ import annotations
@@ -16,6 +16,13 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from .utils import add_seconds
+
+PROFILE_CASE_001 = "job_change_transition_v1"
+PROFILE_CASE_009 = "values_clarification_v1"
+
+
+def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
+    return isinstance(features, dict) and features.get("scenario_profile") == profile
 
 
 def build_trace(
@@ -32,7 +39,7 @@ def build_trace(
     """Build a deterministic trace for a pipeline run."""
 
     # ── Frozen golden contracts ───────────────────────────────────────────
-    if short_id == "case_001":
+    if _has_profile(features, PROFILE_CASE_001):
         return {
             "version": "1.0",
             "steps": [
@@ -58,7 +65,7 @@ def build_trace(
             ],
         }
 
-    if short_id == "case_009":
+    if _has_profile(features, PROFILE_CASE_009):
         return {
             "version": "1.0",
             "steps": [

--- a/tests/test_arbitration_trace.py
+++ b/tests/test_arbitration_trace.py
@@ -40,6 +40,7 @@ def test_trace_compose_output_arbitration_metrics_not_added_to_frozen_case() -> 
         "dilemma": "frozen",
         "values": ["v"],
         "context": {},
+        "extensions": {"scenario_profile": "job_change_transition_v1"},
     }
 
     output = run_case(

--- a/tests/test_ethics_guardrails.py
+++ b/tests/test_ethics_guardrails.py
@@ -45,7 +45,12 @@ def test_ethics_guardrails_v1_only_applies_to_generic_path() -> None:
     _, summary = ethics_v1.apply(
         {"case_id": "case_001_job_change"},
         short_id="case_001",
-        features={"unknowns_count": 9, "stakeholders_count": 9, "days_to_deadline": 1},
+        features={
+            "scenario_profile": "job_change_transition_v1",
+            "unknowns_count": 9,
+            "stakeholders_count": 9,
+            "days_to_deadline": 1,
+        },
         options=options,
     )
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -157,3 +157,11 @@ def test_days_to_deadline_invalid_deadline_returns_none_values() -> None:
     assert features["deadline_present"] is True
     assert features["deadline_iso"] is None
     assert features["days_to_deadline"] is None
+
+
+def test_extract_features_reads_scenario_profile_from_extensions() -> None:
+    case = {"extensions": {"scenario_profile": "job_change_transition_v1"}}
+
+    features = extract_features(case)
+
+    assert features["scenario_profile"] == "job_change_transition_v1"

--- a/tests/test_no_short_id_special_cases.py
+++ b/tests/test_no_short_id_special_cases.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_no_short_id_special_cases_for_case_001_009() -> None:
+    root = Path(__file__).resolve().parents[1]
+    disallowed = (
+        'short_id == "case_001"',
+        "short_id == 'case_001'",
+        'short_id == "case_009"',
+        "short_id == 'case_009'",
+        'short_id in ("case_001", "case_009")',
+        "short_id in ('case_001', 'case_009')",
+    )
+
+    violations: list[str] = []
+    for path in (root / "src" / "pocore").rglob("*.py"):
+        rel = path.relative_to(root)
+        text = path.read_text(encoding="utf-8")
+        for pattern in disallowed:
+            if pattern in text:
+                violations.append(f"{rel}: contains {pattern}")
+
+    assert violations == []

--- a/tests/test_trace_metrics.py
+++ b/tests/test_trace_metrics.py
@@ -74,6 +74,7 @@ def test_build_trace_frozen_case_001_and_009_steps_unchanged():
         options_count=99,
         questions_count=99,
         features={
+            "scenario_profile": "job_change_transition_v1",
             "unknowns_count": 999,
             "stakeholders_count": 999,
             "days_to_deadline": 999,
@@ -108,6 +109,7 @@ def test_build_trace_frozen_case_001_and_009_steps_unchanged():
         options_count=99,
         questions_count=99,
         features={
+            "scenario_profile": "values_clarification_v1",
             "unknowns_count": 999,
             "stakeholders_count": 999,
             "days_to_deadline": 999,


### PR DESCRIPTION
### Motivation
- Remove permanent `short_id`-based exceptions for `case_001`/`case_009` and migrate behavior to a feature-driven design to avoid filename/ID coupling.  
- Make the contract explicit in inputs so the same behavior can be reused for future scenarios without per-case `if` proliferation.  
- Preserve determinism and golden-contract guarantees while enabling rules/features to own case-specific behavior.

### Description
- Extract `extensions.scenario_profile` into `features.scenario_profile` in `parse_input.extract_features()` and use this feature for special-case behavior instead of `short_id`.  
- Replace `short_id == "case_001"` / `short_id == "case_009"` branching in core components with profile checks (`_has_profile(features, ...)`) across `generator_stub`, `recommendation_v1`, `ethics_v1`, `responsibility_v1`, `question_v1`, `uncertainty_v1`, and `tracer`.  
- Add `extensions.scenario_profile` entries to `scenarios/case_001.yaml` and `scenarios/case_009.yaml` and regenerate their expected goldens via a deterministic `regenerate_golden.py`.  
- Introduce ADR `docs/adr/0010-scenario-profile-for-former-frozen-cases.md` documenting the migration and add a test `tests/test_no_short_id_special_cases.py` to prevent reintroducing `short_id` hard-coding.  
- No golden content was hand-edited; regenerated expected files only changed the input digest due to the added `extensions` field.

### Testing
- Regenerated goldens with `PYTHONPATH=src python regenerate_golden.py scenarios/case_001.yaml scenarios/case_009.yaml --seed 0 --now 2026-02-22T00:00:00Z` and wrote `scenarios/case_001_expected.json` and `scenarios/case_009_expected.json` successfully.  
- Ran targeted tests: `PYTHONPATH=src pytest -q tests/test_features.py tests/test_trace_metrics.py tests/test_arbitration_trace.py tests/test_ethics_guardrails.py tests/test_ethics_non_interference.py tests/test_no_short_id_special_cases.py` and they all passed.  
- Ran full suite: `PYTHONPATH=src pytest -q` which completed with `3295 passed, 134 skipped` in this environment.  
- Regenerated golden diffs: only `case_ref.input_digest` changed for both `case_001_expected.json` and `case_009_expected.json` due to the added `extensions.scenario_profile` in the YAML input.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce197322483289e2e7fd9600e1283)