### PR TITLE
feat: normalize_response extracts rationale/confidence/action_type/ci…

### DIFF
--- a/src/po_core/domain/keys.py
+++ b/src/po_core/domain/keys.py
@@ -27,6 +27,10 @@ AUTHOR = "author"
 AUTHOR_RELIABILITY = "author_reliability"
 EMERGENCE_NOVELTY = "emergence_novelty"
 
+# Philosopher response provenance (set by base.propose())
+RATIONALE = "rationale"   # short justification extracted from reason() output
+CITATIONS = "citations"   # list of philosophical references returned by reason()
+
 
 __all__ = [
     "PO_CORE",
@@ -43,4 +47,6 @@ __all__ = [
     "AUTHOR",
     "AUTHOR_RELIABILITY",
     "EMERGENCE_NOVELTY",
+    "RATIONALE",
+    "CITATIONS",
 ]


### PR DESCRIPTION
…tations into Proposal.extra[PO_CORE]

- domain/keys.py: add RATIONALE and CITATIONS constants
- PhilosopherResponse TypedDict: add rationale, confidence, action_type, citations as optional fields (total=False)
- VALID_ACTION_TYPES: frozenset of allowed action_type values; exported in __all__
- normalize_response(): extract four new fields with safe defaults
  - rationale: from 'rationale' key, else first sentence (≤150 chars) of reasoning
  - confidence: from 'confidence', clamped to [0.0,1.0], else 0.5
  - action_type: from 'action_type' if in VALID_ACTION_TYPES, else "answer"
  - citations: from 'citations' if list[str], else []
  - preserved_keys extended so new fields bypass raw-copy loop
- propose(): confidence and action_type are now dynamic (were hardcoded 0.5/"answer")
  - rationale + citations packed into extra[PO_CORE] alongside future AUTHOR
  - has_citations assumption_tag added when citations list is non-empty
- PhilosopherProtocol: docstring updated to formally declare the four extra[PO_CORE] guarantees that every conforming implementation must satisfy

https://claude.ai/code/session_01PJKySxjse86xbjscuxVY2g

## Summary
- 変更概要:
- 背景/目的:

## Policy Change Protocol v1（policy定数変更時のみ必須）
- [ ] policy定数変更なし（該当しない）
- [ ] policy_lab レポート（JSON）を添付した
- [ ] policy_lab レポート（Markdown）を添付した
- [ ] impacted_requirements 上位（例: Top 3）を本文へ記載した
- [ ] golden差分がある場合、再生成で更新した（手編集なし）
- [ ] golden差分要約（対象ケース/主要差分/妥当性）を本文へ記載した

## Evidence
- policy_lab artifacts:
  - JSON:
  - Markdown:
- impacted_requirements (Top):
  1.
  2.
  3.

## Validation
- [ ] `pytest -q` を実行し全通

## Notes
- 追加の注意事項・制約:
