### PR TITLE
Enhance Policy Lab pack metrics and traceability summaries

### DIFF
--- a/tests/test_policy_lab.py
+++ b/tests/test_policy_lab.py
@@ -66,7 +66,9 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     assert result["meta"]["compare_baseline"] is True
     assert result["summary"]["changed_cases"] >= 1
     assert "REQ-ARB-001" in result["summary"]["impacted_requirements"]
+    assert "REQ-ARB" in result["summary"]["impacted_requirements"]
     assert "REQ-VALUES-001" in result["summary"]["impacted_requirements"]
+    assert "REQ-VALUES" in result["summary"]["impacted_requirements"]
     assert "REQ-CONSTRAINT" in result["summary"]["impacted_requirements"]
     assert result["summary"]["two_track_rule_id"] == "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN"
     assert result["summary"]["two_track_triggered_cases"] >= 1
@@ -83,3 +85,6 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     assert result["summary"]["conflict_pack"]["variant"]["rule_case_counts"]
     assert result["summary"]["values_pack"]["delta"]["rule_deltas"]
     assert result["summary"]["conflict_pack"]["delta"]["rule_deltas"]
+    assert result["summary"]["values_pack"]["delta_summary"]
+    assert result["summary"]["conflict_pack"]["delta_summary"]
+    assert "change summary:" in md_text


### PR DESCRIPTION
### Motivation

- Enable measurement of values/conflict rule firing frequency and make baseline diffs easy to interpret for policy experiments. 
- Surface broader requirement identifiers (e.g. `REQ-VALUES` / `REQ-CONSTRAINT`) in impacted requirement reverse-lookups to improve traceability from rule/arbitration firing to requirements.  
- Keep outputs deterministic and CI-safe while adding compact summaries for baseline comparison.

### Description

- Add requirement aliasing in `_load_traceability_index()` so each requirement ID (e.g. `REQ-VALUES-001`) also registers a normalized family alias (e.g. `REQ-VALUES`) for reverse lookup.  
- Compute pack delta summaries via a new `_rule_pack_delta_summary()` and attach `delta_summary` (`increased_rules`, `decreased_rules`, `unchanged_rules`) to both `values_pack` and `conflict_pack` in the JSON `summary`.  
- Render a concise change-summary line (`change summary: +X / -Y / =Z`) into the markdown report for each pack when `--compare-baseline` is used.  
- Update `tests/test_policy_lab.py` to assert the presence of aliased impacted requirement IDs, the new `delta_summary` fields, and the markdown `change summary:` line.

### Testing

- Ran `pytest -q tests/test_policy_lab.py` which passed (`2 passed`).
- Ran full test-suite `pytest -q` which completed successfully (`3357 passed, 134 skipped`).
- Executed `python scripts/policy_lab.py --compare-baseline --output-dir reports/policy_lab_example` and verified the generated report includes `delta_summary` entries and impacted requirements that include aliases such as `REQ-VALUES` and `REQ-CONSTRAINT` (example markdown lines: `- impacted_requirements: ... REQ-CONSTRAINT ... REQ-VALUES` and `- change summary: +0 / -0 / =3`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29f8adb448328915a808299a9111a)