### PR TITLE
Add Japanese tension keyword detection to InteractionMatrix

### DIFF
--- a/tests/test_interaction_tensor_japanese.py
+++ b/tests/test_interaction_tensor_japanese.py
@@ -1,0 +1,36 @@
+"""Japanese tension detection tests for InteractionMatrix."""
+
+from __future__ import annotations
+
+from po_core.domain.proposal import Proposal
+from po_core.tensors.interaction_tensor import InteractionMatrix
+
+
+def _proposal(name: str, content: str) -> Proposal:
+    return Proposal(
+        proposal_id=f"test:{name}:0",
+        action_type="answer",
+        content=content,
+        confidence=0.5,
+        extra={
+            "_po_core": {"author": name},
+            "philosopher": name,
+        },
+    )
+
+
+def test_japanese_opposition_generates_tension_and_interference():
+    """Guarantee JA opposition keywords produce non-zero tension/interference."""
+    proposals = [
+        _proposal("哲学者A", "自由と個人の主観を重視する立場"),
+        _proposal("哲学者B", "決定論と集団の客観を重視する立場"),
+    ]
+
+    matrix = InteractionMatrix.from_proposals(proposals)
+
+    # PR-11 reason: without JA keyword support, tension often became 0 and
+    # deliberation round2 could break early due to empty interference pairs.
+    assert matrix.tension[0, 1] > 0.0
+
+    pairs = matrix.high_interference_pairs(top_k=5)
+    assert pairs


### PR DESCRIPTION
### Motivation
- Deliberation round-2 can exit early when `InteractionMatrix.high_interference_pairs()` is empty because `_compute_tension()` only matched English opposition keywords, producing zero tension for Japanese inputs.
- Enable robust deliberation for Japanese proposals by detecting and scoring language-appropriate opposing concept pairs while keeping existing English behavior and API stability.

### Description
- Use `normalize_text()` and `detect_language_simple()` from `src/po_core/text/normalize.py` inside `_compute_tension()` to normalize inputs and route by language.
- Add `_JA_OPPOSITION_PAIRS` (e.g. `("自由","決定論")`, `("個人","集団")`, `("主観","客観")`, etc.) and choose opposition pairs by language: `ja` → Japanese pairs, `en` → English pairs, `mixed` → both sets.
- Keep the lightweight keyword-scan approach and complexity (single pass over selected pairs, O(number_of_keywords)); maintain API compatibility and scoring formula.
- Include short inline comments explaining the normalization and language selection rationale, and add `tests/test_interaction_tensor_japanese.py` which documents what the test guarantees.

### Testing
- Ran `pytest -q tests/test_interaction_tensor_japanese.py tests/test_interaction_matrix.py`, and all tests in those files passed.
- Added `tests/test_interaction_tensor_japanese.py` which constructs two Japanese proposals and asserts `matrix.tension[0,1] > 0.0` and that `high_interference_pairs(top_k=5)` is non-empty, ensuring Japanese opposition keywords generate non-zero tension/interference.
- Ran the full suite with `pytest -q`; the change did not break interaction matrix tests, but an existing benchmark assertion `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` failed (unrelated performance threshold), otherwise the test suite completed (multiple tests skipped due to existing config).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45c39a67083289cfa37adefad7287)