### PR TITLE
Support multi-proposal philosopher outputs with deterministic normalization

### DIFF
--- a/tests/unit/test_multi_proposal_pipeline.py
+++ b/tests/unit/test_multi_proposal_pipeline.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from po_core.deliberation.engine import DeliberationEngine
+from po_core.domain.context import Context
+from po_core.domain.intent import Intent
+from po_core.domain.keys import AUTHOR, PO_CORE
+from po_core.domain.memory_snapshot import MemorySnapshot
+from po_core.domain.proposal import Proposal
+from po_core.domain.safety_mode import SafetyMode
+from po_core.domain.safety_verdict import SafetyVerdict
+from po_core.domain.tensor_snapshot import TensorSnapshot
+from po_core.ensemble import EnsembleDeps, _PhasePreResult, _normalize_primary_proposals, _run_phase_post
+from po_core.party_machine import run_philosophers
+
+
+class _DummyPhilosopher:
+    def __init__(self, name: str, proposals: list[Proposal | None]) -> None:
+        self.name = name
+        self._proposals = proposals
+
+    def propose(self, *_args, **_kwargs):
+        return list(self._proposals)
+
+
+class _NullMemoryRead:
+    def snapshot(self, _ctx):
+        return MemorySnapshot(items=[], summary=None, meta={})
+
+
+class _NullMemoryWrite:
+    def __init__(self) -> None:
+        self.records = []
+
+    def append(self, _ctx, records):
+        self.records.extend(records)
+
+
+class _NullTracer:
+    def __init__(self) -> None:
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
+
+
+class _NoopTensors:
+    def compute(self, _ctx, _memory):
+        return TensorSnapshot.now({"freedom_pressure": 0.0})
+
+
+class _NoopSolarWill:
+    def compute_intent(self, _ctx, _tensors, _memory):
+        return Intent.neutral(), {}
+
+
+class _AllowGate:
+    def judge_intent(self, _ctx, _intent, _tensors, _memory):
+        return SafetyVerdict.allow()
+
+    def judge_action(self, _ctx, _intent, _proposal, _tensors, _memory):
+        return SafetyVerdict.allow()
+
+
+class _FirstProposalAggregator:
+    def aggregate(self, _ctx, _intent, _tensors, proposals):
+        return proposals[0]
+
+
+def _mk_ctx() -> Context:
+    return Context(
+        request_id="req-multi",
+        created_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        user_input="test",
+    )
+
+
+def _mk_proposal(pid: str, author: str | None = None, *, fallback: bool = False) -> Proposal:
+    extra = {}
+    if author is not None:
+        extra = {PO_CORE: {AUTHOR: author}}
+    if fallback:
+        extra = {"philosopher": "legacy_author"}
+    return Proposal(
+        proposal_id=pid,
+        action_type="answer",
+        content=f"content:{pid}",
+        confidence=0.6,
+        extra=extra,
+    )
+
+
+def test_run_philosophers_collects_multiple_proposals_with_limit() -> None:
+    ctx = _mk_ctx()
+    ph = _DummyPhilosopher("dummy", [_mk_proposal("p0"), _mk_proposal("p1")])
+
+    proposals, results = run_philosophers(
+        [ph],
+        ctx,
+        Intent.neutral(),
+        TensorSnapshot.now({"freedom_pressure": 0.0}),
+        MemorySnapshot(items=[], summary=None, meta={}),
+        max_workers=1,
+        timeout_s=1.0,
+        limit_per_philosopher=3,
+    )
+
+    assert len(proposals) == 2
+    assert results[0].n == 2
+
+
+def test_run_philosophers_embeds_author_and_proposal_index() -> None:
+    ctx = _mk_ctx()
+    ph = _DummyPhilosopher("dummy", [_mk_proposal("p0"), _mk_proposal("p1")])
+
+    proposals, _ = run_philosophers(
+        [ph],
+        ctx,
+        Intent.neutral(),
+        TensorSnapshot.now({"freedom_pressure": 0.0}),
+        MemorySnapshot(items=[], summary=None, meta={}),
+        max_workers=1,
+        timeout_s=1.0,
+        limit_per_philosopher=3,
+    )
+
+    assert proposals[0].extra[PO_CORE][AUTHOR] == "dummy"
+    assert proposals[0].extra[PO_CORE]["proposal_index"] == 0
+    assert proposals[1].extra[PO_CORE][AUTHOR] == "dummy"
+    assert proposals[1].extra[PO_CORE]["proposal_index"] == 1
+
+
+def test_normalize_primary_proposals_handles_empty_none_and_fallback_author() -> None:
+    primary, secondary = _normalize_primary_proposals([])
+    assert primary == []
+    assert secondary == []
+
+    proposals = [
+        _mk_proposal("a-0", "author_a"),
+        _mk_proposal("a-1", "author_a"),
+        _mk_proposal("legacy-0", None, fallback=True),
+        _mk_proposal("legacy-1", None, fallback=True),
+        _mk_proposal("no-author"),
+    ]
+
+    primary, secondary = _normalize_primary_proposals(proposals)
+
+    assert [p.proposal_id for p in primary] == ["a-0", "legacy-0", "no-author"]
+    assert [p.proposal_id for p in secondary] == ["a-1", "legacy-1"]
+
+
+def test_run_phase_post_with_deliberation_rounds_two_completes_without_exception() -> None:
+    ctx = _mk_ctx()
+    tracer = _NullTracer()
+    memory_write = _NullMemoryWrite()
+
+    deps = EnsembleDeps(
+        memory_read=_NullMemoryRead(),
+        memory_write=memory_write,
+        tracer=tracer,
+        tensors=_NoopTensors(),
+        solarwill=_NoopSolarWill(),
+        gate=_AllowGate(),
+        philosophers=[],
+        aggregator=_FirstProposalAggregator(),
+        aggregator_shadow=None,
+        registry=None,  # type: ignore[arg-type]
+        settings=None,  # type: ignore[arg-type]
+        shadow_guard=None,
+        deliberation_engine=DeliberationEngine(max_rounds=2),
+    )
+
+    pre = _PhasePreResult(
+        memory=MemorySnapshot(items=[], summary=None, meta={}),
+        tensors=TensorSnapshot.now({"freedom_pressure": 0.0}),
+        intent=Intent.neutral(),
+        mode=SafetyMode.NORMAL,
+        philosophers=[],
+        max_workers=1,
+        timeout_s=1.0,
+    )
+
+    proposals = [_mk_proposal("a-0", "author_a"), _mk_proposal("a-1", "author_a")]
+    result = _run_phase_post(
+        ctx,
+        deps,
+        pre,
+        proposals + [None],
+        [],
+    )
+
+    assert result["status"] == "ok"
+    assert result["proposal"]["proposal_id"] in {"a-0", "a-1"}


