### PR TITLE
Add manual Policy Lab GitHub Actions workflow with artifact upload

### DIFF
--- a/.github/workflows/policy_lab.yml
+++ b/.github/workflows/policy_lab.yml
@@ -1,0 +1,70 @@
+name: Policy Lab Manual Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      unknown_block:
+        description: "UNKNOWN_BLOCK threshold"
+        required: true
+        type: number
+      time_pressure_days:
+        description: "TIME_PRESSURE_DAYS threshold"
+        required: true
+        type: number
+      now:
+        description: "Deterministic now timestamp"
+        required: true
+        default: "2026-02-22T00:00:00Z"
+        type: string
+      seed:
+        description: "Deterministic seed"
+        required: true
+        default: 0
+        type: number
+      compare_baseline:
+        description: "Compare variant outputs against baseline"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  policy-lab:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run Policy Lab
+        run: |
+          OUTPUT_DIR="reports/policy_lab/run_${{ github.run_id }}_${{ github.run_attempt }}"
+          COMPARE_FLAG=""
+          if [ "${{ inputs.compare_baseline }}" = "true" ]; then
+            COMPARE_FLAG="--compare-baseline"
+          fi
+
+          python scripts/policy_lab.py \
+            --unknown-block ${{ inputs.unknown_block }} \
+            --time-pressure-days ${{ inputs.time_pressure_days }} \
+            --now "${{ inputs.now }}" \
+            --seed ${{ inputs.seed }} \
+            --output-dir "$OUTPUT_DIR" \
+            $COMPARE_FLAG
+
+      - name: Upload Policy Lab artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-lab-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: reports/policy_lab/**
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide a manual, deterministic way to run the Policy Lab experiment in GitHub Actions and collect reports as artifacts without coupling this flow to CI tests.
- Allow experiments to be parameterized by policy thresholds and deterministic runtime inputs so results can be reproduced and compared.

### Description
- Add a new workflow file at `.github/workflows/policy_lab.yml` triggered by `workflow_dispatch` with inputs `unknown_block`, `time_pressure_days`, `now`, `seed`, and `compare_baseline`.
- Workflow steps: `actions/checkout`, set up Python, install dependencies with `pip install -e ".[dev]"`, run `scripts/policy_lab.py` with the provided inputs and a unique `--output-dir` set to `reports/policy_lab/run_${{ github.run_id }}_${{ github.run_attempt }}`.
- The workflow conditionally passes `--compare-baseline` when `compare_baseline` is `true` and uploads `reports/policy_lab/**` as an artifact named `policy-lab-reports-<run_id>-<run_attempt>`.
- This workflow is manual-only (`workflow_dispatch`) and does not modify existing CI jobs or add tests to the CI matrix.

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully with `3307 passed, 134 skipped` in approximately `76.11s`.
- The new workflow is not invoked by CI and therefore did not affect test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a251a5b1fc832890ddc5b4293b325c)