### PR TITLE
Add deterministic Decision Session v1 replay and E2E golden coverage

### DIFF
--- a/docs/spec/requirements_v1.md
+++ b/docs/spec/requirements_v1.md
@@ -63,3 +63,7 @@
   - recommendation 裁定（status / recommended_option_id / arbitration_code）には介入しないこと。
   - Principles: P-ACC-001, P-INT-001, P-NMH-001
 
+
+- **REQ-SESSION-001: session_replay E2E golden 契約**
+  - session answers（JSON Patch）を適用した再実行結果が、session golden expected JSON と一致すること。
+  - Principles: P-ACC-001, P-INT-001

--- a/docs/traceability/traceability_v1.yaml
+++ b/docs/traceability/traceability_v1.yaml
@@ -13,6 +13,8 @@ principles:
       - REQ-QST-001
       - REQ-PLAN-001
       - REQ-VALUES-001
+      - REQ-SESSION-001
+      - REQ-SESSION-001
   - id: P-INT-001
     mapped_requirements:
       - REQ-DET-001
@@ -256,3 +258,14 @@ requirements:
         value: PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN
       - kind: rule_id
         value: PLAN_VALUES_CLARIFICATION_PACK_V1
+
+  - id: REQ-SESSION-001
+    principles: [P-ACC-001, P-INT-001]
+    adrs: [docs/adr/0002-golden-diff-contract.md]
+    tests:
+      - tests/test_session_replay_e2e.py::test_session_replay_matches_expected_json
+    code_refs:
+      - kind: module
+        value: src/pocore/runner.py
+      - kind: module
+        value: tests/test_session_replay_e2e.py

--- a/sessions/session_001_answers.yaml
+++ b/sessions/session_001_answers.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+case_ref: "session_001_case"
+answers:
+  - question_id: "q_unknown_1"
+    answer_text: "負荷試験でピーク時エラー率は0.08%で、許容範囲内でした。"
+    applied_patch_paths:
+      - "/unknowns"
+  - question_id: "q_unknown_2"
+    answer_text: "法務確認が完了し、利用規約改定案は問題ないとの回答を得ました。"
+    applied_patch_paths:
+      - "/assumptions/0"
+patch:
+  - op: "replace"
+    path: "/unknowns"
+    value: []
+  - op: "add"
+    path: "/assumptions"
+    value:
+      - "負荷試験ピーク時エラー率は0.08%で許容範囲内"
+      - "法務確認済み（利用規約改定案）"

--- a/sessions/session_001_case.yaml
+++ b/sessions/session_001_case.yaml
@@ -1,0 +1,20 @@
+case_id: session_001_case
+title: "Decision Session v1: unknowns を回答で解消する"
+locale: ja-JP
+problem: "新機能を今期リリースするか判断したいが、未確認事項が残っている。"
+context:
+  domain: "プロダクト運営"
+constraints:
+  - "障害率を現状より悪化させない"
+  - "法令違反リスクを許容しない"
+values:
+  - "安全性"
+  - "説明責任"
+deadline: "2026-02-23"
+stakeholders:
+  - name: "プロダクト責任者"
+    role: "意思決定主体"
+    impact: "リリース判断と結果責任を負う"
+unknowns:
+  - "負荷試験のピーク時エラー率"
+  - "利用規約改定の法務確認"