### PR DESCRIPTION
### Motivation

- Allow each philosopher to return multiple `Proposal`s without breaking the pipeline while preserving backward compatibility and determinism (registry order + per-philosopher proposal order).
- Ensure downstream phases (deliberation, aggregation, gates) work with a stable "1 author = 1 primary" view while still preserving secondary proposals for scoring/aggregation.

### Description

- Extended `run_philosophers` and `async_run_philosophers` to accept `limit_per_philosopher: int` (default `1`, capped at `5`) and to collect up to that many proposals per philosopher while keeping the returned value a flattened `List[Proposal]` for compatibility; `RunResult.n` now reflects the actual proposals count. (changes: `src/po_core/party_machine.py`)
- Every collected proposal now carries author metadata and an index under `extra[PO_CORE]`: `AUTHOR` and `proposal_index` (0-based) so downstream components can attribute proposals deterministically. (changes: `src/po_core/party_machine.py`)
- Ensemble normalization before deliberation: added `_proposal_author_key` / `_normalize_primary_proposals` to group proposals by author (key = `extra[PO_CORE][AUTHOR]`, fallback `extra["philosopher"]`), pick the first proposal per author as the primary set given to deliberation, preserve secondaries in original order, and recompose `raw_proposals` after deliberation as `deliberated_primaries + preserved_secondaries`. `None` proposals are filtered out early. (changes: `src/po_core/ensemble.py`)
- Defensive change in deliberation `_re_propose()`: when a philosopher returns multiple re-proposals, choose the single candidate with highest `confidence` (stable tie-break: first), attach deliberation metadata, and record number of discarded alternatives in `extra["deliberation_discarded_alternatives"]`. This makes the engine a defensive fallback while ensemble enforces primary-selection. (changes: `src/po_core/deliberation/engine.py`)
- Defensive handling of `None` proposal entries and preservation of existing `proposal_id` semantics (we do not rewrite base `proposal_id` except the small `:0`→`:dN` suffixing that already existed for revised proposals).
- Added unit/integration-style tests exercising multi-proposal collection, metadata embedding, normalization fallback for legacy `extra["philosopher"]`, and `_run_phase_post` flow through deliberation rounds. (new file: `tests/unit/test_multi_proposal_pipeline.py`)

### Testing

- Ran targeted unit tests for the new flow: `pytest -q tests/unit/test_multi_proposal_pipeline.py` — **4 passed**.
- Ran relevant existing suites to validate integration: `pytest -q tests/test_philosopher_concurrency.py tests/unit/test_deliberation_synthesizer_selection.py tests/test_deliberation_engine.py` — **56 passed**.
- Verified golden e2e coverage: `pytest -q tests/test_golden_e2e.py` — **19 passed**.
- Ran the full test suite with `pytest -q` to check regressions; the suite completed with one unrelated failure: `tests/test_session_replay_unit.py::test_session_replay_is_deterministic` failed due to the session-replay answers fixture missing required keys (`version`, `case_ref`, `answers`) in the generated test fixture, which is a preexisting fixture-format mismatch and not caused by the multi-proposal changes; all tests covering modified code and deliberation/ensemble/party_machine flows passed.

Files changed: `src/po_core/party_machine.py`, `src/po_core/ensemble.py`, `src/po_core/deliberation/engine.py`, and added tests `tests/unit/test_multi_proposal_pipeline.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ef8a56c88328b4056fcc689fb0db)