### PR TITLE
Add Two-Track planning rule analytics to Policy Lab report

### DIFF
--- a/docs/experiments/policy_lab.md
+++ b/docs/experiments/policy_lab.md
@@ -47,6 +47,16 @@ python scripts/policy_lab.py \
   - 機械可読。差分判定・ケース詳細・影響REQを含む
 - `policy_lab_report.md`:
   - 人間可読。概要とケース別差分を短く俯瞰
+  - compare時はTwo-Track Planの発火件数とplanning rule頻度上位も表示
+
+### planning summary（compare時）
+
+- `summary.two_track_rule_id`
+  - Two-Track Planの評価対象rule_id（既定: `PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN`）
+- `summary.two_track_triggered_cases`
+  - 上記rule_idが発火したケース数
+- `summary.planning_rule_frequency_top`
+  - planning rule_idの頻度分布（多い順・同率はrule_id昇順）
 
 ### impacted_requirements の意味
 

--- a/docs/experiments/policy_lab_experiment_template.md
+++ b/docs/experiments/policy_lab_experiment_template.md
@@ -1,0 +1,22 @@
+# Policy Lab Experiment Memo (Template)
+
+- Date:
+- Operator:
+- Purpose:
+- Command:
+  ```bash
+  python scripts/policy_lab.py --compare-baseline ...
+  ```
+
+## Key Results
+
+- changed_cases:
+- impacted_requirements (top):
+- two_track_rule_id:
+- two_track_triggered_cases:
+- planning_rule_frequency_top:
+
+## Notes
+
+- Interpretation:
+- Risks / Follow-ups:

--- a/tests/test_policy_lab.py
+++ b/tests/test_policy_lab.py
@@ -66,3 +66,11 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     assert result["meta"]["compare_baseline"] is True
     assert result["summary"]["changed_cases"] >= 1
     assert "REQ-ARB-001" in result["summary"]["impacted_requirements"]
+    assert result["summary"]["two_track_rule_id"] == "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN"
+    assert result["summary"]["two_track_triggered_cases"] >= 1
+    assert result["summary"]["planning_rule_frequency_top"]
+    assert result["summary"]["planning_rule_frequency_top"][0]["rule_id"]
+
+    md_text = Path(out["md"]).read_text(encoding="utf-8")
+    assert "planning two-track triggered cases" in md_text
+    assert "Planning rule frequency (top)" in md_text


### PR DESCRIPTION
### Motivation
- Enable Policy Lab to measure how often the Two-Track Plan planning rule fires and to surface the planning-rule frequency distribution alongside existing `impacted_requirements` so experimenters can judge plan-impact distribution. 
- Keep the change deterministic and traceable so it fits the existing policy-change review flow and does not modify any frozen golden files.

### Description
- Collect `planning_rules_fired` per case in `scripts/policy_lab.py` and aggregate planning metrics via a new `_planning_rules_summary()` helper. 
- Include in `result["summary"]` the keys `two_track_rule_id`, `two_track_triggered_cases`, and `planning_rule_frequency_top` (top-N frequency bucket of planning rule_ids). 
- Treat planning rules as part of baseline/variant diffs: add `planning_rules_fired` to `changed_fields` and include them in `rule_id` traceability lookups for `impacted_requirements`. 
- Render the planning summary in the Markdown report (`policy_lab_report.md`) with a short frequency table and a line showing the Two-Track triggered case count. 
- Updated docs and tests: extended `docs/experiments/policy_lab.md` with the new fields, added `docs/experiments/policy_lab_experiment_template.md` as an experiment memo template, and expanded `tests/test_policy_lab.py` to assert the new summary keys and Markdown contents.

### Testing
- Ran full test suite with `pytest -q`; an initial run produced a transient benchmark assertion failure (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`) but a re-run completed successfully. 
- Final test result: `pytest -q` passed with `3328 passed, 134 skipped`. 
- Unit test added: `tests/test_policy_lab.py` now verifies new `summary` keys and Markdown output and passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a283fdedd4832892d7f77cf22bde0c)