--- a/sessions/session_001_expected.json
+++ b/sessions/session_001_expected.json
@@ -1,0 +1,293 @@
+{
+  "meta": {
+    "schema_version": "1.0",
+    "pocore_version": "0.1.0",
+    "run_id": "session_001_case_expected_stub_compact_v1",
+    "created_at": "2026-02-22T00:00:00Z",
+    "seed": 0,
+    "deterministic": true,
+    "generator": {
+      "name": "generator_stub",
+      "version": "0.1.0",
+      "mode": "stub"
+    }
+  },
+  "case_ref": {
+    "case_id": "session_001_case",
+    "title": "Decision Session v1: unknowns を回答で解消する",
+    "input_digest": "8a2514519cb7d37e674ee9ac5c0501d545cdc7bd7348a4faeea237e5d754d8f4"
+  },
+  "options": [
+    {
+      "option_id": "opt_1",
+      "title": "案A：段階的に進める",
+      "description": "最小コストで試し、学びながら前進する。",
+      "action_plan": [
+        {
+          "step": "最小実験を設計して実施する"
+        }
+      ],
+      "pros": [
+        "失敗コストを抑えられる"
+      ],
+      "cons": [
+        "進行が遅く感じる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "検証不足",
+          "severity": "medium",
+          "mitigation": "検証項目を明文化する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "1-2 weeks",
+        "confidence": "medium"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "nonmaleficence"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "速度と安全の緊張",
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "時間圧力下でも最小限の検証を維持する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "プロダクト責任者",
+            "role": "意思決定主体",
+            "impact": "リリース判断と結果責任を負う"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    },
+    {
+      "option_id": "opt_2",
+      "title": "案B：情報収集してから決める",
+      "description": "重要な不明点を埋めてから判断する。",
+      "action_plan": [
+        {
+          "step": "不足情報を3〜5項目に絞って集める"
+        }
+      ],
+      "pros": [
+        "判断精度が上がる"
+      ],
+      "cons": [
+        "機会損失が起きる可能性"
+      ],
+      "risks": [
+        {
+          "risk": "先延ばし",
+          "severity": "low",
+          "mitigation": "期限と判断条件を設定する"
+        }
+      ],
+      "feasibility": {
+        "effort": "low",
+        "timeline": "3-5 days",
+        "confidence": "high"
+      },
+      "uncertainty": {
+        "overall_level": "medium",
+        "reasons": [],
+        "assumptions": [],
+        "known_unknowns": []
+      },
+      "ethics_review": {
+        "principles_applied": [
+          "integrity",
+          "autonomy",
+          "nonmaleficence"
+        ],
+        "tradeoffs": [
+          {
+            "tension": "速度と安全の緊張",
+            "between": [
+              "autonomy",
+              "nonmaleficence"
+            ],
+            "mitigation": "時間圧力下でも最小限の検証を維持する",
+            "severity": "medium"
+          }
+        ],
+        "concerns": [
+          "不確実な事実を断言しない"
+        ],
+        "confidence": "medium"
+      },
+      "responsibility_review": {
+        "decision_owner": "user",
+        "stakeholders": [
+          {
+            "name": "プロダクト責任者",
+            "role": "意思決定主体",
+            "impact": "リリース判断と結果責任を負う"
+          }
+        ],
+        "accountability_notes": "最終判断はユーザー。Po_coreは構造化と検証手続きを提供する。",
+        "confidence": "medium"
+      }
+    }
+  ],
+  "recommendation": {
+    "status": "recommended",
+    "recommended_option_id": "opt_1",
+    "reason": "害を抑えつつ前進できるため。",
+    "counter": "遅いと感じる可能性がある。",
+    "alternatives": [
+      {
+        "option_id": "opt_2",
+        "when_to_choose": "不明点が多い場合"
+      }
+    ],
+    "confidence": "medium"
+  },
+  "ethics": {
+    "principles_used": [
+      "integrity",
+      "autonomy",
+      "nonmaleficence",
+      "justice",
+      "accountability"
+    ],
+    "tradeoffs": [
+      {
+        "tension": "速度と安全（nonmaleficence）の緊張",
+        "between": [
+          "autonomy",
+          "nonmaleficence"
+        ],
+        "mitigation": "時間制約下でも検証を省略しない",
+        "severity": "medium"
+      }
+    ],
+    "guardrails": [
+      "不確実な事実を断言しない",
+      "意思決定主体をユーザーから奪わない",
+      "推奨には反証と代替案を併記する",
+      "時間圧力下でも検証を省略しない"
+    ],
+    "notes": "M2以降で倫理ルールを拡張予定。現段階ではガードレール中心。"
+  },
+  "responsibility": {
+    "decision_owner": "user",
+    "stakeholders": [
+      {
+        "name": "プロダクト責任者",
+        "role": "意思決定主体",
+        "impact": "リリース判断と結果責任を負う"
+      }
+    ],
+    "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは説明可能な判断材料を整理する。",
+    "consent_considerations": []
+  },
+  "questions": [
+    {
+      "question_id": "q_deadline_flex_1",
+      "question": "期限の柔軟性はどこまであるか？（延長可否/最短再設定日）",
+      "priority": 1,
+      "why_needed": "時間圧の中で実行可能な計画へ再設計するため。",
+      "assumption_if_unanswered": "期限は固定で延長不可と仮定する",
+      "optional": false
+    },
+    {
+      "question_id": "q_temporary_scope_1",
+      "question": "暫定対応として許容できる範囲は？（品質/コスト/対象範囲）",
+      "priority": 1,
+      "why_needed": "未知が残る状況でも被害を限定して前進するため。",
+      "assumption_if_unanswered": "可逆で低リスクな最小範囲のみ許容とする",
+      "optional": false
+    }
+  ],
+  "uncertainty": {
+    "overall_level": "low",
+    "reasons": [
+      "入力情報が比較的揃っている"
+    ],
+    "assumptions": [
+      "提示された制約が正しい"
+    ],
+    "known_unknowns": []
+  },
+  "trace": {
+    "version": "1.0",
+    "steps": [
+      {
+        "name": "parse_input",
+        "started_at": "2026-02-22T00:00:00Z",
+        "ended_at": "2026-02-22T00:00:01Z",
+        "summary": "入力を正規化し、特徴量（features）を抽出した",
+        "metrics": {
+          "options_planned": 2,
+          "questions_planned": 2,
+          "unknowns_count": 0,
+          "stakeholders_count": 1,
+          "rules_fired": [
+            "ETH_TIME_PRESSURE_SAFETY"
+          ],
+          "days_to_deadline": 1
+        }
+      },
+      {
+        "name": "generate_options",
+        "started_at": "2026-02-22T00:00:01Z",
+        "ended_at": "2026-02-22T00:00:02Z",
+        "summary": "特徴量に基づいて選択肢を生成した",
+        "metrics": {
+          "options": 2
+        }
+      },
+      {
+        "name": "question_layer",
+        "started_at": "2026-02-22T00:00:02Z",
+        "ended_at": "2026-02-22T00:00:03Z",
+        "summary": "不足情報を補う問いを生成した",
+        "metrics": {
+          "questions": 2
+        }
+      },
+      {
+        "name": "compose_output",
+        "started_at": "2026-02-22T00:00:03Z",
+        "ended_at": "2026-02-22T00:00:04Z",
+        "summary": "推奨・反証・代替案を含む出力を組み立てた",
+        "metrics": {
+          "arbitration_code": "DEFAULT_RECOMMEND",
+          "rules_fired": [
+            "ETH_TIME_PRESSURE_SAFETY"
+          ],
+          "policy_snapshot": {
+            "UNKNOWN_BLOCK": 4,
+            "TIME_PRESSURE_DAYS": -4
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/pocore/__init__.py
+++ b/src/pocore/__init__.py
@@ -9,8 +9,9 @@ Design stance:
 Public API
 ----------
     run_case_file(path, *, seed, now, deterministic) -> dict
+    run_session_replay(case_path, answers_path, *, seed, now, deterministic) -> dict
 """
 
-from .runner import run_case_file
+from .runner import run_case_file, run_session_replay
 
-__all__ = ["run_case_file"]
+__all__ = ["run_case_file", "run_session_replay"]

--- a/src/pocore/runner.py
+++ b/src/pocore/runner.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Union
+from copy import deepcopy
+from typing import Any, Dict, List, Union
 
 import yaml
 from jsonschema import Draft202012Validator, FormatChecker
@@ -56,6 +57,15 @@ def _load_yaml_case(path: Path) -> Dict[str, Any]:
     return data
 
 
+def _load_yaml_payload(path: Path, *, label: str) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    data = to_json_compatible(data)
+    if not isinstance(data, dict):
+        raise TypeError(f"{label} YAML must be an object at top-level: {path}")
+    return data
+
+
 def _get_validator(schema_name: str) -> Draft202012Validator:
     schema_path = _repo_root() / "docs" / "spec" / schema_name
     schema = _load_json(schema_path)
@@ -75,6 +85,102 @@ def _validate_or_raise(
         )
         lines.append(f"[{i}] {path}: {err.message}")
     raise ValueError("\n".join(lines))
+
+
+def _decode_pointer_token(token: str) -> str:
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _parse_json_pointer(path: str) -> List[str]:
+    if not path.startswith("/"):
+        raise ValueError(f"JSON pointer must start with '/': {path}")
+    if path == "/":
+        return [""]
+    return [_decode_pointer_token(part) for part in path.lstrip("/").split("/")]
+
+
+def _resolve_parent(container: Any, tokens: List[str], *, path: str) -> tuple[Any, str]:
+    if not tokens:
+        raise ValueError(f"Root replacement is not supported in patch path: {path}")
+
+    current = container
+    for tok in tokens[:-1]:
+        if isinstance(current, list):
+            if not tok.isdigit():
+                raise ValueError(f"List index must be integer in patch path: {path}")
+            idx = int(tok)
+            if idx < 0 or idx >= len(current):
+                raise ValueError(f"List index out of range in patch path: {path}")
+            current = current[idx]
+        elif isinstance(current, dict):
+            if tok not in current:
+                raise ValueError(f"Missing object key in patch path: {path}")
+            current = current[tok]
+        else:
+            raise ValueError(f"Cannot traverse patch path: {path}")
+    return current, tokens[-1]
+
+
+def _apply_patch(case: Dict[str, Any], patch_ops: List[Dict[str, Any]]) -> Dict[str, Any]:
+    updated = deepcopy(case)
+    for op in patch_ops:
+        op_name = str(op.get("op"))
+        path = str(op.get("path", ""))
+        tokens = _parse_json_pointer(path)
+        parent, leaf = _resolve_parent(updated, tokens, path=path)
+        value = deepcopy(op.get("value"))
+
+        if isinstance(parent, list):
+            if leaf == "-" and op_name == "add":
+                parent.append(value)
+                continue
+            if not leaf.isdigit():
+                raise ValueError(f"List index must be integer in patch path: {path}")
+            index = int(leaf)
+            if op_name == "add":
+                if index < 0 or index > len(parent):
+                    raise ValueError(f"List add index out of range in patch path: {path}")
+                parent.insert(index, value)
+            elif op_name == "replace":
+                if index < 0 or index >= len(parent):
+                    raise ValueError(
+                        f"List replace index out of range in patch path: {path}"
+                    )
+                parent[index] = value
+            elif op_name == "remove":
+                if index < 0 or index >= len(parent):
+                    raise ValueError(
+                        f"List remove index out of range in patch path: {path}"
+                    )
+                del parent[index]
+            elif op_name == "test":
+                if index < 0 or index >= len(parent):
+                    raise ValueError(f"List test index out of range in patch path: {path}")
+                if parent[index] != value:
+                    raise ValueError(f"JSON patch test failed at {path}")
+            else:
+                raise ValueError(f"Unsupported patch operation: {op_name}")
+            continue
+
+        if not isinstance(parent, dict):
+            raise ValueError(f"Patch target parent must be object or array: {path}")
+
+        if op_name == "add":
+            parent[leaf] = value
+        elif op_name == "replace":
+            if leaf not in parent:
+                raise ValueError(f"Replace target does not exist in patch path: {path}")
+            parent[leaf] = value
+        elif op_name == "remove":
+            if leaf not in parent:
+                raise ValueError(f"Remove target does not exist in patch path: {path}")
+            del parent[leaf]
+        elif op_name == "test":
+            if parent.get(leaf) != value:
+                raise ValueError(f"JSON patch test failed at {path}")
+        else:
+            raise ValueError(f"Unsupported patch operation: {op_name}")
+    return updated
 
 
 def run_case_file(
@@ -121,4 +227,66 @@ def run_case_file(
         label=f"Output for {case_path.name}",
     )
 
+    return out
+
+
+def run_session_replay(
+    case_path: Union[str, Path],
+    answers_path: Union[str, Path],
+    *,
+    seed: int = 0,
+    now: Union[str, Any] = "2026-02-22T00:00:00Z",
+    deterministic: bool = True,
+) -> Dict[str, Any]:
+    """Apply Decision Session answers patch to a case and run deterministic pipeline."""
+    case_file = Path(case_path)
+    answers_file = Path(answers_path)
+    if not case_file.exists():
+        raise FileNotFoundError(f"Case file not found: {case_file}")
+    if not answers_file.exists():
+        raise FileNotFoundError(f"Session answers file not found: {answers_file}")
+
+    case = _load_yaml_case(case_file)
+    _validate_or_raise(
+        _get_validator("input_schema_v1.json"),
+        case,
+        label=f"Input case {case_file.name}",
+    )
+
+    answers = _load_yaml_payload(answers_file, label="Session answers")
+    _validate_or_raise(
+        _get_validator("session_answers_schema_v1.json"),
+        answers,
+        label=f"Session answers {answers_file.name}",
+    )
+
+    case_ref = str(answers.get("case_ref", ""))
+    if case_ref and case_ref != str(case.get("case_id", "")):
+        raise ValueError(
+            f"Session answers case_ref mismatch: {case_ref} != {case.get('case_id')}"
+        )
+
+    patch_ops = answers.get("patch", [])
+    if not isinstance(patch_ops, list):
+        raise ValueError("Session answers patch must be an array")
+
+    replay_case = _apply_patch(case, patch_ops)
+    _validate_or_raise(
+        _get_validator("input_schema_v1.json"),
+        replay_case,
+        label=f"Patched case for {case_file.name}",
+    )
+
+    out = run_case(
+        replay_case,
+        case_path=case_file,
+        seed=seed,
+        now=now,
+        deterministic=deterministic,
+    )
+    _validate_or_raise(
+        _get_validator("output_schema_v1.json"),
+        out,
+        label=f"Output for replay {case_file.name}",
+    )
     return out

--- a/tests/test_session_replay_e2e.py
+++ b/tests/test_session_replay_e2e.py
@@ -1,0 +1,62 @@
+"""Decision Session v1 replay golden diff E2E."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_DIR = ROOT / "sessions"
+
+
+def _import_run_session_replay() -> Callable[..., dict[str, Any]]:
+    candidates = [
+        ("pocore.runner", "run_session_replay"),
+        ("pocore", "run_session_replay"),
+    ]
+    for mod_name, fn_name in candidates:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        fn = getattr(mod, fn_name, None)
+        if callable(fn):
+            return fn
+    raise ImportError("Could not import run_session_replay")
+
+
+def _canonicalize(obj: Any, *, parent_key: str = "") -> Any:
+    if isinstance(obj, dict):
+        return {k: _canonicalize(v, parent_key=k) for k, v in obj.items()}
+    if isinstance(obj, list):
+        items = [_canonicalize(i, parent_key=parent_key) for i in obj]
+        if parent_key == "options":
+            return sorted(items, key=lambda x: x.get("option_id", ""))
+        if parent_key == "questions":
+            return sorted(items, key=lambda x: (x.get("priority", 0), x.get("question_id", "")))
+        if parent_key == "stakeholders":
+            return sorted(items, key=lambda x: (x.get("name", ""), x.get("role", "")))
+        return items
+    return obj
+
+
+def test_session_replay_matches_expected_json() -> None:
+    run_session_replay = _import_run_session_replay()
+
+    case_path = SESSIONS_DIR / "session_001_case.yaml"
+    answers_path = SESSIONS_DIR / "session_001_answers.yaml"
+    expected_path = SESSIONS_DIR / "session_001_expected.json"
+
+    actual = run_session_replay(
+        case_path,
+        answers_path,
+        seed=0,
+        now="2026-02-22T00:00:00Z",
+        deterministic=True,
+    )
+
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+
+    assert _canonicalize(actual) == _canonicalize(expected)


### PR DESCRIPTION
### Motivation
- Provide a deterministic replay path for Decision Session v1 so session answers (JSON Patch) can be applied to a case and the pipeline re-run for E2E golden regression checks.
- Keep the decision pipeline and golden contract deterministic and schema-validated while avoiding changes to existing frozen goldens or non-deterministic outputs.

### Description
- Added `run_session_replay(case_path, answers_path, *, seed, now, deterministic)` to `src/pocore/runner.py` which validates input, validates `session_answers_schema_v1.json`, applies an RFC6902-like patch subset (`add|replace|remove|test`) using JSON Pointer handling, re-validates the patched case, runs the deterministic pipeline, and validates the output against the output schema.
- Implemented JSON Pointer parsing and a safe patch applier helpers in `src/pocore/runner.py` and exported `run_session_replay` from `src/pocore/__init__.py`.
- Added Decision Session v1 golden assets under `sessions/`: `sessions/session_001_case.yaml`, `sessions/session_001_answers.yaml`, and the generated `sessions/session_001_expected.json` (produced by running the deterministic replay with fixed `seed`/`now`).
- Added an E2E test `tests/test_session_replay_e2e.py` that runs `run_session_replay` with fixed `seed=0` and `now="2026-02-22T00:00:00Z"` and canonicalizes/compares the output to the golden expected JSON, and updated traceability and requirements with `REQ-SESSION-001` linking the new test and code.

### Testing
- Ran the full automated test suite with `PYTHONPATH=src pytest -q` and the run completed successfully with `3361 passed, 134 skipped` (the new `tests/test_session_replay_e2e.py` passed as part of this run).
- The session golden `sessions/session_001_expected.json` was produced by invoking `run_session_replay(...)` with `seed=0` and `now="2026-02-22T00:00:00Z"` before adding it as the expected file to ensure canonical determinism.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a7218da4832898ef2677963402df)