### PR TITLE
docs: Add ADR 0012 Policy Change Protocol v1 and PR checklist template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+- 変更概要:
+- 背景/目的:
+
+## Policy Change Protocol v1（policy定数変更時のみ必須）
+- [ ] policy定数変更なし（該当しない）
+- [ ] policy_lab レポート（JSON）を添付した
+- [ ] policy_lab レポート（Markdown）を添付した
+- [ ] impacted_requirements 上位（例: Top 3）を本文へ記載した
+- [ ] golden差分がある場合、再生成で更新した（手編集なし）
+- [ ] golden差分要約（対象ケース/主要差分/妥当性）を本文へ記載した
+
+## Evidence
+- policy_lab artifacts:
+  - JSON:
+  - Markdown:
+- impacted_requirements (Top):
+  1.
+  2.
+  3.
+
+## Validation
+- [ ] `pytest -q` を実行し全通
+
+## Notes
+- 追加の注意事項・制約:

--- a/docs/adr/0012-policy-change-protocol-v1.md
+++ b/docs/adr/0012-policy-change-protocol-v1.md
@@ -1,0 +1,73 @@
+# ADR 0012: Policy Change Protocol v1
+
+**Date:** 2026-02-28
+**Status:** Accepted
+**Deciders:** Po_core project
+
+---
+
+## Context
+
+`policy_v1` 等の政策定数（閾値・重み・裁定順序）を変更すると、recommendation/ethics/trace/golden に連鎖影響が出る。
+
+しかし「雰囲気で変更して expected を合わせる」運用は、Po_core の最優先要件である決定性・説明責任・安全な変更管理を壊す。
+
+そのため、policy変更時に必須の儀式（protocol）を固定し、PRレビューで機械的に検証できる状態にする。
+
+## Decision
+
+policy定数を変更するPRでは、以下を **必須** とする。
+
+1. **policy_lab レポート添付（JSON + Markdown）**
+   - policy差分を評価した `policy_lab` の成果物を PR に添付する。
+   - 最低限、次の2形式を含める。
+     - 機械可読: `*.json`
+     - 人間可読: `*.md`
+
+2. **PR本文に impacted_requirements 上位を明記**
+   - `policy_lab` が算出した `impacted_requirements` の上位項目（例: Top 3）をPR本文へ記載する。
+   - 「何が、なぜ影響を受けるか」をレポート参照付きで説明する。
+
+3. **必要時のgolden再生成（手編集禁止）**
+   - 変更影響で golden 差分が発生する場合は、決定論パラメータで再生成する。
+   - `scenarios/*_expected.json` の手編集は禁止（生成物のみを採用）。
+   - PR本文に golden 差分要約（対象ケース、主要差分、妥当性）を記載する。
+
+## Operational Protocol (PR Ritual)
+
+policy定数変更を含むPRは、以下を順番に満たす。
+
+1. policy変更内容を実装（変更理由をコミットメッセージに明示）
+2. `policy_lab` 実行でレポート（json/md）を生成
+3. レポートから `impacted_requirements` 上位を抽出
+4. 必要なgoldenを再生成（手編集禁止）
+5. `pytest -q` を実行して全通を確認
+6. PR本文に以下を記載
+   - policy_lab 添付物の場所
+   - impacted_requirements 上位
+   - （golden差分がある場合）差分要約
+
+## Rationale
+
+- 政策変更の根拠を成果物で固定し、レビューの主観依存を減らせる
+- impacted_requirements の明示で、仕様影響範囲の説明責任を満たせる
+- golden再生成を手編集禁止にすることで、契約変更の追跡可能性を維持できる
+
+## Consequences
+
+- policy変更PRの準備コストは上がるが、監査可能性が向上する
+- PR本文のフォーマットが半自動化しやすくなる
+- golden差分があるPRでは「生成手順」がレビュー対象となる
+
+## Non-Goals
+
+- policy内容（閾値そのもの）の妥当性を本ADR単体で保証すること
+- policy_lab の評価アルゴリズム詳細を固定すること（別ADRで管理）
+
+## Alternatives Considered
+
+| 代替案 | 却下理由 |
+|---|---|
+| PR説明のみで運用（添付物なし） | 証跡が弱く、再現不能になりやすい |
+| impacted_requirements 記載を任意化 | 影響説明が抜け落ち、レビューが属人化する |
+| golden手編集を許可 | 差分由来が不明瞭になり、契約管理が壊れる |

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -15,5 +15,6 @@ Po_coreで採用済み/提案中のArchitectural Decision Records一覧。
 | 0009 | Traceへrecommendation裁定経路を記録する | Accepted | traceの compose_output metrics に `arbitration_code` と policy snapshot を記録。 |
 | 0010 | case_001/case_009 short_id特例の撤去とscenario_profile移行 | Accepted | 永久特例を `extensions.scenario_profile`→`features` に移し、rulesで吸収する。 |
 | 0011 | case_001/case_009 凍結解除計画（J0/J1） | Accepted | 凍結解除を二段階化し、再生成スクリプト経由でのみexpected更新を許可。 |
+| 0012 | Policy Change Protocol v1 | Accepted | policy定数変更PRで policy_lab証跡・impacted_requirements明記・golden再生成手順を必須化。 |
 
 > 現時点で `docs/adr/*.md` に Proposed はなく、すべて Accepted。


### PR DESCRIPTION
### Motivation
- Formalize a mandatory ritual for changing policy constants so policy adjustments remain auditable and deterministic.
- Prevent ad-hoc "tweaks to golden outputs" by requiring evidence (`policy_lab` artifacts) and mechanized golden regeneration when needed.
- Make reviewers’ job mechanical by surfacing top `impacted_requirements` and a golden-diff summary in the PR.

### Description
- Added ADR file `docs/adr/0012-policy-change-protocol-v1.md` that specifies the Policy Change Protocol v1 including required `policy_lab` artifacts (JSON + Markdown), `impacted_requirements` disclosure, and golden re-generation rules (no hand edits).
- Registered the ADR in `docs/adr/index.md` by adding an entry for `0012` as Accepted.
- Added a PR template at `.github/pull_request_template.md` with a checklist enforcing the Policy Change Protocol v1 items and an Evidence section.
- No frozen golden files (`scenarios/case_001_expected.json`, `scenarios/case_009_expected.json`) were touched and no tests were weakened.

### Testing
- Ran `pytest -q` and verified the test suite passed with a large passing surface: `3306 passed, 134 skipped` (run time ~98.12s).
- The modified documentation and template changes do not affect runtime behavior and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24a05d2408328bbf1ce40c6e6f6d8)