### PR TITLE
Add manual Policy Lab workflow_dispatch artifact pipeline

### DIFF
--- a/.github/workflows/policy_lab.yml
+++ b/.github/workflows/policy_lab.yml
@@ -1,14 +1,14 @@
-name: Policy Lab Manual Run
+name: Policy Lab (Manual)
 
 on:
   workflow_dispatch:
     inputs:
       unknown_block:
-        description: "UNKNOWN_BLOCK threshold"
+        description: "UNKNOWN_BLOCK threshold (int)"
         required: true
         type: number
       time_pressure_days:
-        description: "TIME_PRESSURE_DAYS threshold"
+        description: "TIME_PRESSURE_DAYS threshold (int)"
         required: true
         type: number
       now:
@@ -22,13 +22,14 @@ on:
         default: 0
         type: number
       compare_baseline:
-        description: "Compare variant outputs against baseline"
+        description: "Compare with baseline"
         required: true
         default: true
         type: boolean
 
 jobs:
   policy-lab:
+    name: Policy Lab Experiment (manual only)
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +49,7 @@ jobs:
 
       - name: Run Policy Lab
         run: |
-          OUTPUT_DIR="reports/policy_lab/run_${{ github.run_id }}_${{ github.run_attempt }}"
+          OUTPUT_DIR="reports/policy_lab/ub${{ inputs.unknown_block }}_tp${{ inputs.time_pressure_days }}_${{ github.run_id }}"
           COMPARE_FLAG=""
           if [ "${{ inputs.compare_baseline }}" = "true" ]; then
             COMPARE_FLAG="--compare-baseline"
@@ -62,9 +63,9 @@ jobs:
             --output-dir "$OUTPUT_DIR" \
             $COMPARE_FLAG
 
-      - name: Upload Policy Lab artifacts
+      - name: Upload reports artifact
         uses: actions/upload-artifact@v4
         with:
-          name: policy-lab-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          name: policy-lab-reports-${{ github.run_id }}
           path: reports/policy_lab/**
           if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide a manual-only GitHub Actions workflow to run Policy Lab experiments with deterministic inputs and collect `reports/policy_lab/**` as artifacts for analysis.

### Description
- Update `.github/workflows/policy_lab.yml` to expose `workflow_dispatch` inputs `unknown_block`, `time_pressure_days`, `now` (default `"2026-02-22T00:00:00Z"`), `seed` (default `0`) and `compare_baseline` (default `true`), run steps `checkout` → Python setup → install deps → invoke `python scripts/policy_lab.py` with those inputs and `--output-dir` set to the unique path `reports/policy_lab/ub{unknown}_tp{time}_{github.run_id}`, and upload `reports/policy_lab/**` with `actions/upload-artifact`.

### Testing
- Ran `pytest -q` locally (automated tests): `3307 passed, 134 skipped` and no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a269f5720c8328ab127d505082ec53)