### PR TITLE
Add Decision Session v1 answers contract: docs, schema, and validation tests

### DIFF
--- a/docs/spec/session_answers_schema_v1.json
+++ b/docs/spec/session_answers_schema_v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pocore.local/spec/session_answers_schema_v1.json",
+  "title": "Decision Session Answers v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "case_ref", "answers", "patch"],
+  "properties": {
+    "version": {"type": "string", "const": "1.0"},
+    "case_ref": {"type": "string", "minLength": 1},
+    "answers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["question_id", "answer_text", "applied_patch_paths"],
+        "properties": {
+          "question_id": {"type": "string", "minLength": 1},
+          "answer_text": {"type": "string", "minLength": 1},
+          "applied_patch_paths": {
+            "type": "array",
+            "items": {"type": "string", "pattern": "^/"},
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "patch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["op", "path", "value"],
+        "properties": {
+          "op": {
+            "type": "string",
+            "enum": ["add", "remove", "replace", "move", "copy", "test"]
+          },
+          "path": {"type": "string", "pattern": "^/"},
+          "value": {}
+        }
+      }
+    }
+  }
+}

--- a/docs/spec/session_answers_v1.md
+++ b/docs/spec/session_answers_v1.md
@@ -1,0 +1,78 @@
+# Decision Session v1: 回答入力契約（session_answers_v1）
+
+この文書は、Decision Session v1 における「回答入力」の固定契約を定義する。
+
+- 対応スキーマ: `docs/spec/session_answers_schema_v1.json`
+- 目的: 質問回答と、その回答を反映する JSON Patch を決定的に受け渡す
+
+## 1. トップレベル構造
+
+トップレベルは次の4キーを必須とする。
+
+- `version`: 契約バージョン文字列（`"1.0"` 固定）
+- `case_ref`: 対象ケース参照（`case_id` など）
+- `answers`: 質問ごとの回答配列
+- `patch`: RFC6902 JSON Patch 操作配列
+
+```json
+{
+  "version": "1.0",
+  "case_ref": "case_012",
+  "answers": [
+    {
+      "question_id": "q_budget_limit",
+      "answer_text": "初期予算は月5万円までです。",
+      "applied_patch_paths": ["/constraints/budget", "/notes/0"]
+    }
+  ],
+  "patch": [
+    { "op": "replace", "path": "/constraints/budget", "value": "<=50000 JPY/month" },
+    { "op": "add", "path": "/notes/0", "value": "予算上限: 月5万円" }
+  ]
+}
+```
+
+## 2. answers[]
+
+`answers[]` の各要素は以下を必須とする。
+
+- `question_id` (`string`): 質問ID
+- `answer_text` (`string`): ユーザー回答本文
+- `applied_patch_paths` (`string[]`): この回答が影響する JSON Pointer の配列
+
+制約:
+
+- `question_id` は1文字以上
+- `answer_text` は1文字以上
+- `applied_patch_paths` は空配列可、各要素は `/` で始まる JSON Pointer 形式
+
+## 3. patch[]
+
+`patch[]` は RFC6902 互換の操作配列。
+
+各操作オブジェクトで以下を必須とする。
+
+- `op`: `add | remove | replace | move | copy | test`
+- `path`: JSON Pointer（`/` で開始）
+- `value`: 操作値（JSON値）
+
+注記:
+
+- 本契約では入力の単純化のため `value` を常に要求する。
+- `from` を使う操作（`move`/`copy`）は v1 では受け付けない。
+
+## 4. YAML入力例
+
+```yaml
+version: "1.0"
+case_ref: "case_012"
+answers:
+  - question_id: "q_budget_limit"
+    answer_text: "初期予算は月5万円までです。"
+    applied_patch_paths:
+      - "/constraints/budget"
+patch:
+  - op: "replace"
+    path: "/constraints/budget"
+    value: "<=50000 JPY/month"
+```

--- a/tests/fixtures/session_answers_valid.yaml
+++ b/tests/fixtures/session_answers_valid.yaml
@@ -1,0 +1,15 @@
+version: "1.0"
+case_ref: "case_012"
+answers:
+  - question_id: "q_budget_limit"
+    answer_text: "初期予算は月5万円までです。"
+    applied_patch_paths:
+      - "/constraints/budget"
+      - "/notes/0"
+patch:
+  - op: "replace"
+    path: "/constraints/budget"
+    value: "<=50000 JPY/month"
+  - op: "add"
+    path: "/notes/0"
+    value: "予算上限: 月5万円"

--- a/tests/test_session_answers_schema.py
+++ b/tests/test_session_answers_schema.py
@@ -1,0 +1,55 @@
+"""session_answers_v1 schema contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT_DIR / "docs" / "spec" / "session_answers_schema_v1.json"
+VALID_YAML_PATH = ROOT_DIR / "tests" / "fixtures" / "session_answers_valid.yaml"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"{path} must contain a mapping at top-level"
+    return data
+
+
+def test_session_answers_schema_file_exists() -> None:
+    assert SCHEMA_PATH.exists(), f"Schema not found: {SCHEMA_PATH}"
+
+
+def test_session_answers_yaml_conforms_to_schema() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    payload = _load_yaml(VALID_YAML_PATH)
+    validator = Draft202012Validator(schema)
+
+    errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
+    if errors:
+        details = "\n".join(
+            f"- {err.message} at path={list(err.path)} schema_path={list(err.schema_path)}"
+            for err in errors
+        )
+        pytest.fail(f"Schema validation failed:\n{details}")
+
+
+def test_session_answers_rejects_missing_required_field() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    payload = _load_yaml(VALID_YAML_PATH)
+    del payload["patch"]
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
+    assert errors, "Expected validation errors when patch is missing"


### PR DESCRIPTION
### Motivation
- Define and lock a strict, deterministic input contract for Decision Session v1 answers so question responses and their corresponding JSON Patch operations can be exchanged reliably.
- Ensure the contract requires RFC6902-style patch operations and disallows unexpected fields to avoid drift and non-determinism.

### Description
- Added `docs/spec/session_answers_v1.md` documenting the contract (top-level `version`, `case_ref`, `answers`, `patch`) and providing YAML/JSON examples.
- Added `docs/spec/session_answers_schema_v1.json` implementing a strict JSON Schema that enforces `version: "1.0"`, `additionalProperties: false`, `answers[]` with required `question_id`/`answer_text`/`applied_patch_paths`, and `patch[]` entries requiring `op`/`path`/`value` with `op` limited to RFC6902 verbs.
- Added `tests/test_session_answers_schema.py` which loads a YAML fixture and validates it against the schema and includes a negative test that removing the required `patch` field fails validation.
- Added `tests/fixtures/session_answers_valid.yaml` as a canonical valid payload used by the tests and committed alongside the schema and docs.

### Testing
- Ran the full test suite with `pytest -q` and observed the test run complete successfully with `3360 passed, 134 skipped`.
- The new `tests/test_session_answers_schema.py` passed as part of that run, validating the sample YAML against `docs/spec/session_answers_schema_v1.json`.
- No existing frozen golden files were modified and no test or schema weakening was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a5b431b08328a50902d3e73f6215)