### PR TITLE
Add pairwise boundary golden scenarios for R5/R6

### DIFF
--- a/scenarios/case_014.yaml
+++ b/scenarios/case_014.yaml
@@ -1,0 +1,18 @@
+case_id: case_014_values_empty_deadline_near
+title: "価値軸空白のまま期限直前：最小未知で判断を整える"
+locale: ja-JP
+problem: "価値の優先順位を決めきれないまま、提出期限が目前に迫っている。安全に次の行動を決めたい。"
+context:
+  domain: "契約更新判断"
+  current_state: "選択肢は2つあるが評価軸が言語化できていない"
+constraints:
+  - "法令違反のリスクがある変更はしない"
+  - "既存顧客への説明責任を果たす"
+values: []
+deadline: "2026-02-21"
+stakeholders:
+  - name: "担当者本人"
+    role: "意思決定主体"
+    impact: "期限内の判断と説明責任を負う"
+unknowns:
+  - "どの価値を最優先に置くか"

--- a/scenarios/case_014_expected.json
+++ b/scenarios/case_014_expected.json
@@ -1,0 +1,342 @@
+{
+  "case_ref": {
+    "case_id": "case_014_values_empty_deadline_near",
+    "input_digest": "1b1e0d2ec9bbf439a71fd4f1d92ef5c8f8f259091232c844328963c24887ecbf",
+    "title": "価値軸空白のまま期限直前：最小未知で判断を整える"
+  },
+  "ethics": {
+    "guardrails": [
+      "不確実な事実を断言しない",
+      "意思決定主体をユーザーから奪わない",
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "価値軸が空のまま推奨を断言しない",
+      "価値軸を獲得する質問と手順を先に実施する"
+    ],
+    "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。",
+    "principles_used": [
+      "integrity",
+      "autonomy",
+      "nonmaleficence",
+      "justice",
+      "accountability"
+    ],
+    "tradeoffs": [
+      {
+        "between": [
+          "autonomy",
+          "integrity"
+        ],
+        "mitigation": "価値軸獲得の手続きを先に提示し、裁定は保留する",
+        "severity": "medium",
+        "tension": "選好の自由と断言回避の緊張"
+      }
+    ]
+  },
+  "meta": {
+    "created_at": "2026-02-22T00:00:00Z",
+    "deterministic": true,
+    "generator": {
+      "mode": "stub",
+      "name": "generator_stub",
+      "version": "0.1.0"
+    },
+    "pocore_version": "0.1.0",
+    "run_id": "case_014_expected_stub_compact_v1",
+    "schema_version": "1.0",
+    "seed": 0
+  },
+  "options": [
+    {
+      "action_plan": [
+        {
+          "rationale": "選択肢を固定し、価値軸を可視化する",
+          "step": "10分タイマーをセットし、候補価値（安定/成長/自由/関係性）から上位3つを選ぶ"
+        },
+        {
+          "rationale": "順序を固定して比較基準を作る",
+          "step": "上位3つを1位〜3位に並べ、『なぜ重要か』を各1文で記録する"
+        },
+        {
+          "rationale": "トレードオフを明文化し、後悔の理由を減らす",
+          "step": "最下位1つを『今回は優先しない価値』として明示する"
+        },
+        {
+          "rationale": "価値軸を行動に接続し、先延ばしを防ぐ",
+          "step": "次の一歩を1つ決める（24時間以内に実行できる行動に限定）"
+        },
+        {
+          "rationale": "見直し手順を先に定義して意思決定の質を保つ",
+          "step": "実行後に再評価する時刻をカレンダーへ固定する（例: 48時間後）"
+        }
+      ],
+      "cons": [
+        "進行が遅く感じる可能性"
+      ],
+      "description": "最小コストで試し、学びながら前進する。",
+      "ethics_review": {
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する",
+          "価値軸が空のまま推奨を断言しない"
+        ],
+        "confidence": "medium",
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "accountability"
+        ],
+        "tradeoffs": []
+      },
+      "feasibility": {
+        "confidence": "medium",
+        "effort": "low",
+        "timeline": "1-2 weeks"
+      },
+      "option_id": "opt_1",
+      "pros": [
+        "失敗コストを抑えられる"
+      ],
+      "responsibility_review": {
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium",
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "impact": "期限内の判断と説明責任を負う",
+            "name": "担当者本人",
+            "role": "意思決定主体"
+          }
+        ]
+      },
+      "risks": [
+        {
+          "mitigation": "検証項目を明文化する",
+          "risk": "検証不足",
+          "severity": "medium"
+        }
+      ],
+      "title": "案A：段階的に進める",
+      "uncertainty": {
+        "assumptions": [],
+        "known_unknowns": [],
+        "overall_level": "medium",
+        "reasons": []
+      }
+    },
+    {
+      "action_plan": [
+        {
+          "rationale": "選択肢を固定し、価値軸を可視化する",
+          "step": "10分タイマーをセットし、候補価値（安定/成長/自由/関係性）から上位3つを選ぶ"
+        },
+        {
+          "rationale": "順序を固定して比較基準を作る",
+          "step": "上位3つを1位〜3位に並べ、『なぜ重要か』を各1文で記録する"
+        },
+        {
+          "rationale": "トレードオフを明文化し、後悔の理由を減らす",
+          "step": "最下位1つを『今回は優先しない価値』として明示する"
+        },
+        {
+          "rationale": "価値軸を行動に接続し、先延ばしを防ぐ",
+          "step": "次の一歩を1つ決める（24時間以内に実行できる行動に限定）"
+        },
+        {
+          "rationale": "見直し手順を先に定義して意思決定の質を保つ",
+          "step": "実行後に再評価する時刻をカレンダーへ固定する（例: 48時間後）"
+        }
+      ],
+      "cons": [
+        "機会損失が起きる可能性"
+      ],
+      "description": "重要な不明点を埋めてから判断する。",
+      "ethics_review": {
+        "concerns": [
+          "不確実な事実を断言しない",
+          "前提と不確実性を明示する",
+          "価値軸が空のまま推奨を断言しない"
+        ],
+        "confidence": "medium",
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "accountability"
+        ],
+        "tradeoffs": []
+      },
+      "feasibility": {
+        "confidence": "high",
+        "effort": "low",
+        "timeline": "3-5 days"
+      },
+      "option_id": "opt_2",
+      "pros": [
+        "判断精度が上がる"
+      ],
+      "responsibility_review": {
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium",
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "impact": "期限内の判断と説明責任を負う",
+            "name": "担当者本人",
+            "role": "意思決定主体"
+          }
+        ]
+      },
+      "risks": [
+        {
+          "mitigation": "期限と判断条件を設定する",
+          "risk": "先延ばし",
+          "severity": "low"
+        }
+      ],
+      "title": "案B：情報収集してから決める",
+      "uncertainty": {
+        "assumptions": [],
+        "known_unknowns": [],
+        "overall_level": "medium",
+        "reasons": []
+      }
+    }
+  ],
+  "questions": [
+    {
+      "assumption_if_unanswered": "期限は固定で延長不可と仮定する",
+      "optional": false,
+      "priority": 1,
+      "question": "期限の柔軟性はどこまであるか？（延長可否/最短再設定日）",
+      "question_id": "q_deadline_flex_1",
+      "why_needed": "時間圧の中で実行可能な計画へ再設計するため。"
+    },
+    {
+      "assumption_if_unanswered": "可逆で低リスクな最小範囲のみ許容とする",
+      "optional": false,
+      "priority": 1,
+      "question": "暫定対応として許容できる範囲は？（品質/コスト/対象範囲）",
+      "question_id": "q_temporary_scope_1",
+      "why_needed": "未知が残る状況でも被害を限定して前進するため。"
+    },
+    {
+      "assumption_if_unanswered": "安定を優先する",
+      "optional": false,
+      "priority": 2,
+      "question": "最優先する価値は何？（例：安定、成長、自由、関係性）",
+      "question_id": "q_values_1",
+      "why_needed": "価値が定義されないと推奨が恣意的になるため。"
+    },
+    {
+      "assumption_if_unanswered": "可逆性を最優先し、不可逆な損失を避ける",
+      "optional": false,
+      "priority": 2,
+      "question": "この意思決定で『絶対に避けたい結果』は何か？",
+      "question_id": "q_values_axis_1",
+      "why_needed": "回避条件を先に定義すると、価値軸の下限が安定するため。"
+    },
+    {
+      "assumption_if_unanswered": "生活安定と学習継続を両立した状態を成功とみなす",
+      "optional": false,
+      "priority": 3,
+      "question": "3か月後に『良い判断だった』と言える状態は何か？",
+      "question_id": "q_values_axis_2",
+      "why_needed": "短期の成功状態を定義しないと評価軸が曖昧になるため。"
+    }
+  ],
+  "recommendation": {
+    "confidence": "high",
+    "missing_info": [
+      "価値の優先順位"
+    ],
+    "next_steps": [
+      "価値の優先順位を仮決めする"
+    ],
+    "reason": "価値観（評価軸）が未確定なため、推奨は恣意的になる。",
+    "status": "no_recommendation"
+  },
+  "responsibility": {
+    "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは説明可能な判断材料を整理する。",
+    "consent_considerations": [],
+    "decision_owner": "user",
+    "stakeholders": [
+      {
+        "impact": "期限内の判断と説明責任を負う",
+        "name": "担当者本人",
+        "role": "意思決定主体"
+      }
+    ]
+  },
+  "trace": {
+    "steps": [
+      {
+        "ended_at": "2026-02-22T00:00:01Z",
+        "metrics": {
+          "days_to_deadline": -1,
+          "options_planned": 2,
+          "questions_planned": 5,
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_VALUES_EMPTY_CLARIFICATION"
+          ],
+          "stakeholders_count": 1,
+          "unknowns_count": 1
+        },
+        "name": "parse_input",
+        "started_at": "2026-02-22T00:00:00Z",
+        "summary": "入力を正規化し、特徴量（features）を抽出した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:02Z",
+        "metrics": {
+          "options": 2
+        },
+        "name": "generate_options",
+        "started_at": "2026-02-22T00:00:01Z",
+        "summary": "特徴量に基づいて選択肢を生成した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:03Z",
+        "metrics": {
+          "questions": 5
+        },
+        "name": "question_layer",
+        "started_at": "2026-02-22T00:00:02Z",
+        "summary": "不足情報を補う問いを生成した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:04Z",
+        "metrics": {
+          "arbitration_code": "NO_VALUES",
+          "policy_snapshot": {
+            "TIME_PRESSURE_DAYS": -4,
+            "UNKNOWN_BLOCK": 4
+          },
+          "rules_fired": [
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_VALUES_EMPTY_CLARIFICATION"
+          ],
+          "rules_fired_planning": [
+            "PLAN_VALUES_CLARIFICATION_PACK_V1"
+          ]
+        },
+        "name": "compose_output",
+        "started_at": "2026-02-22T00:00:03Z",
+        "summary": "推奨・反証・代替案を含む出力を組み立てた"
+      }
+    ],
+    "version": "1.0"
+  },
+  "uncertainty": {
+    "assumptions": [
+      "提示された制約が正しい"
+    ],
+    "known_unknowns": [
+      "どの価値を最優先に置くか"
+    ],
+    "overall_level": "low",
+    "reasons": [
+      "入力情報が比較的揃っている"
+    ]
+  }
+}

--- a/scenarios/case_015.yaml
+++ b/scenarios/case_015.yaml
@@ -1,0 +1,27 @@
+case_id: case_015_constraint_conflict_multi_stakeholders
+title: "制約競合と関係者複数：実行条件の再設計"
+locale: ja-JP
+problem: "改善施策を急ぎたいが、時間制約が矛盾し、複数関係者への影響も大きい。"
+context:
+  domain: "業務改善プロジェクト"
+  current_state: "施策実行の要請は強いが、投入可能時間と要件が噛み合っていない"
+constraints:
+  - "施策には週15時間以上を確保する"
+  - "現行業務の都合で追加投入は週6時間以内"
+  - "収入を落とせない"
+  - "現職は継続する"
+values:
+  - "説明責任"
+  - "実現可能性"
+stakeholders:
+  - name: "プロジェクト責任者"
+    role: "提案者"
+    impact: "成果責任と進捗説明責任を負う"
+  - name: "実行チーム"
+    role: "実務担当"
+    impact: "工数配分と運用品質に影響を受ける"
+  - name: "経営層"
+    role: "承認候補"
+    impact: "投資判断と対外説明責任を負う"
+unknowns:
+  - "段階導入時の最小実行範囲"

--- a/scenarios/case_015_expected.json
+++ b/scenarios/case_015_expected.json
@@ -1,0 +1,417 @@
+{
+  "case_ref": {
+    "case_id": "case_015_constraint_conflict_multi_stakeholders",
+    "input_digest": "eee0faa39e0dcf02f4fa201a05477f501687e400c97d33bb3064762c7b981cd1",
+    "title": "制約競合と関係者複数：実行条件の再設計"
+  },
+  "ethics": {
+    "guardrails": [
+      "不確実な事実を断言しない",
+      "意思決定主体をユーザーから奪わない",
+      "推奨には反証と代替案を併記する",
+      "前提と不確実性を明示する",
+      "関係者への影響と同意を考慮する"
+    ],
+    "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。",
+    "principles_used": [
+      "integrity",
+      "autonomy",
+      "nonmaleficence",
+      "justice",
+      "accountability"
+    ],
+    "tradeoffs": [
+      {
+        "between": [
+          "autonomy",
+          "nonmaleficence"
+        ],
+        "mitigation": "期限・実験・ガードレールで両立を狙う",
+        "severity": "medium",
+        "tension": "速度と安全の緊張"
+      },
+      {
+        "between": [
+          "autonomy",
+          "justice"
+        ],
+        "mitigation": "関係者への影響を可視化し、同意可能な進め方を選ぶ",
+        "severity": "medium",
+        "tension": "自己決定と外部性/公正の緊張"
+      }
+    ]
+  },
+  "meta": {
+    "created_at": "2026-02-22T00:00:00Z",
+    "deterministic": true,
+    "generator": {
+      "mode": "stub",
+      "name": "generator_stub",
+      "version": "0.1.0"
+    },
+    "pocore_version": "0.1.0",
+    "run_id": "case_015_expected_stub_compact_v1",
+    "schema_version": "1.0",
+    "seed": 0
+  },
+  "options": [
+    {
+      "action_plan": [
+        {
+          "step": "矛盾している制約を1枚に書き出し、どれを緩められるか順位づけする"
+        },
+        {
+          "step": "『週5時間』で成立する最小スコープ（検証実験）に縮退する"
+        },
+        {
+          "step": "時間を増やす手段（業務調整/家事外注/睡眠削減禁止）を検討する"
+        }
+      ],
+      "cons": [
+        "一部の願望（期限・投入時間）を修正する必要がある"
+      ],
+      "description": "矛盾している制約（要求:15h/週, 上限:6h/週）を可視化し、緩める順序と代替手段（交渉・外注・スコープ縮小）を決めて進める。",
+      "ethics_review": {
+        "concerns": [
+          "矛盾した制約を無視して断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium",
+        "principles_applied": [
+          "integrity",
+          "nonmaleficence",
+          "accountability",
+          "justice",
+          "autonomy"
+        ],
+        "tradeoffs": [
+          {
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "制約を可視化して破綻条件を先に潰す",
+            "severity": "high",
+            "tension": "野心と持続可能性の緊張"
+          },
+          {
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium",
+            "tension": "自己決定と外部性/公正の緊張"
+          }
+        ]
+      },
+      "feasibility": {
+        "confidence": "medium",
+        "effort": "medium",
+        "timeline": "2-4 weeks"
+      },
+      "option_id": "opt_1",
+      "pros": [
+        "破綻条件を先に潰せる"
+      ],
+      "responsibility_review": {
+        "accountability_notes": "RESP_STAKEHOLDER_CONSENT_CHECK: 決裁者が不明なため、最初に意思決定者を特定する。関係者への通知・同意・相談の実施と記録を前提に進める。",
+        "confidence": "high",
+        "decision_owner": "未確定（要確認）",
+        "stakeholders": [
+          {
+            "impact": "成果責任と進捗説明責任を負う",
+            "name": "プロジェクト責任者",
+            "role": "提案者"
+          },
+          {
+            "impact": "工数配分と運用品質に影響を受ける",
+            "name": "実行チーム",
+            "role": "実務担当"
+          },
+          {
+            "impact": "投資判断と対外説明責任を負う",
+            "name": "経営層",
+            "role": "承認候補"
+          }
+        ]
+      },
+      "risks": [
+        {
+          "mitigation": "時間・収入・健康の下限を守るルールを先に固定する",
+          "risk": "制約を無視して突っ込むと燃え尽きる",
+          "severity": "high"
+        }
+      ],
+      "title": "制約を再設計して“段階的に起業”する",
+      "uncertainty": {
+        "assumptions": [
+          "制約の一部は交渉・設計変更で動かせる"
+        ],
+        "known_unknowns": [
+          "時間を増やせる余地",
+          "副業規定",
+          "市場ニーズ"
+        ],
+        "overall_level": "high",
+        "reasons": [
+          "制約が矛盾しているため、前提の調整が必要"
+        ]
+      }
+    },
+    {
+      "action_plan": [
+        {
+          "step": "週5時間で回る検証メニューを作る（ヒアリング/LP/試作）"
+        },
+        {
+          "step": "8週間で『進める/止める』の判断基準を置く"
+        }
+      ],
+      "cons": [
+        "スピード感は落ちる"
+      ],
+      "description": "『半年で本格始動』をいったん外し、週5時間でできる検証（顧客ヒアリング/LP/プロト）に限定する。",
+      "ethics_review": {
+        "concerns": [
+          "矛盾した制約を無視して断言しない",
+          "前提と不確実性を明示する"
+        ],
+        "confidence": "medium",
+        "principles_applied": [
+          "integrity",
+          "nonmaleficence",
+          "accountability",
+          "justice",
+          "autonomy"
+        ],
+        "tradeoffs": [
+          {
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "制約を可視化して破綻条件を先に潰す",
+            "severity": "high",
+            "tension": "野心と持続可能性の緊張"
+          },
+          {
+            "between": [
+              "autonomy",
+              "justice"
+            ],
+            "mitigation": "関係者影響を可視化し、同意可能な線で意思決定する",
+            "severity": "medium",
+            "tension": "自己決定と外部性/公正の緊張"
+          }
+        ]
+      },
+      "feasibility": {
+        "confidence": "high",
+        "effort": "low",
+        "timeline": "8 weeks"
+      },
+      "option_id": "opt_2",
+      "pros": [
+        "現実制約に沿って継続しやすい"
+      ],
+      "responsibility_review": {
+        "accountability_notes": "RESP_STAKEHOLDER_CONSENT_CHECK: 決裁者が不明なため、最初に意思決定者を特定する。関係者への通知・同意・相談の実施と記録を前提に進める。",
+        "confidence": "high",
+        "decision_owner": "未確定（要確認）",
+        "stakeholders": [
+          {
+            "impact": "成果責任と進捗説明責任を負う",
+            "name": "プロジェクト責任者",
+            "role": "提案者"
+          },
+          {
+            "impact": "工数配分と運用品質に影響を受ける",
+            "name": "実行チーム",
+            "role": "実務担当"
+          },
+          {
+            "impact": "投資判断と対外説明責任を負う",
+            "name": "経営層",
+            "role": "承認候補"
+          }
+        ]
+      },
+      "risks": [
+        {
+          "mitigation": "成果指標（ヒアリング件数等）を週単位で置く",
+          "risk": "進捗が遅くモチベが折れる",
+          "severity": "medium"
+        }
+      ],
+      "title": "期限目標を下げ、検証に縮退する",
+      "uncertainty": {
+        "assumptions": [
+          "週5時間は確保できる"
+        ],
+        "known_unknowns": [
+          "顧客の反応",
+          "継続可能性"
+        ],
+        "overall_level": "medium",
+        "reasons": [
+          "市場ニーズが未検証"
+        ]
+      }
+    }
+  ],
+  "questions": [
+    {
+      "assumption_if_unanswered": "健康と収入を最優先と仮定する",
+      "optional": false,
+      "priority": 1,
+      "question": "矛盾している制約のうち、絶対に守るのはどれ？（時間/収入/健康/期限など）",
+      "question_id": "q_conflict_1",
+      "why_needed": "優先順位がないと制約の再設計ができないため。"
+    },
+    {
+      "assumption_if_unanswered": "決裁者は未確定として判断を保留する",
+      "optional": false,
+      "priority": 1,
+      "question": "この意思決定の決裁者（最終承認者）は誰か？",
+      "question_id": "q_stakeholder_1",
+      "why_needed": "責任所在が未確定だと実行後の説明責任が崩れるため。"
+    },
+    {
+      "assumption_if_unanswered": "主要関係者全員に事前相談が必要と仮定する",
+      "optional": false,
+      "priority": 2,
+      "question": "関係者の同意・相談が必要な対象は誰か？",
+      "question_id": "q_stakeholder_2",
+      "why_needed": "外部性を受ける人の合意形成を先に設計するため。"
+    },
+    {
+      "assumption_if_unanswered": "不利益が大きい側を保護する案を優先する",
+      "optional": false,
+      "priority": 2,
+      "question": "影響範囲は？（誰が何を失い、何を得るか）",
+      "question_id": "q_stakeholder_3",
+      "why_needed": "便益と不利益の配分を記録し、公正性を検証するため。"
+    },
+    {
+      "assumption_if_unanswered": "文書通知を48時間以内に実施すると仮定する",
+      "optional": false,
+      "priority": 3,
+      "question": "通知・説明の方法と期限は？",
+      "question_id": "q_stakeholder_4",
+      "why_needed": "合意形成を実務として実行可能にするため。"
+    }
+  ],
+  "recommendation": {
+    "alternatives": [
+      {
+        "option_id": "opt_2",
+        "when_to_choose": "期限目標を下げ、週5時間で検証に縮退したい場合"
+      }
+    ],
+    "confidence": "medium",
+    "counter": "制約の調整ができない場合、目標（期限/投入時間）を下げる必要がある。",
+    "reason": "制約が矛盾している状態では、どの案も破綻しやすい。まず制約を再設計してから進めるべき。",
+    "recommended_option_id": "opt_1",
+    "status": "recommended"
+  },
+  "responsibility": {
+    "accountability_notes": "RESP_STAKEHOLDER_CONSENT_CHECK: 決裁者/意思決定者が未確定なら先に確定する。RESP_IMPACT_SCOPE: 外部性があるため、通知・同意・相談の結果と合意事項を記録する。",
+    "consent_considerations": [
+      "収入への影響（減収リスク）を明示し、必要なら支援/予備費を検討する",
+      "RESP_STAKEHOLDER_CONSENT_CHECK: 決裁者を特定し、承認権限を確認する",
+      "RESP_STAKEHOLDER_CONSENT_CHECK: 影響を受ける関係者への通知・同意・相談の要否を確認する",
+      "RESP_IMPACT_SCOPE: 影響範囲（誰が何を得る/失うか）と合意内容を記録する",
+      "RESP_IMPACT_SCOPE: コミュニケーション手段と期限を決め、実施ログを残す"
+    ],
+    "decision_owner": "未確定（要確認）",
+    "stakeholders": [
+      {
+        "impact": "成果責任と進捗説明責任を負う",
+        "name": "プロジェクト責任者",
+        "role": "提案者"
+      },
+      {
+        "impact": "工数配分と運用品質に影響を受ける",
+        "name": "実行チーム",
+        "role": "実務担当"
+      },
+      {
+        "impact": "投資判断と対外説明責任を負う",
+        "name": "経営層",
+        "role": "承認候補"
+      }
+    ]
+  },
+  "trace": {
+    "steps": [
+      {
+        "ended_at": "2026-02-22T00:00:01Z",
+        "metrics": {
+          "constraint_conflict": true,
+          "options_planned": 2,
+          "questions_planned": 5,
+          "rules_fired": [
+            "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ],
+          "stakeholders_count": 3,
+          "unknowns_count": 1
+        },
+        "name": "parse_input",
+        "started_at": "2026-02-22T00:00:00Z",
+        "summary": "入力を正規化し、特徴量（features）を抽出した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:02Z",
+        "metrics": {
+          "options": 2
+        },
+        "name": "generate_options",
+        "started_at": "2026-02-22T00:00:01Z",
+        "summary": "特徴量に基づいて選択肢を生成した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:03Z",
+        "metrics": {
+          "questions": 5
+        },
+        "name": "question_layer",
+        "started_at": "2026-02-22T00:00:02Z",
+        "summary": "不足情報を補う問いを生成した"
+      },
+      {
+        "ended_at": "2026-02-22T00:00:04Z",
+        "metrics": {
+          "arbitration_code": "CONSTRAINT_CONFLICT",
+          "policy_snapshot": {
+            "TIME_PRESSURE_DAYS": -4,
+            "UNKNOWN_BLOCK": 4
+          },
+          "rules_fired": [
+            "ETH_CONSTRAINT_CONFLICT_DISCLOSURE",
+            "ETH_NO_OVERCLAIM_UNKNOWN",
+            "ETH_STAKEHOLDER_CONSENT"
+          ]
+        },
+        "name": "compose_output",
+        "started_at": "2026-02-22T00:00:03Z",
+        "summary": "推奨・反証・代替案を含む出力を組み立てた"
+      }
+    ],
+    "version": "1.0"
+  },
+  "uncertainty": {
+    "assumptions": [
+      "健康と生活維持は下限として守る"
+    ],
+    "known_unknowns": [
+      "段階導入時の最小実行範囲"
+    ],
+    "overall_level": "high",
+    "reasons": [
+      "制約が矛盾している"
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation

- Add deterministic golden examples that exercise pairwise boundary conditions around deadline/values and constraint/stakeholder interactions to strengthen coverage for R5/R6.
- Ensure these cases are captured as executable specifications (goldens) so the E2E contract and feature-driven ruleset remain testable and auditable.

### Description

- Added two scenario inputs: `scenarios/case_014.yaml` (values_empty + near deadline with minimal unknowns) and `scenarios/case_015.yaml` (constraint_conflict + multiple stakeholders). 
- Generated deterministic expected outputs with `scripts/regenerate_golden.py --case case_014 --case case_015 --write`, producing `scenarios/case_014_expected.json` and `scenarios/case_015_expected.json` without manual editing. 
- Extended `tests/test_golden_coverage.py` to (a) include `values_empty` and `constraint_conflict` in its diagnostic lines and (b) add two new assertions that a golden exists for `values_empty && days_to_deadline <= 1` and for `constraint_conflict && stakeholders_count >= 2`.
- No changes were made to recommendation/arbitration policy logic and no `if short_id == ...` case-branching was introduced; this remains feature-driven and deterministic.

### Testing

- Regenerated goldens with `python scripts/regenerate_golden.py --case case_014 --case case_015 --write` and saved both expected files successfully. (succeeded)
- Ran `pytest -q tests/test_golden_coverage.py tests/test_golden_e2e.py` and observed all tests in those modules passing. (succeeded)
- Ran full test suite with `pytest -q` and observed `3357 passed, 134 skipped`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2990dc7388328ac2ebe95f2cf5bc6)