### PR TITLE
Expand Policy Lab reporting for values/conflict rule packs

### DIFF
--- a/docs/traceability/traceability_v1.yaml
+++ b/docs/traceability/traceability_v1.yaml
@@ -203,6 +203,20 @@ requirements:
         value: q_unknown_1
 
 
+  - id: REQ-CONSTRAINT
+    principles: [P-ACC-001, P-INT-001, P-NMH-001]
+    adrs: [docs/adr/0008-ethics-guardrails-v1-non-interference.md]
+    tests:
+      - tests/test_features.py::test_constraint_conflict_detects_contradictory_weekly_hours
+      - tests/test_golden_e2e.py::test_constraint_conflict_triggers_recommendation
+    code_refs:
+      - kind: module
+        value: src/pocore/utils.py
+      - kind: arbitration_code
+        value: CONSTRAINT_CONFLICT
+      - kind: rule_id
+        value: ETH_CONSTRAINT_CONFLICT_DISCLOSURE
+
   - id: REQ-VALUES-001
     principles: [P-ACC-001, P-INT-001, P-NMH-001]
     adrs: [docs/adr/0014-values-clarification-pack-v1.md]

--- a/tests/test_policy_lab.py
+++ b/tests/test_policy_lab.py
@@ -66,6 +66,8 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     assert result["meta"]["compare_baseline"] is True
     assert result["summary"]["changed_cases"] >= 1
     assert "REQ-ARB-001" in result["summary"]["impacted_requirements"]
+    assert "REQ-VALUES-001" in result["summary"]["impacted_requirements"]
+    assert "REQ-CONSTRAINT" in result["summary"]["impacted_requirements"]
     assert result["summary"]["two_track_rule_id"] == "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN"
     assert result["summary"]["two_track_triggered_cases"] >= 1
     assert result["summary"]["planning_rule_frequency_top"]
@@ -74,3 +76,10 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     md_text = Path(out["md"]).read_text(encoding="utf-8")
     assert "planning two-track triggered cases" in md_text
     assert "Planning rule frequency (top)" in md_text
+    assert "Values Pack rule frequency" in md_text
+    assert "Conflict Pack baseline delta (--compare-baseline)" in md_text
+
+    assert result["summary"]["values_pack"]["variant"]["rule_case_counts"]
+    assert result["summary"]["conflict_pack"]["variant"]["rule_case_counts"]
+    assert result["summary"]["values_pack"]["delta"]["rule_deltas"]
+    assert result["summary"]["conflict_pack"]["delta"]["rule_deltas"]


### PR DESCRIPTION
### Motivation
- Provide measurable metrics for values/conflict rule packs (R5/R6) so the lab can report firing counts and distribution per `rule_id` across scenarios.  
- Surface baseline-vs-variant deltas when `--compare-baseline` is used to make increases/decreases explicit in JSON and Markdown.  
- Improve traceability so `impacted_requirements` can pick up `REQ-VALUES-001` and a new `REQ-CONSTRAINT` mapping from `traceability_v1.yaml` while preserving determinism and not changing frozen goldens.

### Description
- Added rule-pack constants and functions: `VALUES_PACK_RULE_IDS`/`CONFLICT_PACK_RULE_IDS`, `_rule_pack_summary` and `_rule_pack_delta`, and wired them into `run_policy_lab` to produce `summary.values_pack` and `summary.conflict_pack` (baseline/variant/delta).  
- Extended `_case_record` to include `question_ids` and extended `_render_markdown` to render the new pack frequency and delta sections in the report MD.  
- Made `_load_traceability_index` generic by indexing all `code_refs.kind` values dynamically and updated `_diff_case` to consult `question_id` and to use safe `get(...)` lookups for trace kinds.  
- Added `REQ-CONSTRAINT` block to `docs/traceability/traceability_v1.yaml` mapping constraint/arbitration/rule evidence, and updated `tests/test_policy_lab.py` to assert the new summary fields, markdown sections, and impacted requirement IDs (`REQ-VALUES-001`, `REQ-CONSTRAINT`).

### Testing
- Ran `pytest -q tests/test_policy_lab.py` and the file-level tests passed (`2 passed`).  
- Ran the full suite with `pytest -q` and the repository tests succeeded (`3341 passed, 134 skipped`).  
- Verified `python -m py_compile scripts/policy_lab.py` succeeded and executed `python scripts/policy_lab.py --compare-baseline --output-dir reports/policy_lab_example` to generate a sample JSON/MD report showing the new `values_pack`/`conflict_pack` outputs and deltas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2991fc6dc8328b35291dc2b44beb7)