### PR TITLE
Implement Questions v2 deterministic prioritization (unknowns × deadline)

### DIFF
--- a/docs/spec/requirements_v1.md
+++ b/docs/spec/requirements_v1.md
@@ -44,6 +44,13 @@
   - golden set は主要境界条件（feature/rule/arbitration path）を継続的にカバーすること。
   - Principles: P-ACC-001, P-JUS-001
 
+
+- **REQ-QST-001: Questions v2（unknowns × deadline 優先順位）**
+  - questions は features（unknowns_count / unknowns_items / days_to_deadline / stakeholders_count）を用いた決定論ルールで優先順位付けし、最大5件を返すこと。
+  - unknowns_items がある場合は質問へ変換し、deadline が近い場合は「期限の柔軟性」「暫定対応の許容範囲」を上位に出すこと。
+  - recommendation 裁定（status / recommended_option_id / arbitration_code）には介入しないこと。
+  - Principles: P-ACC-001, P-INT-001, P-NMH-001
+
 - **REQ-PLAN-001: Two-Track Plan（unknowns × time pressure）**
   - unknowns があり期限圧力が閾値以上のとき、action_plan に Track A（可逆・低リスク）と Track B（unknowns解消）を決定論順序で出力すること。
   - recommendation 裁定（status / recommended_option_id / arbitration_code）には介入しないこと。

--- a/docs/traceability/traceability_v1.yaml
+++ b/docs/traceability/traceability_v1.yaml
@@ -10,6 +10,7 @@ principles:
       - REQ-ETH-002
       - REQ-TRC-002
       - REQ-GCV-001
+      - REQ-QST-001
       - REQ-PLAN-001
   - id: P-INT-001
     mapped_requirements:
@@ -18,6 +19,7 @@ principles:
       - REQ-E2E-001
       - REQ-ARB-001
       - REQ-ETH-001
+      - REQ-QST-001
       - REQ-PLAN-001
   - id: P-AUT-001
     mapped_requirements:
@@ -27,6 +29,7 @@ principles:
     mapped_requirements:
       - REQ-ARB-001
       - REQ-ETH-002
+      - REQ-QST-001
       - REQ-PLAN-001
   - id: P-JUS-001
     mapped_requirements:
@@ -171,6 +174,29 @@ requirements:
     code_refs:
       - kind: module
         value: tests/test_golden_coverage.py
+
+  - id: REQ-QST-001
+    principles: [P-ACC-001, P-INT-001, P-NMH-001]
+    adrs: [docs/adr/0013-two-track-plan-v1.md]
+    tests:
+      - tests/test_questions_v2.py::test_questions_v2_prioritizes_deadline_and_unknowns_with_cap
+      - tests/test_questions_v2.py::test_questions_v2_converts_unknown_items_deterministically
+    code_refs:
+      - kind: module
+        value: src/pocore/engines/question_v1.py
+      - kind: rule_id
+        value: Q_DEADLINE_FLEXIBILITY
+      - kind: rule_id
+        value: Q_TEMPORARY_SCOPE
+      - kind: rule_id
+        value: Q_UNKNOWN_ITEM
+      - kind: question_id
+        value: q_deadline_flex_1
+      - kind: question_id
+        value: q_temporary_scope_1
+      - kind: question_id
+        value: q_unknown_1
+
 
 
   - id: REQ-PLAN-001

