### PR TITLE
Fix CI: apply black/isort formatting for lint stability

### DIFF
--- a/src/po_core/cli/experiment.py
+++ b/src/po_core/cli/experiment.py
@@ -29,7 +29,8 @@ from po_core.experiments.storage import ExperimentStorage
 
 def _print_help():
     """ヘルプメッセージを表示"""
-    print("""
+    print(
+        """
 Po_core Experiment CLI
 
 Usage:
@@ -43,7 +44,8 @@ Commands:
     analyze      Analyze experiment results
     promote      Promote winner to main (if recommendation is 'promote')
     rollback     Rollback to previous backup
-""")
+"""
+    )
 
 
 def cmd_list():

--- a/src/pocore/engines/ethics_v1.py
+++ b/src/pocore/engines/ethics_v1.py
@@ -30,8 +30,12 @@ def _is_short_deadline(days_to_deadline: Any) -> bool:
     return 0 <= days_to_deadline <= 7
 
 
-def _collect_rules_fired(*, short_id: str, features: Optional[Dict[str, Any]]) -> List[str]:
-    if _has_profile(features, PROFILE_CASE_001) or _has_profile(features, PROFILE_CASE_009):
+def _collect_rules_fired(
+    *, short_id: str, features: Optional[Dict[str, Any]]
+) -> List[str]:
+    if _has_profile(features, PROFILE_CASE_001) or _has_profile(
+        features, PROFILE_CASE_009
+    ):
         return []
 
     feats = features or {}
