### PR TITLE
Fix CI lint failures: apply black and isort to recently added files

### DIFF
--- a/src/pocore/engines/generator_stub.py
+++ b/src/pocore/engines/generator_stub.py
@@ -444,51 +444,57 @@ def generate_options(
         ]
 
     # Default fallback
-    return _apply_two_track_plan_if_needed(_apply_values_clarification_pack_if_needed([
-        {
-            "option_id": "opt_1",
-            "title": "案A：段階的に進める",
-            "description": "最小コストで試し、学びながら前進する。",
-            "action_plan": [{"step": "最小実験を設計して実施する"}],
-            "pros": ["失敗コストを抑えられる"],
-            "cons": ["進行が遅く感じる可能性"],
-            "risks": [
+    return _apply_two_track_plan_if_needed(
+        _apply_values_clarification_pack_if_needed(
+            [
                 {
-                    "risk": "検証不足",
-                    "severity": "medium",
-                    "mitigation": "検証項目を明文化する",
-                }
-            ],
-            "feasibility": {
-                "effort": "low",
-                "timeline": "1-2 weeks",
-                "confidence": "medium",
-            },
-            "uncertainty": _ph_uncertainty(),
-            "ethics_review": _ph_ethics(),
-            "responsibility_review": _ph_responsibility(),
-        },
-        {
-            "option_id": "opt_2",
-            "title": "案B：情報収集してから決める",
-            "description": "重要な不明点を埋めてから判断する。",
-            "action_plan": [{"step": "不足情報を3〜5項目に絞って集める"}],
-            "pros": ["判断精度が上がる"],
-            "cons": ["機会損失が起きる可能性"],
-            "risks": [
+                    "option_id": "opt_1",
+                    "title": "案A：段階的に進める",
+                    "description": "最小コストで試し、学びながら前進する。",
+                    "action_plan": [{"step": "最小実験を設計して実施する"}],
+                    "pros": ["失敗コストを抑えられる"],
+                    "cons": ["進行が遅く感じる可能性"],
+                    "risks": [
+                        {
+                            "risk": "検証不足",
+                            "severity": "medium",
+                            "mitigation": "検証項目を明文化する",
+                        }
+                    ],
+                    "feasibility": {
+                        "effort": "low",
+                        "timeline": "1-2 weeks",
+                        "confidence": "medium",
+                    },
+                    "uncertainty": _ph_uncertainty(),
+                    "ethics_review": _ph_ethics(),
+                    "responsibility_review": _ph_responsibility(),
+                },
                 {
-                    "risk": "先延ばし",
-                    "severity": "low",
-                    "mitigation": "期限と判断条件を設定する",
-                }
+                    "option_id": "opt_2",
+                    "title": "案B：情報収集してから決める",
+                    "description": "重要な不明点を埋めてから判断する。",
+                    "action_plan": [{"step": "不足情報を3〜5項目に絞って集める"}],
+                    "pros": ["判断精度が上がる"],
+                    "cons": ["機会損失が起きる可能性"],
+                    "risks": [
+                        {
+                            "risk": "先延ばし",
+                            "severity": "low",
+                            "mitigation": "期限と判断条件を設定する",
+                        }
+                    ],
+                    "feasibility": {
+                        "effort": "low",
+                        "timeline": "3-5 days",
+                        "confidence": "high",
+                    },
+                    "uncertainty": _ph_uncertainty(),
+                    "ethics_review": _ph_ethics(),
+                    "responsibility_review": _ph_responsibility(),
+                },
             ],
-            "feasibility": {
-                "effort": "low",
-                "timeline": "3-5 days",
-                "confidence": "high",
-            },
-            "uncertainty": _ph_uncertainty(),
-            "ethics_review": _ph_ethics(),
-            "responsibility_review": _ph_responsibility(),
-        },
-    ], feats), feats)
+            feats,
+        ),
+        feats,
+    )