--- a/scenarios/case_002_expected.json
+++ b/scenarios/case_002_expected.json
@@ -235,7 +235,7 @@
     {
       "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "影響範囲は？（誰が何を失い、何を得るか）",
       "question_id": "q_stakeholder_3",
       "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
@@ -243,10 +243,18 @@
     {
       "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "通知・説明の方法と期限は？",
       "question_id": "q_stakeholder_4",
       "why_needed": "合意形成を実務として実行可能にするため。"
+    },
+    {
+      "assumption_if_unanswered": "当該不明点は高リスク側に倒して扱う",
+      "optional": false,
+      "priority": 3,
+      "question": "不明点『削減の許容手段（異動・契約変更・採用凍結など）』を検証するため、最短で確認できる事実は何か？",
+      "question_id": "q_unknown_1",
+      "why_needed": "未解消の不確実性を具体的な検証タスクへ分解するため。"
     }
   ],
   "recommendation": {
@@ -301,7 +309,7 @@
         "metrics": {
           "days_to_deadline": 16,
           "options_planned": 2,
-          "questions_planned": 4,
+          "questions_planned": 5,
           "rules_fired": [
             "ETH_NO_OVERCLAIM_UNKNOWN",
             "ETH_STAKEHOLDER_CONSENT"
@@ -325,7 +333,7 @@
       {
         "ended_at": "2026-02-22T00:00:03Z",
         "metrics": {
-          "questions": 4
+          "questions": 5
         },
         "name": "question_layer",
         "started_at": "2026-02-22T00:00:02Z",

--- a/scenarios/case_003_expected.json
+++ b/scenarios/case_003_expected.json
@@ -235,7 +235,7 @@
     {
       "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "影響範囲は？（誰が何を失い、何を得るか）",
       "question_id": "q_stakeholder_3",
       "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
@@ -243,10 +243,18 @@
     {
       "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "通知・説明の方法と期限は？",
       "question_id": "q_stakeholder_4",
       "why_needed": "合意形成を実務として実行可能にするため。"
+    },
+    {
+      "assumption_if_unanswered": "当該不明点は高リスク側に倒して扱う",
+      "optional": false,
+      "priority": 3,
+      "question": "不明点『医師の見立て（進行予測、必要ケアレベル）』を検証するため、最短で確認できる事実は何か？",
+      "question_id": "q_unknown_1",
+      "why_needed": "未解消の不確実性を具体的な検証タスクへ分解するため。"
     }
   ],
   "recommendation": {
@@ -301,7 +309,7 @@
         "metrics": {
           "days_to_deadline": 38,
           "options_planned": 2,
-          "questions_planned": 4,
+          "questions_planned": 5,
           "rules_fired": [
             "ETH_NO_OVERCLAIM_UNKNOWN",
             "ETH_STAKEHOLDER_CONSENT"
@@ -325,7 +333,7 @@
       {
         "ended_at": "2026-02-22T00:00:03Z",
         "metrics": {
-          "questions": 4
+          "questions": 5
         },
         "name": "question_layer",
         "started_at": "2026-02-22T00:00:02Z",

--- a/scenarios/case_006_expected.json
+++ b/scenarios/case_006_expected.json
@@ -237,36 +237,44 @@
   ],
   "questions": [
     {
-      "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
+      "assumption_if_unanswered": "期限は固定で延長不可と仮定する",
       "optional": false,
       "priority": 1,
+      "question": "期限の柔軟性はどこまであるか？（延長可否/最短再設定日）",
+      "question_id": "q_deadline_flex_1",
+      "why_needed": "時間圧の中で実行可能な計画へ再設計するため。"
+    },
+    {
+      "assumption_if_unanswered": "可逆で低リスクな最小範囲のみ許容とする",
+      "optional": false,
+      "priority": 1,
+      "question": "暫定対応として許容できる範囲は？（品質/コスト/対象範囲）",
+      "question_id": "q_temporary_scope_1",
+      "why_needed": "未知が残る状況でも被害を限定して前進するため。"
+    },
+    {
+      "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
+      "optional": false,
+      "priority": 2,
       "question": "この意思決定の決裁者（最終承認者）は誰か？",
       "question_id": "q_stakeholder_1",
       "why_needed": "責任所在が未確定だと実行後の説明責任が崩れるため。"
     },
     {
+      "assumption_if_unanswered": "当該不明点は高リスク側に倒して扱う",
+      "optional": false,
+      "priority": 2,
+      "question": "不明点『実際に外部閲覧があったか（ログ分析）』を検証するため、最短で確認できる事実は何か？",
+      "question_id": "q_unknown_1",
+      "why_needed": "未解消の不確実性を具体的な検証タスクへ分解するため。"
+    },
+    {
       "assumption_if_unanswered": "主要関係者全員に事前相談が必要と仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 3,
       "question": "関係者の同意・相談が必要な対象は誰か？",
       "question_id": "q_stakeholder_2",
       "why_needed": "外部性を受ける人の合意形成を先に設計するため。"
-    },
-    {
-      "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
-      "optional": false,
-      "priority": 1,
-      "question": "影響範囲は？（誰が何を失い、何を得るか）",
-      "question_id": "q_stakeholder_3",
-      "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
-    },
-    {
-      "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
-      "optional": false,
-      "priority": 1,
-      "question": "通知・説明の方法と期限は？",
-      "question_id": "q_stakeholder_4",
-      "why_needed": "合意形成を実務として実行可能にするため。"
     }
   ],
   "recommendation": {
@@ -316,7 +324,7 @@
         "metrics": {
           "days_to_deadline": 2,
           "options_planned": 2,
-          "questions_planned": 4,
+          "questions_planned": 5,
           "rules_fired": [
             "ETH_NO_OVERCLAIM_UNKNOWN",
             "ETH_STAKEHOLDER_CONSENT",
@@ -341,7 +349,7 @@
       {
         "ended_at": "2026-02-22T00:00:03Z",
         "metrics": {
-          "questions": 4
+          "questions": 5
         },
         "name": "question_layer",
         "started_at": "2026-02-22T00:00:02Z",

--- a/scenarios/case_010_expected.json
+++ b/scenarios/case_010_expected.json
@@ -270,22 +270,6 @@
       "why_needed": "優先順位がないと制約の再設計ができないため。"
     },
     {
-      "assumption_if_unanswered": "週末に2h×2回が確保できると仮定する",
-      "optional": false,
-      "priority": 2,
-      "question": "週5時間の内訳は？（平日/週末、連続時間の有無）",
-      "question_id": "q_conflict_2",
-      "why_needed": "実行可能な検証タスクへ分解するため。"
-    },
-    {
-      "assumption_if_unanswered": "許可が必要と仮定し、確認を最優先にする",
-      "optional": false,
-      "priority": 2,
-      "question": "現職の副業規定（許可制/禁止/競業）を確認した？",
-      "question_id": "q_conflict_3",
-      "why_needed": "実行可能性（法務・契約）を左右するため。"
-    },
-    {
       "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
       "optional": false,
       "priority": 1,
@@ -296,10 +280,26 @@
     {
       "assumption_if_unanswered": "主要関係者全員に事前相談が必要と仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "関係者の同意・相談が必要な対象は誰か？",
       "question_id": "q_stakeholder_2",
       "why_needed": "外部性を受ける人の合意形成を先に設計するため。"
+    },
+    {
+      "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
+      "optional": false,
+      "priority": 2,
+      "question": "影響範囲は？（誰が何を失い、何を得るか）",
+      "question_id": "q_stakeholder_3",
+      "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
+    },
+    {
+      "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
+      "optional": false,
+      "priority": 3,
+      "question": "通知・説明の方法と期限は？",
+      "question_id": "q_stakeholder_4",
+      "why_needed": "合意形成を実務として実行可能にするため。"
     }
   ],
   "recommendation": {

--- a/scenarios/case_011_expected.json
+++ b/scenarios/case_011_expected.json
@@ -235,7 +235,7 @@
     {
       "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "影響範囲は？（誰が何を失い、何を得るか）",
       "question_id": "q_stakeholder_3",
       "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
@@ -243,10 +243,18 @@
     {
       "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 2,
       "question": "通知・説明の方法と期限は？",
       "question_id": "q_stakeholder_4",
       "why_needed": "合意形成を実務として実行可能にするため。"
+    },
+    {
+      "assumption_if_unanswered": "当該不明点は高リスク側に倒して扱う",
+      "optional": false,
+      "priority": 3,
+      "question": "不明点『値上げ許容度の分布』を検証するため、最短で確認できる事実は何か？",
+      "question_id": "q_unknown_1",
+      "why_needed": "未解消の不確実性を具体的な検証タスクへ分解するため。"
     }
   ],
   "recommendation": {
@@ -300,7 +308,7 @@
         "ended_at": "2026-02-22T00:00:01Z",
         "metrics": {
           "options_planned": 2,
-          "questions_planned": 4,
+          "questions_planned": 5,
           "rules_fired": [
             "ETH_NO_OVERCLAIM_UNKNOWN",
             "ETH_STAKEHOLDER_CONSENT"
@@ -324,7 +332,7 @@
       {
         "ended_at": "2026-02-22T00:00:03Z",
         "metrics": {
-          "questions": 4
+          "questions": 5
         },
         "name": "question_layer",
         "started_at": "2026-02-22T00:00:02Z",

--- a/scenarios/case_012_expected.json
+++ b/scenarios/case_012_expected.json
@@ -263,36 +263,44 @@
   ],
   "questions": [
     {
-      "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
+      "assumption_if_unanswered": "期限は固定で延長不可と仮定する",
       "optional": false,
       "priority": 1,
+      "question": "期限の柔軟性はどこまであるか？（延長可否/最短再設定日）",
+      "question_id": "q_deadline_flex_1",
+      "why_needed": "時間圧の中で実行可能な計画へ再設計するため。"
+    },
+    {
+      "assumption_if_unanswered": "可逆で低リスクな最小範囲のみ許容とする",
+      "optional": false,
+      "priority": 1,
+      "question": "暫定対応として許容できる範囲は？（品質/コスト/対象範囲）",
+      "question_id": "q_temporary_scope_1",
+      "why_needed": "未知が残る状況でも被害を限定して前進するため。"
+    },
+    {
+      "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
+      "optional": false,
+      "priority": 2,
       "question": "この意思決定の決裁者（最終承認者）は誰か？",
       "question_id": "q_stakeholder_1",
       "why_needed": "責任所在が未確定だと実行後の説明責任が崩れるため。"
     },
     {
+      "assumption_if_unanswered": "当該不明点は高リスク側に倒して扱う",
+      "optional": false,
+      "priority": 2,
+      "question": "不明点『実際の影響ユーザー範囲』を検証するため、最短で確認できる事実は何か？",
+      "question_id": "q_unknown_1",
+      "why_needed": "未解消の不確実性を具体的な検証タスクへ分解するため。"
+    },
+    {
       "assumption_if_unanswered": "主要関係者全員に事前相談が必要と仮定する",
       "optional": false,
-      "priority": 1,
+      "priority": 3,
       "question": "関係者の同意・相談が必要な対象は誰か？",
       "question_id": "q_stakeholder_2",
       "why_needed": "外部性を受ける人の合意形成を先に設計するため。"
-    },
-    {
-      "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
-      "optional": false,
-      "priority": 1,
-      "question": "影響範囲は？（誰が何を失い、何を得るか）",
-      "question_id": "q_stakeholder_3",
-      "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
-    },
-    {
-      "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
-      "optional": false,
-      "priority": 1,
-      "question": "通知・説明の方法と期限は？",
-      "question_id": "q_stakeholder_4",
-      "why_needed": "合意形成を実務として実行可能にするため。"
     }
   ],
   "recommendation": {
@@ -337,7 +345,7 @@
         "metrics": {
           "days_to_deadline": -6,
           "options_planned": 2,
-          "questions_planned": 4,
+          "questions_planned": 5,
           "rules_fired": [
             "ETH_NO_OVERCLAIM_UNKNOWN",
             "ETH_STAKEHOLDER_CONSENT"
@@ -361,7 +369,7 @@
       {
         "ended_at": "2026-02-22T00:00:03Z",
         "metrics": {
-          "questions": 4
+          "questions": 5
         },
         "name": "question_layer",
         "started_at": "2026-02-22T00:00:02Z",

--- a/tests/test_questions_v2.py
+++ b/tests/test_questions_v2.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pocore.engines import question_v1
+
+
+def test_questions_v2_prioritizes_deadline_and_unknowns_with_cap() -> None:
+    case = {"unknowns": [f"u{i}" for i in range(1, 8)]}
+    features = {
+        "unknowns_count": 7,
+        "unknowns_items": [f"u{i}" for i in range(1, 8)],
+        "days_to_deadline": 1,
+        "stakeholders_count": 3,
+    }
+
+    questions = question_v1.generate(case, short_id="case_custom", features=features)
+
+    assert len(questions) == 5
+    assert [q["question_id"] for q in questions] == [
+        "q_deadline_flex_1",
+        "q_temporary_scope_1",
+        "q_stakeholder_1",
+        "q_unknown_1",
+        "q_stakeholder_2",
+    ]
+    assert [q["priority"] for q in questions] == [1, 1, 2, 2, 3]
+
+
+def test_questions_v2_converts_unknown_items_deterministically() -> None:
+    case = {
+        "unknowns": ["法務確認", "費用見積", "運用体制"],
+    }
+    features = {
+        "unknowns_count": 3,
+        "unknowns_items": ["法務確認", "費用見積", "運用体制"],
+        "days_to_deadline": 10,
+        "stakeholders_count": 1,
+    }
+
+    questions = question_v1.generate(case, short_id="case_custom", features=features)
+
+    assert [q["question_id"] for q in questions] == [
+        "q_unknown_1",
+        "q_unknown_2",
+        "q_unknown_3",
+        "q_unknowns_bundle_1",
+    ]
+    assert questions[0]["question"] == (
+        "不明点『法務確認』を検証するため、最短で確認できる事実は何か？"
+    )
+    assert questions[3]["priority"] == 2

--- a/tests/test_responsibility_stakeholders.py
+++ b/tests/test_responsibility_stakeholders.py
@@ -57,4 +57,4 @@ def test_questions_add_high_priority_stakeholder_prompts() -> None:
         "q_stakeholder_3",
         "q_stakeholder_4",
     ]
-    assert all(q["priority"] == 1 for q in questions)
+    assert [q["priority"] for q in questions] == [1, 1, 2, 2]


### PR DESCRIPTION
### Motivation

- Add a deterministic, feature-driven Questions v2 layer that prioritizes questions based on `unknowns_count`, `unknowns_items`, `days_to_deadline`, and `stakeholders_count` so the system surfaces progress-enabling clarifying questions under uncertainty and time pressure. 
- Ensure the change follows existing constraints: no new `short_id` branching, no interference with recommendation arbitration, no schema/test weakening, and preserve determinism for golden tests.

### Description

- Implemented feature-driven scoring/ranking in `src/pocore/engines/question_v1.py` with constants and helpers (`MAX_QUESTIONS`, `DEADLINE_NEAR_DAYS`, scoring, `_append_candidate`, `_is_deadline_near`) and deterministic sort by `(-_score, question_id)`. 
- Added deadline-high-priority prompts `q_deadline_flex_1` and `q_temporary_scope_1`, conversion of `unknowns_items` → `q_unknown_{n}`, and a deterministic top-5 cap with a fixed `priority` mapping for output. 
- Added tests `tests/test_questions_v2.py` and updated `tests/test_responsibility_stakeholders.py` expectations to match the new priority mapping. 
- Updated documentation/traceability: inserted `REQ-QST-001` into `docs/spec/requirements_v1.md` and added mappings (rule/question ids) to `docs/traceability/traceability_v1.yaml`, and regenerated affected scenario golden files using the provided deterministic script (`scripts/regenerate_golden.py --all --write`) (frozen goldens were preserved). 

### Testing

- Ran the new unit tests: `pytest -q tests/test_questions_v2.py` and `pytest -q tests/test_responsibility_stakeholders.py`, and traceability checks `pytest -q tests/test_traceability.py`, all passed. 
- Regenerated golden outputs with `python scripts/regenerate_golden.py --all --write` and validated the changes were produced by the deterministic runner (no manual edits of expected files). 
- Executed the full test suite with `pytest -q`, which completed successfully in this environment (all tests passed, frozen goldens unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a282778d80832894feb5db67651a6b)