### PR TITLE
fix: apply black and isort formatting to test_execution_coverage and …

### DIFF
--- a/tests/test_execution_coverage.py
+++ b/tests/test_execution_coverage.py
@@ -38,7 +38,9 @@ def _collect_execution_coverage() -> Tuple[Set[str], Set[str]]:
 
             rules_fired = metrics.get("rules_fired")
             if isinstance(rules_fired, list):
-                ethics_rule_ids.update(rule for rule in rules_fired if isinstance(rule, str))
+                ethics_rule_ids.update(
+                    rule for rule in rules_fired if isinstance(rule, str)
+                )
 
     return arbitration_codes, ethics_rule_ids
 
@@ -47,9 +49,17 @@ def test_execution_covers_minimum_arbitration_codes_and_ethics_rules() -> None:
     arbitration_codes, ethics_rule_ids = _collect_execution_coverage()
 
     required_arbitration = set(BASE_ARBITRATION_CODES)
-    if run_case_file(
-        SCENARIOS / "case_005.yaml", seed=0, deterministic=True, now=FIXED_NOW
-    ).get("trace", {}).get("steps", [{}])[-1].get("metrics", {}).get("policy_snapshot", {}).get("TIME_PRESSURE_DAYS", 0) >= 0:
+    if (
+        run_case_file(
+            SCENARIOS / "case_005.yaml", seed=0, deterministic=True, now=FIXED_NOW
+        )
+        .get("trace", {})
+        .get("steps", [{}])[-1]
+        .get("metrics", {})
+        .get("policy_snapshot", {})
+        .get("TIME_PRESSURE_DAYS", 0)
+        >= 0
+    ):
         required_arbitration.add("TIME_PRESSURE_LOW_CONF")
 
     missing_arbitration = required_arbitration - arbitration_codes

--- a/tests/test_responsibility_stakeholders.py
+++ b/tests/test_responsibility_stakeholders.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pocore.engines import question_v1, responsibility_v1
 
-
 BASE_CASE = {
     "case_id": "case_externality_unit",
     "title": "外部性がある意思決定",
@@ -33,8 +32,13 @@ def test_responsibility_adds_externality_checklist_for_many_stakeholders() -> No
     )
 
     assert summary["decision_owner"] == "未確定（要確認）"
-    assert any("RESP_STAKEHOLDER_CONSENT_CHECK" in item for item in summary["consent_considerations"])
-    assert any("RESP_IMPACT_SCOPE" in item for item in summary["consent_considerations"])
+    assert any(
+        "RESP_STAKEHOLDER_CONSENT_CHECK" in item
+        for item in summary["consent_considerations"]
+    )
+    assert any(
+        "RESP_IMPACT_SCOPE" in item for item in summary["consent_considerations"]
+    )
     assert "決裁者/意思決定者" in summary["accountability_notes"]
 
 


### PR DESCRIPTION
…test_responsibility_stakeholders

PR #240 and #241 added tests without running the formatter.
- Wrap long lines in test_execution_coverage.py (line > 88 chars)
- Wrap long assert lines in test_responsibility_stakeholders.py
- Remove extra blank line after import in test_responsibility_stakeholders.py

Fixes CI lint job failures on `black --check` and `isort --check-only`.

https://claude.ai/code/session_01DqkrGa6XYd9c1bLPvTnVmJ

## Summary
- 変更概要:
- 背景/目的:

## Policy Change Protocol v1（policy定数変更時のみ必須）
- [ ] policy定数変更なし（該当しない）
- [ ] policy_lab レポート（JSON）を添付した
- [ ] policy_lab レポート（Markdown）を添付した
- [ ] impacted_requirements 上位（例: Top 3）を本文へ記載した
- [ ] golden差分がある場合、再生成で更新した（手編集なし）
- [ ] golden差分要約（対象ケース/主要差分/妥当性）を本文へ記載した

## Evidence
- policy_lab artifacts:
  - JSON:
  - Markdown:
- impacted_requirements (Top):
  1.
  2.
  3.

## Validation
- [ ] `pytest -q` を実行し全通

## Notes
- 追加の注意事項・制約:
