### PR TITLE
Add trade-off observation bench script, smoke test, and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,25 @@ d = response.to_dict()            # JSON-serializable dict
 restored = PoSelfResponse.from_dict(d)  # Round-trip
 ```
 
+### Observe `synthesis_report` (Trade-off Device Bench)
+
+`PoSelf` includes `metadata["synthesis_report"]` when structured output mode is enabled.
+
+```bash
+export PO_STRUCTURED_OUTPUT=1
+python scripts/observe_device.py "転職するべき？家族とキャリアのトレードオフが悩み"
+```
+
+The observer script will print:
+
+- `request_id`, `status`, `degraded`, and `consensus_leader`
+- pretty-printed `metadata["synthesis_report"]`
+- `DeliberationCompleted` payload from `PoSelf.get_trace()` (when present)
+- short summaries for `scoreboard` / `disagreements` when available
+
+`scripts/observe_device.py` also sets `PO_STRUCTURED_OUTPUT=1` with
+`os.environ.setdefault(...)`, so existing environment values are preserved.
+
 ### Legacy API (Deprecated — will be removed in v0.3)
 
 ```python

--- a/scripts/observe_device.py
+++ b/scripts/observe_device.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Observe trade-off device outputs and deliberation traces from PoSelf."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from po_core.po_self import PoSelf
+from po_core.trace.in_memory import InMemoryTracer
+
+
+def _short_summary(report: Dict[str, Any] | None) -> None:
+    if not isinstance(report, dict):
+        return
+
+    scoreboard = report.get("scoreboard")
+    disagreements = report.get("disagreements")
+
+    if isinstance(scoreboard, dict):
+        print("\n[scoreboard summary]")
+        for axis in sorted(scoreboard.keys()):
+            entry = scoreboard.get(axis)
+            if isinstance(entry, dict):
+                mean = entry.get("mean")
+                variance = entry.get("variance")
+                samples = entry.get("samples")
+                print(
+                    f"- {axis}: mean={mean}, variance={variance}, samples={samples}"
+                )
+
+    if isinstance(disagreements, list):
+        print("\n[disagreements summary]")
+        for idx, item in enumerate(disagreements[:3], start=1):
+            if isinstance(item, dict):
+                axis = item.get("axis")
+                spread = item.get("spread")
+                print(f"- #{idx}: axis={axis}, spread={spread}")
+            else:
+                print(f"- #{idx}: {item}")
+        if len(disagreements) > 3:
+            print(f"- ... ({len(disagreements) - 3} more)")
+
+
+def main() -> int:
+    prompt = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else "転職するべき？家族とキャリアのトレードオフが悩み"
+    )
+
+    os.environ.setdefault("PO_STRUCTURED_OUTPUT", "1")
+
+    po = PoSelf(enable_trace=True)
+    response = po.generate(prompt)
+
+    metadata = response.metadata or {}
+
+    print(f"request_id: {metadata.get('request_id')}")
+    print(f"status: {metadata.get('status')}")
+    print(f"degraded: {metadata.get('degraded')}")
+    print(f"consensus_leader: {response.consensus_leader}")
+
+    report = metadata.get("synthesis_report")
+    print("\n[synthesis_report]")
+    if report is None:
+        print("None")
+    else:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+
+    tracer = po.get_trace()
+    print("\n[DeliberationCompleted payload]")
+    if not isinstance(tracer, InMemoryTracer):
+        print("None")
+        return 0
+
+    event = next(
+        (e for e in tracer.events if e.event_type == "DeliberationCompleted"), None
+    )
+    if event is None:
+        print("None")
+        return 0
+
+    print(json.dumps(event.payload, ensure_ascii=False, indent=2, sort_keys=True))
+    _short_summary(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_observe_device_smoke.py
+++ b/tests/test_observe_device_smoke.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from po_core.po_self import PoSelf
+
+
+def test_poself_metadata_has_synthesis_report_key(monkeypatch) -> None:
+    monkeypatch.setenv("PO_STRUCTURED_OUTPUT", "1")
+
+    response = PoSelf(enable_trace=True).generate("Is freedom important?")
+
+    assert "synthesis_report" in response.metadata


### PR DESCRIPTION
### Motivation

- Provide a minimal observation bench to inspect the trade-off device's `synthesis_report` and deliberation trace without changing the `run_turn` pipeline logic.  
- Make it easy to debug and summarize `scoreboard` / `disagreements` and DeliberationCompleted payloads while preserving deterministic/golden contracts and existing behavior.

### Description

- Add `scripts/observe_device.py` which calls `PoSelf(enable_trace=True).generate(prompt)`, runs `os.environ.setdefault("PO_STRUCTURED_OUTPUT","1")`, prints `request_id`, `status`, `degraded`, `consensus_leader`, pretty-prints `metadata["synthesis_report"]`, extracts the `DeliberationCompleted` event from `PoSelf.get_trace()` and prints a short `scoreboard`/`disagreements` summary.  
- Add smoke test `tests/test_observe_device_smoke.py` which `monkeypatch.setenv("PO_STRUCTURED_OUTPUT","1")`, invokes `PoSelf(enable_trace=True).generate("Is freedom important?")` and asserts that `response.metadata` contains the `synthesis_report` key.  
- Update `README.md` with a new section showing `PO_STRUCTURED_OUTPUT=1` usage and an example run of `scripts/observe_device.py`.  
- No pipeline logic was changed, no new dependencies were added, and frozen golden files were not modified.

### Testing

- Ran `pytest -q tests/test_observe_device_smoke.py` which passed.  
- Ran full test suite with `pytest -q`, which completed successfully (`3446 passed, 134 skipped`).  
- The added smoke test is lightweight and uses `monkeypatch` to avoid heavy runtime overhead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45c1b164c83288439c49a24e3cead)