--- a/src/pocore/engines/question_v1.py
+++ b/src/pocore/engines/question_v1.py
@@ -269,7 +269,9 @@ def generate(
 
     if unknowns_count > 0 and unknown_items_norm:
         headroom = max(0, MAX_QUESTIONS - len(candidates))
-        for index, item in enumerate(unknown_items_norm[: max(MAX_QUESTIONS, headroom)], start=1):
+        for index, item in enumerate(
+            unknown_items_norm[: max(MAX_QUESTIONS, headroom)], start=1
+        ):
             penalty = 2 * (index - 1)
             urgency_bonus = 10 if is_deadline_near else 0
             stakeholder_bonus = 2 if stakeholders_count >= 2 else 0

--- a/src/pocore/runner.py
+++ b/src/pocore/runner.py
@@ -24,8 +24,8 @@ Design stance:
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import yaml
@@ -121,7 +121,9 @@ def _resolve_parent(container: Any, tokens: List[str], *, path: str) -> tuple[An
     return current, tokens[-1]
 
 
-def _apply_patch(case: Dict[str, Any], patch_ops: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _apply_patch(
+    case: Dict[str, Any], patch_ops: List[Dict[str, Any]]
+) -> Dict[str, Any]:
     updated = deepcopy(case)
     for op in patch_ops:
         op_name = str(op.get("op"))
@@ -139,7 +141,9 @@ def _apply_patch(case: Dict[str, Any], patch_ops: List[Dict[str, Any]]) -> Dict[
             index = int(leaf)
             if op_name == "add":
                 if index < 0 or index > len(parent):
-                    raise ValueError(f"List add index out of range in patch path: {path}")
+                    raise ValueError(
+                        f"List add index out of range in patch path: {path}"
+                    )
                 parent.insert(index, value)
             elif op_name == "replace":
                 if index < 0 or index >= len(parent):
@@ -155,7 +159,9 @@ def _apply_patch(case: Dict[str, Any], patch_ops: List[Dict[str, Any]]) -> Dict[
                 del parent[index]
             elif op_name == "test":
                 if index < 0 or index >= len(parent):
-                    raise ValueError(f"List test index out of range in patch path: {path}")
+                    raise ValueError(
+                        f"List test index out of range in patch path: {path}"
+                    )
                 if parent[index] != value:
                     raise ValueError(f"JSON patch test failed at {path}")
             else:

--- a/tests/test_execution_coverage.py
+++ b/tests/test_execution_coverage.py
@@ -57,7 +57,9 @@ def _collect_execution_coverage() -> Tuple[Set[str], Set[str], Set[str]]:
 
 
 def test_execution_covers_minimum_arbitration_codes_and_ethics_rules() -> None:
-    arbitration_codes, ethics_rule_ids, planning_rule_ids = _collect_execution_coverage()
+    arbitration_codes, ethics_rule_ids, planning_rule_ids = (
+        _collect_execution_coverage()
+    )
 
     required_arbitration = set(BASE_ARBITRATION_CODES)
     if (

--- a/tests/test_golden_coverage.py
+++ b/tests/test_golden_coverage.py
@@ -124,8 +124,7 @@ def test_golden_has_two_track_planning_under_time_pressure_unknowns() -> None:
         if row["features"].get("days_to_deadline") is not None
         and row["features"].get("unknowns_count", 0) > 0
         and row["features"].get("days_to_deadline") <= TIME_PRESSURE_DAYS
-        and PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN
-        in row.get("planning_rules_fired", [])
+        and PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN in row.get("planning_rules_fired", [])
     ]
 
     if TIME_PRESSURE_DAYS >= 0:
@@ -144,8 +143,7 @@ def test_golden_has_two_track_planning_under_time_pressure_unknowns() -> None:
         for row in records
         if row["features"].get("days_to_deadline") is not None
         and row["features"].get("unknowns_count", 0) > 0
-        and PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN
-        in row.get("planning_rules_fired", [])
+        and PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN in row.get("planning_rules_fired", [])
     ]
     assert unknowns_present, (
         "No *_expected.json-backed case validates Two-Track Plan observability with "

--- a/tests/test_policy_lab.py
+++ b/tests/test_policy_lab.py
@@ -70,7 +70,9 @@ def test_policy_lab_compare_baseline_generates_impacted_requirements(
     assert "REQ-VALUES-001" in result["summary"]["impacted_requirements"]
     assert "REQ-VALUES" in result["summary"]["impacted_requirements"]
     assert "REQ-CONSTRAINT" in result["summary"]["impacted_requirements"]
-    assert result["summary"]["two_track_rule_id"] == "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN"
+    assert (
+        result["summary"]["two_track_rule_id"] == "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN"
+    )
     assert result["summary"]["two_track_triggered_cases"] >= 1
     assert result["summary"]["planning_rule_frequency_top"]
     assert result["summary"]["planning_rule_frequency_top"][0]["rule_id"]

--- a/tests/test_session_replay_e2e.py
+++ b/tests/test_session_replay_e2e.py
@@ -35,7 +35,9 @@ def _canonicalize(obj: Any, *, parent_key: str = "") -> Any:
         if parent_key == "options":
             return sorted(items, key=lambda x: x.get("option_id", ""))
         if parent_key == "questions":
-            return sorted(items, key=lambda x: (x.get("priority", 0), x.get("question_id", "")))
+            return sorted(
+                items, key=lambda x: (x.get("priority", 0), x.get("question_id", ""))
+            )
         if parent_key == "stakeholders":
             return sorted(items, key=lambda x: (x.get("name", ""), x.get("role", "")))
         return items

--- a/tests/test_session_replay_unit.py
+++ b/tests/test_session_replay_unit.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "session_replay.py"
 CASE_PATH = ROOT / "scenarios" / "case_002.yaml"
@@ -15,11 +14,17 @@ def _run_replay(tmp_path: Path, out_name: str) -> dict:
     answers = {
         "patch": [
             {"op": "replace", "path": "/unknowns", "value": ["評価データはHR確認済み"]},
-            {"op": "add", "path": "/extensions", "value": {"session_replay": "unit-test"}},
+            {
+                "op": "add",
+                "path": "/extensions",
+                "value": {"session_replay": "unit-test"},
+            },
         ]
     }
     answers_path = tmp_path / f"answers_{out_name}.json"
-    answers_path.write_text(json.dumps(answers, ensure_ascii=False, indent=2), encoding="utf-8")
+    answers_path.write_text(
+        json.dumps(answers, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     out_dir = tmp_path / out_name
     cmd = [

--- a/tests/test_two_track_plan.py
+++ b/tests/test_two_track_plan.py
@@ -21,8 +21,9 @@ def test_two_track_plan_emitted_under_time_pressure_with_unknowns() -> None:
     assert any(step.startswith("[Track B]") for step in steps)
 
 
-
-def test_two_track_plan_reflects_unknown_items_in_track_b_with_deterministic_order() -> None:
+def test_two_track_plan_reflects_unknown_items_in_track_b_with_deterministic_order() -> (
+    None
+):
     unknowns = ["監査ログの欠落範囲", "通知対象ユーザー数", "契約上の通知期限"]
     options = generator_stub.generate_options(
         {},


### PR DESCRIPTION
## Summary
- 変更概要:
- 背景/目的:

## Policy Change Protocol v1（policy定数変更時のみ必須）
- [ ] policy定数変更なし（該当しない）
- [ ] policy_lab レポート（JSON）を添付した
- [ ] policy_lab レポート（Markdown）を添付した
- [ ] impacted_requirements 上位（例: Top 3）を本文へ記載した
- [ ] golden差分がある場合、再生成で更新した（手編集なし）
- [ ] golden差分要約（対象ケース/主要差分/妥当性）を本文へ記載した

## Evidence
- policy_lab artifacts:
  - JSON:
  - Markdown:
- impacted_requirements (Top):
  1.
  2.
  3.

## Validation
- [ ] `pytest -q` を実行し全通

## Notes
- 追加の注意事項・制約: