### PR TITLE
feat: add Good First Issues infrastructure to attract contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,45 @@ pip install po-core-flyingpig
 - その結果を golden（期待JSON）へ固定し、CI（`pytest -q`）で契約を検証する。
 - 凍結golden `scenarios/case_001_expected.json` / `scenarios/case_009_expected.json` は変更禁止。
 
-## Contribution Tracks
+## 🚀 Good First Issues — Jump In Today
+
+> No philosophy PhD required. No ML expertise required. Just curiosity.
+
+We have **23 ready-to-claim tasks** across three tracks. Pick one and open a PR!
+
+### 🧪 AI Track — Add unit tests for a philosopher (`ai-easy`)
+
+23 philosophers have no dedicated unit test file. Pick one, copy the pattern from
+[`tests/unit/test_philosophers/test_kant.py`](./tests/unit/test_philosophers/test_kant.py),
+and submit a PR. **Estimated time: 1–2 hours.**
+
+Unclaimed philosophers:
+`beauvoir` · `butler` · `descartes` · `dogen` · `epicurus` · `foucault` ·
+`hegel` · `husserl` · `jonas` · `laozi` · `marcus_aurelius` · `nagarjuna` ·
+`nishida` · `parmenides` · `plato` · `schopenhauer` · `spinoza` · `weil`
+and more.
+
+```bash
+# Grab one and go:
+cp tests/unit/test_philosophers/test_kant.py \
+   tests/unit/test_philosophers/test_<your_philosopher>.py
+# Edit the file, run: pytest tests/unit/test_philosophers/test_<your_philosopher>.py -v
+```
+
+### 📖 Philosophy Track — No code required (`phil-easy`)
+
+- **Review philosophical accuracy** of any of the 39 philosopher modules — just read
+  `src/po_core/philosophers/<name>.py` and comment on the GitHub issue
+- **Propose a new philosopher** (Ubuntu ethics, Gilligan, Thich Nhat Hanh, etc.)
+- **Translate key concepts** in `docs/` from English ↔ Japanese ↔ your language
+
+### 🌉 Bridge Track — Python basics + philosophy curiosity (`bridge`)
+
+- **Implement a new philosopher stub** by copying `src/po_core/philosophers/aristotle.py`
+  as a template — add your chosen thinker in ~100 lines
+
+**→ [See all prepared issues](./.github/ISSUE_TEMPLATE/PREPARED_ISSUES.md)**
+**→ [Full contribution guide](./CONTRIBUTING.md)**
 
 ### <a id="ai-track"></a> AI Track
 

--- a/src/po_core/cli.py
+++ b/src/po_core/cli.py
@@ -21,7 +21,7 @@ SAMPLE_PROMPT = "What does it mean to live authentically?"
 
 
 @click.group()
-@click.version_option(version="0.1.0-alpha", prog_name="po-core")
+@click.version_option(version=__version__, prog_name="po-core")
 def main() -> None:
     """
     Po_core: Philosophy-Driven AI System 🐷🎈
@@ -78,12 +78,15 @@ def hello(sample: bool) -> None:
 def status(sample: bool) -> None:
     """Show project status"""
     console.print("[bold]📊 Po_core Project Status[/bold]\n")
-    console.print("✅ Philosophical Framework: 100%")
-    console.print("✅ Documentation: 100%")
-    console.print("✅ Architecture Design: 100%")
-    console.print("🔄 Implementation: 60% (ensemble + Po_trace)")
-    console.print("🔄 Testing: 20% (unit coverage for ensemble/CLI)")
-    console.print("⏳ Visualization: 10% (CLI stub, visuals pending)")
+    console.print(f"Version: [bold cyan]{__version__}[/bold cyan]")
+    console.print("")
+    console.print("✅ Phase 1: 39-philosopher scaling + tech debt cleared")
+    console.print("✅ Phase 2: ML tensors + Deliberation Engine")
+    console.print("✅ Phase 3: Viewer WebUI + Explainable W_Ethics Gate")
+    console.print("✅ Phase 4: Adversarial Hardening + Red team tests")
+    console.print("✅ Phase 5: REST API + Docker + Async streaming")
+    console.print("")
+    console.print("[dim]3100+ tests · 39 philosopher personas · Production-ready[/dim]")
     if sample:
         console.print("\n[dim]Running Po_self sample...[/dim]")
         console.print(_render_sample_generation(SAMPLE_PROMPT))

--- a/tests/unit/test_philosophers/test_kant.py
+++ b/tests/unit/test_philosophers/test_kant.py
@@ -1,0 +1,317 @@
+"""
+Tests for Kant Philosopher Module
+
+Tests Kant's critical philosophy focusing on:
+- Categorical Imperative (three formulations)
+- Phenomena vs Noumena
+- Transcendental Idealism
+- Autonomy and Duty
+- Kingdom of Ends
+- Good Will
+
+--- GOOD FIRST ISSUE TEMPLATE ---
+23 philosophers currently lack a dedicated unit test file.
+Copy this file, replace `Kant` with your philosopher, and adjust the
+field names to match that philosopher's `reason()` output.
+
+Unclaimed: beauvoir, butler, descartes, dogen, epicurus, foucault,
+           hegel, husserl, jonas, laozi, marcus_aurelius, nagarjuna,
+           nishida, parmenides, plato, schopenhauer, spinoza, weil
+           (see README.md for full list)
+"""
+
+import pytest
+
+from po_core.philosophers.kant import Kant
+
+
+class TestKantBasicFunctionality:
+    """Test basic initialization and interface of the Kant module."""
+
+    def test_kant_initialization(self):
+        """Test that Kant initializes with the correct identity."""
+        kant = Kant()
+
+        assert "Kant" in kant.name
+        assert kant.description is not None
+        assert len(kant.description) > 0
+
+    def test_kant_has_tradition(self):
+        """Test that Kant has a philosophical tradition set."""
+        kant = Kant()
+
+        assert hasattr(kant, "tradition")
+        assert "Critical" in kant.tradition or "Idealism" in kant.tradition
+
+    def test_kant_has_key_concepts(self):
+        """Test that Kant's key concepts are populated."""
+        kant = Kant()
+
+        assert hasattr(kant, "key_concepts")
+        assert len(kant.key_concepts) > 0
+        concepts_lower = [c.lower() for c in kant.key_concepts]
+        assert any("categorical" in c or "imperative" in c for c in concepts_lower)
+
+
+class TestKantReasonMethod:
+    """Test the reason() method structure and required fields."""
+
+    def test_reason_returns_dict(self, simple_prompt):
+        """Test that reason() returns a dictionary."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result, dict)
+
+    def test_reason_has_required_fields(self, simple_prompt):
+        """Test that the result contains all expected Kantian fields."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        required = [
+            "reasoning",
+            "perspective",
+            "tension",
+            "categorical_imperative",
+            "phenomena_noumena",
+            "autonomy",
+            "duty",
+            "kingdom_of_ends",
+            "good_will",
+            "metadata",
+        ]
+        for field in required:
+            assert field in result, f"Missing field: {field}"
+
+    def test_perspective_is_deontological(self, simple_prompt):
+        """Test that Kant's perspective is deontological / critical philosophy."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        perspective = result["perspective"]
+        assert "Critical" in perspective or "Deontolog" in perspective
+
+    def test_metadata_structure(self, simple_prompt):
+        """Test that metadata identifies the philosopher correctly."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        metadata = result["metadata"]
+        assert "Kant" in metadata["philosopher"]
+        assert "approach" in metadata
+        assert "focus" in metadata
+
+    def test_reason_accepts_context(self, simple_prompt):
+        """Test that reason() accepts an optional context parameter."""
+        kant = Kant()
+        result = kant.reason(simple_prompt, context={"session": "test"})
+
+        assert isinstance(result, dict)
+
+    def test_reason_works_without_context(self, simple_prompt):
+        """Test that reason() works with no context argument."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result, dict)
+
+
+class TestKantCategoricalImperative:
+    """Test Kant's categorical imperative analysis."""
+
+    def test_categorical_imperative_exists(self, simple_prompt):
+        """Test that categorical_imperative field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        ci = result["categorical_imperative"]
+        assert ci is not None
+
+    def test_universalizability_detected(self):
+        """Test detection of universalizability formulation."""
+        kant = Kant()
+        prompt = "Act only according to rules you could will to become universal laws."
+        result = kant.reason(prompt)
+
+        ci = result["categorical_imperative"]
+        assert isinstance(ci, dict)
+
+    def test_humanity_formula_detected(self):
+        """Test detection of the humanity formulation (treat persons as ends)."""
+        kant = Kant()
+        prompt = "We must treat every person as an end in themselves, never merely as a means."
+        result = kant.reason(prompt)
+
+        ci = result["categorical_imperative"]
+        assert isinstance(ci, dict)
+
+
+class TestKantAutonomy:
+    """Test Kant's autonomy assessment."""
+
+    def test_autonomy_field_exists(self, simple_prompt):
+        """Test that autonomy field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert "autonomy" in result
+
+    def test_autonomy_detected_in_self_directed_prompt(self):
+        """Test that autonomy is detected when self-legislation language appears."""
+        kant = Kant()
+        prompt = "I choose my own moral law through reason; I am autonomous and self-determining."
+        result = kant.reason(prompt)
+
+        autonomy = result["autonomy"]
+        assert isinstance(autonomy, dict)
+
+
+class TestKantDuty:
+    """Test Kant's duty analysis."""
+
+    def test_duty_field_exists(self, simple_prompt):
+        """Test that duty field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert "duty" in result
+
+    def test_duty_detected_in_obligatory_prompt(self):
+        """Test that duty concepts are detected when obligation language appears."""
+        kant = Kant()
+        prompt = "I have a duty and obligation to fulfill my promise, regardless of consequences."
+        result = kant.reason(prompt)
+
+        duty = result["duty"]
+        assert isinstance(duty, dict)
+
+
+class TestKantKingdomOfEnds:
+    """Test Kant's kingdom of ends concept."""
+
+    def test_kingdom_of_ends_field_exists(self, simple_prompt):
+        """Test that kingdom_of_ends field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert "kingdom_of_ends" in result
+
+    def test_kingdom_of_ends_is_dict(self, simple_prompt):
+        """Test that kingdom_of_ends returns a dictionary."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result["kingdom_of_ends"], dict)
+
+
+class TestKantGoodWill:
+    """Test Kant's good will concept."""
+
+    def test_good_will_field_exists(self, simple_prompt):
+        """Test that good_will field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert "good_will" in result
+
+    def test_good_will_is_dict(self, simple_prompt):
+        """Test that good_will returns a dictionary."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result["good_will"], dict)
+
+
+class TestKantReasoningText:
+    """Test the free-text reasoning output."""
+
+    def test_reasoning_is_string(self, simple_prompt):
+        """Test that reasoning is a non-empty string."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result["reasoning"], str)
+        assert len(result["reasoning"]) > 0
+
+    def test_reasoning_references_kantian_concepts(self, ethical_prompt):
+        """Test that reasoning mentions key Kantian concepts."""
+        kant = Kant()
+        result = kant.reason(ethical_prompt)
+
+        reasoning_lower = result["reasoning"].lower()
+        kantian_keywords = ["kant", "categorical", "duty", "universal", "moral law", "autonomy"]
+        assert any(kw in reasoning_lower for kw in kantian_keywords)
+
+
+class TestKantTensionField:
+    """Test Kant's tension field (shared pattern across all philosophers)."""
+
+    def test_tension_exists(self, simple_prompt):
+        """Test that tension field is present."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert "tension" in result
+
+    def test_tension_is_dict(self, simple_prompt):
+        """Test that tension is a dictionary."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        assert isinstance(result["tension"], dict)
+
+    def test_tension_has_required_keys(self, simple_prompt):
+        """Test that tension contains level, description, and elements."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        tension = result["tension"]
+        assert "level" in tension
+        assert "description" in tension
+        assert "elements" in tension
+
+    def test_tension_level_is_valid(self, simple_prompt):
+        """Test that tension level is one of the known values."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        valid_levels = ["Very Low", "Low", "Moderate", "High", "Very High"]
+        assert result["tension"]["level"] in valid_levels
+
+    def test_tension_elements_is_list(self, simple_prompt):
+        """Test that tension elements is a list of strings."""
+        kant = Kant()
+        result = kant.reason(simple_prompt)
+
+        elements = result["tension"]["elements"]
+        assert isinstance(elements, list)
+        for elem in elements:
+            assert isinstance(elem, str)
+
+
+class TestKantEdgeCases:
+    """Test edge cases that all philosopher modules should handle gracefully."""
+
+    def test_empty_prompt(self, empty_prompt):
+        """Test that an empty prompt does not raise an exception."""
+        kant = Kant()
+        result = kant.reason(empty_prompt)
+
+        assert isinstance(result, dict)
+        assert "reasoning" in result
+
+    def test_long_prompt(self, complex_prompt):
+        """Test that a long, complex prompt is processed without error."""
+        kant = Kant()
+        result = kant.reason(complex_prompt)
+
+        assert isinstance(result, dict)
+        assert len(result["reasoning"]) > 0
+
+    def test_existential_prompt(self, existential_prompt):
+        """Test that an existential prompt produces a valid Kantian analysis."""
+        kant = Kant()
+        result = kant.reason(existential_prompt)
+
+        assert isinstance(result, dict)
+        assert result["perspective"] is not None


### PR DESCRIPTION
- fix: CLI --version now reads dynamically from __version__ (was hardcoded to "0.1.0-alpha" while package is 0.2.0b4)
- feat: CLI status command updated to reflect all 5 completed phases
- feat: README gets prominent "Good First Issues" section with 23 specific tasks, quick-start commands, and links to existing issue templates
- feat: tests/unit/test_philosophers/test_kant.py — 30-test reference implementation that serves as the copy-paste template for the 22 remaining philosopher unit test Good First Issues

Resolves the discoverability gap that was preventing new contributors from finding actionable entry points into the project.

https://claude.ai/code/session_01RP16Sb1ZHHDJHNseqNueFE

## Summary
- 変更概要:
- 背景/目的:

## Policy Change Protocol v1（policy定数変更時のみ必須）
- [ ] policy定数変更なし（該当しない）
- [ ] policy_lab レポート（JSON）を添付した
- [ ] policy_lab レポート（Markdown）を添付した
- [ ] impacted_requirements 上位（例: Top 3）を本文へ記載した
- [ ] golden差分がある場合、再生成で更新した（手編集なし）
- [ ] golden差分要約（対象ケース/主要差分/妥当性）を本文へ記載した

## Evidence
- policy_lab artifacts:
  - JSON:
  - Markdown:
- impacted_requirements (Top):
  1.
  2.
  3.

## Validation
- [ ] `pytest -q` を実行し全通

## Notes
- 追加の注意事項・制約:
