### PR TITLE
Add deterministic execution coverage test for arbitration and ethics rules

### DIFF
--- a/tests/test_execution_coverage.py
+++ b/tests/test_execution_coverage.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Set, Tuple
+
+from pocore.runner import run_case_file
+
+ROOT = Path(__file__).resolve().parents[1]
+SCENARIOS = ROOT / "scenarios"
+FIXED_NOW = "2026-02-22T00:00:00Z"
+
+MUST_COVER_ARBITRATION_CODES = {
+    "DEFAULT_RECOMMEND",
+    "TIME_PRESSURE_LOW_CONF",
+    "CONSTRAINT_CONFLICT",
+}
+MUST_COVER_ETHICS_RULE_IDS = {
+    "ETH_NO_OVERCLAIM_UNKNOWN",
+    "ETH_STAKEHOLDER_CONSENT",
+}
+
+
+def _collect_execution_coverage() -> Tuple[Set[str], Set[str]]:
+    arbitration_codes: Set[str] = set()
+    ethics_rule_ids: Set[str] = set()
+
+    for yaml_path in sorted(SCENARIOS.glob("*.yaml")):
+        output = run_case_file(
+            yaml_path,
+            seed=0,
+            deterministic=True,
+            now=FIXED_NOW,
+        )
+        for step in output.get("trace", {}).get("steps", []):
+            metrics = step.get("metrics", {})
+            arbitration_code = metrics.get("arbitration_code")
+            if arbitration_code:
+                arbitration_codes.add(arbitration_code)
+
+            rules_fired = metrics.get("rules_fired")
+            if isinstance(rules_fired, list):
+                ethics_rule_ids.update(rule for rule in rules_fired if isinstance(rule, str))
+
+    return arbitration_codes, ethics_rule_ids
+
+
+def test_execution_covers_minimum_arbitration_codes_and_ethics_rules() -> None:
+    arbitration_codes, ethics_rule_ids = _collect_execution_coverage()
+
+    missing_arbitration = MUST_COVER_ARBITRATION_CODES - arbitration_codes
+    missing_rules = MUST_COVER_ETHICS_RULE_IDS - ethics_rule_ids
+
+    assert not missing_arbitration, (
+        "Missing required arbitration_code coverage from scenarios/*.yaml execution: "
+        f"{sorted(missing_arbitration)}\n"
+        f"covered={sorted(arbitration_codes)}"
+    )
+    assert not missing_rules, (
+        "Missing required ethics rule_id coverage from scenarios/*.yaml execution: "
+        f"{sorted(missing_rules)}\n"
+        f"covered={sorted(ethics_rule_ids)}"
+    )


### PR DESCRIPTION
### Motivation

- Ensure key arbitration paths and ethics rules remain exercised by real scenario executions so silent dead-rule drift is caught by CI.
- Make coverage a deterministic, executable contract by running `scenarios/*.yaml` through the same `run_case_file` pipeline used by other tests with a fixed `seed` and `now`.

### Description

- Add `tests/test_execution_coverage.py` which iterates `scenarios/*.yaml`, calls `run_case_file(..., seed=0, deterministic=True, now="2026-02-22T00:00:00Z")`, and aggregates `trace.steps[*].metrics.arbitration_code` and `trace.steps[*].metrics.rules_fired`.
- Define minimal `MUST_COVER` sets: three arbitration codes (`DEFAULT_RECOMMEND`, `TIME_PRESSURE_LOW_CONF`, `CONSTRAINT_CONFLICT`) and two ethics rule ids (`ETH_NO_OVERCLAIM_UNKNOWN`, `ETH_STAKEHOLDER_CONSENT`) and assert they are observed.
- No changes to frozen golden files or schema/tests weakening were made.

### Testing

- Run `PYTHONPATH=src pytest -q`; result: `3307 passed, 134 skipped`.
- Ran the coverage collector (`tests.test_execution_coverage._collect_execution_coverage`) and observed arbitration codes `CONSTRAINT_CONFLICT`, `DEFAULT_RECOMMEND`, `TIME_PRESSURE_LOW_CONF` and ethics rules `ETH_CONSTRAINT_CONFLICT_DISCLOSURE`, `ETH_NO_OVERCLAIM_UNKNOWN`, `ETH_STAKEHOLDER_CONSENT`, `ETH_TIME_PRESSURE_SAFETY` which satisfy the asserted `MUST_COVER` sets.
- No automated tests were modified or weakened and frozen goldens were not edited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24a133f208328b7c6752061a82c83)