@@ -44,7 +48,8 @@ def _collect_rules_fired(*, short_id: str, features: Optional[Dict[str, Any]]) -
         ),
         (
             ETH_NO_OVERCLAIM_UNKNOWN,
-            lambda f: isinstance(f.get("unknowns_count"), int) and f.get("unknowns_count") > 0,
+            lambda f: isinstance(f.get("unknowns_count"), int)
+            and f.get("unknowns_count") > 0,
         ),
         (
             ETH_STAKEHOLDER_CONSENT,

--- a/src/pocore/engines/recommendation_v1.py
+++ b/src/pocore/engines/recommendation_v1.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from pocore.policy_v1 import has_time_pressure_with_unknowns, should_block_recommendation
+from pocore.policy_v1 import (
+    has_time_pressure_with_unknowns,
+    should_block_recommendation,
+)
 
 PROFILE_CASE_001 = "job_change_transition_v1"
 PROFILE_CASE_009 = "values_clarification_v1"
@@ -133,7 +136,9 @@ def arbitrate_recommendation(
             "recommended_option_id": "opt_1",
             "reason": "害を抑えつつ前進できるため。",
             "counter": "遅いと感じる可能性がある。",
-            "alternatives": [{"option_id": "opt_2", "when_to_choose": "不明点が多い場合"}],
+            "alternatives": [
+                {"option_id": "opt_2", "when_to_choose": "不明点が多い場合"}
+            ],
             "confidence": "medium",
         },
         "DEFAULT_RECOMMEND",

--- a/src/pocore/orchestrator.py
+++ b/src/pocore/orchestrator.py
@@ -22,8 +22,8 @@ from .engines import (
     responsibility_v1,
     uncertainty_v1,
 )
-from .tracer import build_trace
 from .policy_v1 import TIME_PRESSURE_DAYS, UNKNOWN_BLOCK
+from .tracer import build_trace
 from .utils import deterministic_run_id, input_digest, normalize_now
 
 POCORE_VERSION = "0.1.0"

--- a/src/pocore/parse_input.py
+++ b/src/pocore/parse_input.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .utils import case_short_id, detect_constraint_conflict, parse_deadline_iso, parse_iso_datetime
+from .utils import (
+    case_short_id,
+    detect_constraint_conflict,
+    parse_deadline_iso,
+    parse_iso_datetime,
+)
 
 
 @dataclass(frozen=True)
@@ -75,7 +80,9 @@ def _extract_deadline_features(deadline: Any, now: Optional[str]) -> Dict[str, A
     return result
 
 
-def extract_features(case: Dict[str, Any], *, now: Optional[str] = None) -> Dict[str, Any]:
+def extract_features(
+    case: Dict[str, Any], *, now: Optional[str] = None
+) -> Dict[str, Any]:
     """Derive feature flags from case dict for engine dispatch."""
     values = case.get("values", [])
     constraints = case.get("constraints", [])

--- a/src/pocore/policy_v1.py
+++ b/src/pocore/policy_v1.py
@@ -9,12 +9,10 @@ UNKNOWN_SOFT = 1
 TIME_PRESSURE_DAYS = 7
 
 
-
 def should_block_recommendation(features: Dict[str, Any]) -> bool:
     """Return True when missing critical information should block recommendation."""
     unknowns_count = int(features.get("unknowns_count", 0) or 0)
     return unknowns_count >= UNKNOWN_BLOCK
-
 
 
 def has_time_pressure_with_unknowns(features: Dict[str, Any]) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,8 @@ def pytest_pyfunc_call(pyfuncitem):
     if not asyncio.iscoroutinefunction(test_func):
         return None
 
-    kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+    kwargs = {
+        name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames
+    }
     asyncio.run(test_func(**kwargs))
     return True

--- a/tests/test_arbitration_trace.py
+++ b/tests/test_arbitration_trace.py
@@ -2,11 +2,15 @@ from pocore.orchestrator import run_case
 
 
 def _compose_metrics(output: dict) -> dict:
-    compose_step = next(step for step in output["trace"]["steps"] if step["name"] == "compose_output")
+    compose_step = next(
+        step for step in output["trace"]["steps"] if step["name"] == "compose_output"
+    )
     return compose_step.get("metrics", {})
 
 
-def test_trace_compose_output_includes_arbitration_code_and_policy_snapshot_for_generic_case() -> None:
+def test_trace_compose_output_includes_arbitration_code_and_policy_snapshot_for_generic_case() -> (
+    None
+):
     case = {
         "case_id": "case_custom_arbitration",
         "title": "arbitration trace check",
@@ -50,5 +54,7 @@ def test_trace_compose_output_arbitration_metrics_not_added_to_frozen_case() -> 
         deterministic=True,
     )
 
-    compose_step = next(step for step in output["trace"]["steps"] if step["name"] == "compose_output")
+    compose_step = next(
+        step for step in output["trace"]["steps"] if step["name"] == "compose_output"
+    )
     assert "metrics" not in compose_step

--- a/tests/test_ethics_non_interference.py
+++ b/tests/test_ethics_non_interference.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pocore.runner import run_case_file
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CASE_PATH = ROOT / "scenarios" / "case_010.yaml"
 
@@ -43,7 +42,13 @@ def test_ethics_changes_do_not_change_recommendation(monkeypatch) -> None:
                 "confidence": "low",
             }
         return options, {
-            "principles_used": ["integrity", "autonomy", "nonmaleficence", "justice", "accountability"],
+            "principles_used": [
+                "integrity",
+                "autonomy",
+                "nonmaleficence",
+                "justice",
+                "accountability",
+            ],
             "tradeoffs": [
                 {
                     "tension": "ダミー倫理トレードオフ",

--- a/tests/test_golden_e2e.py
+++ b/tests/test_golden_e2e.py
@@ -210,7 +210,9 @@ def _format_failure(actual: Dict, expected: Dict, name: str) -> str:
     if udiff:
         parts.append("\n── Unified diff (expected → actual) ──")
         parts.extend(udiff[:120])  # cap at 120 diff lines
-    parts.append("\nTo update goldens: python scripts/regenerate_golden.py --all --write")
+    parts.append(
+        "\nTo update goldens: python scripts/regenerate_golden.py --all --write"
+    )
     return "\n".join(parts)
 
 

--- a/tests/test_trace_metrics.py
+++ b/tests/test_trace_metrics.py
@@ -40,7 +40,11 @@ def test_build_trace_generic_omits_days_to_deadline_when_unknown():
         created_at="2026-02-22T00:00:00Z",
         options_count=1,
         questions_count=0,
-        features={"unknowns_count": 1, "stakeholders_count": 0, "days_to_deadline": None},
+        features={
+            "unknowns_count": 1,
+            "stakeholders_count": 0,
+            "days_to_deadline": None,
+        },
     )
 
     metrics = _parse_step(trace)["metrics"]
@@ -60,7 +64,9 @@ def test_build_trace_generic_compose_output_metrics_include_rules_fired() -> Non
         arbitration_code="REC_A",
     )
 
-    compose_step = next(step for step in trace["steps"] if step["name"] == "compose_output")
+    compose_step = next(
+        step for step in trace["steps"] if step["name"] == "compose_output"
+    )
     assert compose_step["metrics"]["rules_fired"] == ["ETH_STAKEHOLDER_CONSENT"]
     assert compose_step["metrics"]["arbitration_code"] == "REC_A"
 


### PR DESCRIPTION
### Motivation

- The CI `lint` job fails on the **Check code formatting with black** step because `black --check src tests` reported files that `would reformat`.  
- The goal is to restore CI lint stability with the minimal, behavior-preserving edits so existing outputs (especially goldens) remain unchanged.

### Description

- Applied `black` formatting to the files reported by the failing check and applied `isort` where import ordering was flagged, with no logic changes.  
- Files modified (formatting-only): `src/po_core/cli/experiment.py`, `src/pocore/engines/ethics_v1.py`, `src/pocore/engines/recommendation_v1.py`, `src/pocore/orchestrator.py`, `src/pocore/parse_input.py`, `src/pocore/policy_v1.py`, `tests/conftest.py`, `tests/test_arbitration_trace.py`, `tests/test_ethics_non_interference.py`, `tests/test_golden_e2e.py`, and `tests/test_trace_metrics.py`.  
- No golden JSON files were modified and no runtime logic or behavior was altered, only formatting and import order adjustments were made.  
- Rationale: match CI lint expectations (`black --check src tests` and `isort --check-only src tests`) to avoid spurious formatting failures.

### Testing

- Reproduced the failure locally with `black --check src tests` which initially returned `would reformat` for 10 files, confirming the root cause.  
- Ran `black src tests` and `isort src tests` to apply fixes, then verified `black --check src tests` and `isort --check-only src tests` both succeed.  
- Ran `mypy` with `mypy src/po_core/domain/ src/po_core/experiments/ src/po_core/app/ src/po_core/ports/` which reported `Success: no issues found`.  
- Ran `pytest -q` which completed successfully (summary: `3300 passed, 134 skipped`).  
- Note: `flake8`/dev-deps installation could not be executed in this environment due to external package index/proxy restrictions, so `flake8` was not run locally, but the committed changes are formatter/import-order only and do not alter behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1d0d563483289289d71932b587b4)