### PR TITLE
PR-6-0301: 日本語対応の freedom_pressure 正規化と v2 アンカー多言語拡張

### DIFF
--- a/src/po_core/text/__init__.py
+++ b/src/po_core/text/__init__.py
@@ -1,0 +1,6 @@
+"""Text utilities for language-robust metric preprocessing."""
+
+from po_core.text.normalize import detect_language_simple, normalize_text
+
+__all__ = ["normalize_text", "detect_language_simple"]
+

--- a/src/po_core/text/normalize.py
+++ b/src/po_core/text/normalize.py
@@ -1,0 +1,49 @@
+"""Normalization and simple language detection utilities."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Literal
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_JA_CHAR_RE = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]")
+_LATIN_CHAR_RE = re.compile(r"[A-Za-z]")
+
+Language = Literal["ja", "en", "mixed"]
+
+
+def normalize_text(text: str) -> str:
+    """
+    Normalize text for deterministic keyword/anchor matching.
+
+    - Unicode NFKC normalization
+    - Collapse repeated spaces/newlines/tabs into single spaces
+    - Lowercase English letters (Japanese characters are unchanged)
+    """
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = _WHITESPACE_RE.sub(" ", normalized).strip()
+    return normalized.lower()
+
+
+def detect_language_simple(text: str) -> Language:
+    """
+    Detect text language with a lightweight heuristic.
+
+    Returns:
+        - "ja": Japanese scripts only (hiragana/katakana/kanji)
+        - "en": Latin letters only
+        - "mixed": both Japanese and Latin are present, or neither is clear
+    """
+    has_ja = bool(_JA_CHAR_RE.search(text))
+    has_latin = bool(_LATIN_CHAR_RE.search(text))
+
+    if has_ja and not has_latin:
+        return "ja"
+    if has_latin and not has_ja:
+        return "en"
+    return "mixed"
+
+
+__all__ = ["normalize_text", "detect_language_simple", "Language"]
+

--- a/tests/test_freedom_pressure_japanese.py
+++ b/tests/test_freedom_pressure_japanese.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+
+from po_core.domain.context import Context
+from po_core.domain.memory_snapshot import MemorySnapshot
+from po_core.tensors.freedom_pressure_v2 import FreedomPressureV2
+from po_core.tensors.metrics.freedom_pressure import metric_freedom_pressure
+
+
+def _ctx(text: str) -> Context:
+    return Context.now(request_id=str(uuid.uuid4()), user_input=text, meta={})
+
+
+def _empty_mem() -> MemorySnapshot:
+    return MemorySnapshot(items=[], summary=None, meta={})
+
+
+def test_freedom_pressure_v1_japanese_is_non_zero() -> None:
+    text = "私はどちらを選ぶべきでしょうか。社会への影響と責任があり、今すぐ判断したいです。"
+    _, score = metric_freedom_pressure(_ctx(text), _empty_mem())
+    assert score > 0.0
+
+
+def test_freedom_pressure_v2_japanese_has_non_zero_and_variance() -> None:
+    fp = FreedomPressureV2(model_name="__nonexistent_model_to_force_keyword_fallback__")
+    fp.reset_state()
+    result = fp.compute_v2(
+        "どの選択肢を選ぶべきか迷っています。倫理と責任、社会的影響を考える必要があります。"
+    )
+
+    values = list(result.values.values())
+    assert any(v > 0.0 for v in values)
+    assert len({round(v, 4) for v in values}) > 1
+
+
+def test_freedom_pressure_v2_english_regression_case() -> None:
+    fp = FreedomPressureV2(model_name="__nonexistent_model_to_force_keyword_fallback__")
+    fp.reset_state()
+    result = fp.compute_v2(
+        "I must decide quickly because this is urgent and affects other people in society."
+    )
+
+    assert result.values["choice"] > 0.0
+    assert result.values["urgency"] > 0.0
+    assert result.values["social"] > 0.0


### PR DESCRIPTION
### Motivation

- 日本語入力で freedom_pressure 系が「全次元0に張り付く」「言語差でゲートが誤作動する」問題を低減するため、軽量な正規化と言語判定を導入してキーワード/アンカー照合を言語に依存しない形にする。 

### Description

- 新規に `src/po_core/text/normalize.py` を追加し、`normalize_text(text: str)`（NFKC・空白正規化・英字の lower 化）と `detect_language_simple(text)`（`"ja"|"en"|"mixed"` の簡易判定）を実装し公開用 `src/po_core/text/__init__.py` を追加。 
- `src/po_core/tensors/metrics/freedom_pressure.py` を拡張し、既存の英語キーワード挙動は維持したまま日本語キーワード辞書を追加し、日本語は分かち書き不要の部分一致（substring/regex）で評価するロジックを導入して v1 の日本語頑健性を向上。 
- `src/po_core/tensors/freedom_pressure_v2.py` を拡張し、アンカーフレーズを英語/日本語の2セット化、キーワードフォールバックも EN/JA 2セット化、`detect_language_simple` による言語切替（`en`/`ja` は該当セット、`mixed` は両者の次元ごと max を採用）を実装し、将来の校正のため `correlation_matrix`／`anchor_phrases_en`／`anchor_phrases_ja`／`keyword_anchors_*` をコンストラクタ/ファクトリ引数で差し替え可能にした。 
- 日本語対応を確認するため `tests/test_freedom_pressure_japanese.py` を追加し、v1/v2 の日本語非ゼロ化と v2 の次元分散、及び英語回帰ケースを検証するテストを追加。 
- 依存は追加せず（形態素解析器は導入していません）、既存の英語挙動を壊さないように実装。 

### Testing

- 実行したコマンド: `pytest -q tests/test_freedom_pressure_japanese.py tests/test_tensor_metrics.py tests/unit/test_freedom_pressure_v2.py` — 結果: `88 passed`（全件成功）。
- 実行したコマンド: `pytest -q`（全テストスイート） — 結果: `1 failed, 3385 passed, 134 skipped` にて失敗が発生しましたが、失敗したテストは `tests/test_session_replay_unit.py::test_session_replay_is_deterministic` で、`scripts/session_replay.py` が読み込む answers JSON のスキーマ（`version`/`case_ref`/`answers` 必須）に起因するもので、本PRで変更した freedom_pressure ロジックや追加したテキスト正規化とは無関係と判断しました。 
- 追加の静的チェック: 新規/変更ファイルに対して `python -m py_compile` を実行しコンパイルエラーなしを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42cfcf0b48328982162a2f6a2cf10)