### PR TITLE
PR-12: Auto-populate axis_scores for synthesis report scoreboard

### DIFF
--- a/src/po_core/axis/__init__.py
+++ b/src/po_core/axis/__init__.py
@@ -1,5 +1,6 @@
-"""Decision axis related models."""
+"""Decision axis related models and utilities."""
 
+from .scoring import score_text
 from .spec import AxisDimension, AxisSpec, load_axis_spec
 
-__all__ = ["AxisDimension", "AxisSpec", "load_axis_spec"]
+__all__ = ["AxisDimension", "AxisSpec", "load_axis_spec", "score_text"]

--- a/src/po_core/axis/scoring.py
+++ b/src/po_core/axis/scoring.py
@@ -1,0 +1,88 @@
+"""Deterministic axis scoring based on keyword-hit ratio.
+
+This module projects free-form proposal text into axis scores by counting
+whether dimension-specific keywords appear in normalized text.
+The resulting score expresses a *relative emphasis* among dimensions
+(keyword-hit ratio), not a semantic truth estimate.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from po_core.axis.spec import AxisSpec, load_axis_spec
+from po_core.text.normalize import normalize_text
+
+_KEYWORDS_BY_DIMENSION: dict[str, tuple[str, ...]] = {
+    "safety": (
+        "risk",
+        "harm",
+        "danger",
+        "safety",
+        "危険",
+        "リスク",
+        "安全",
+        "炎上",
+        "損害",
+        "法的",
+    ),
+    "benefit": (
+        "benefit",
+        "value",
+        "utility",
+        "profit",
+        "メリット",
+        "価値",
+        "利益",
+        "効果",
+        "便益",
+        "成長",
+    ),
+    "feasibility": (
+        "feasible",
+        "practical",
+        "plan",
+        "steps",
+        "implement",
+        "現実的",
+        "実現",
+        "可能",
+        "手順",
+        "実装",
+        "工数",
+        "予算",
+    ),
+}
+
+
+def score_text(text: str, spec: AxisSpec) -> Dict[str, float]:
+    """Score text across axis dimensions by normalized keyword-hit ratios.
+
+    The score means "how strongly each dimension is emphasized *relative to the
+    other dimensions* by keyword presence". It is intentionally lightweight and
+    deterministic, and should be interpreted as a heuristic projection.
+    """
+
+    normalized = normalize_text(text)
+    dimension_ids = [d.dimension_id for d in spec.dimensions]
+    if not dimension_ids:
+        return {}
+
+    hits_by_dimension: dict[str, int] = {}
+    for dimension_id in dimension_ids:
+        keywords = _KEYWORDS_BY_DIMENSION.get(dimension_id, ())
+        hits = sum(1 for kw in keywords if kw in normalized)
+        hits_by_dimension[dimension_id] = hits
+
+    total_hits = sum(hits_by_dimension.values())
+    if total_hits <= 0:
+        uniform = 1.0 / float(len(dimension_ids))
+        return {dimension_id: uniform for dimension_id in dimension_ids}
+
+    return {
+        dimension_id: (hits_by_dimension[dimension_id] / float(total_hits))
+        for dimension_id in dimension_ids
+    }
+
+
+__all__ = ["score_text", "load_axis_spec", "AxisSpec"]

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Union
 
 from po_core import philosophers
+from po_core.axis.scoring import score_text
+from po_core.axis.spec import load_axis_spec
 from po_core.deliberation.protocol import run_deliberation
 from po_core.domain.context import Context as DomainContext
 from po_core.domain.keys import (
@@ -490,6 +492,7 @@ def _run_phase_post(
 
     enriched: List[DomainProposal] = []
     precheck_counts: Dict[str, int] = {"allow": 0, "revise": 0, "reject": 0}
+    axis_spec = load_axis_spec()
 
     for p in raw_proposals:
         extra = dict(p.extra) if isinstance(p.extra, Mapping) else {}
@@ -515,6 +518,9 @@ def _run_phase_post(
         }
         precheck_counts[v.decision.value] = precheck_counts.get(v.decision.value, 0) + 1
         pc[FREEDOM_PRESSURE] = fp_str
+        pc["axis_scores"] = score_text(str(p.content), axis_spec)
+        pc["axis_name"] = axis_spec.axis_name
+        pc["axis_spec_version"] = axis_spec.spec_version
         extra[PO_CORE] = pc
         enriched.append(
             DomainProposal(

--- a/tests/test_axis_scoring_v1.py
+++ b/tests/test_axis_scoring_v1.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from po_core.axis.scoring import score_text
+from po_core.axis.spec import load_axis_spec
+
+
+def test_score_text_safety_emphasis() -> None:
+    spec = load_axis_spec()
+    text = "This plan has legal risk and potential harm; safety must come first."
+
+    scores = score_text(text, spec)
+
+    assert set(scores.keys()) == {"safety", "benefit", "feasibility"}
+    assert scores["safety"] > scores["benefit"]
+    assert scores["safety"] > scores["feasibility"]
+
+
+def test_score_text_feasibility_emphasis() -> None:
+    spec = load_axis_spec()
+    text = "現実的な手順と実装計画を明示し、工数と予算の見積もりを出す。"
+
+    scores = score_text(text, spec)
+
+    assert set(scores.keys()) == {"safety", "benefit", "feasibility"}
+    assert scores["feasibility"] > scores["safety"]
+    assert scores["feasibility"] > scores["benefit"]

--- a/tests/test_synthesis_report_scoreboard.py
+++ b/tests/test_synthesis_report_scoreboard.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from po_core.po_self import PoSelf
+
+
+def test_synthesis_report_scoreboard_has_axis_samples(monkeypatch) -> None:
+    monkeypatch.setenv("PO_STRUCTURED_OUTPUT", "1")
+
+    response = PoSelf(enable_trace=True).generate(
+        "Please propose a practical plan with explicit steps and budget."
+    )
+
+    report = response.metadata.get("synthesis_report")
+    assert isinstance(report, dict)
+
+    scoreboard = report.get("scoreboard")
+    assert isinstance(scoreboard, dict)
+
+    for axis in ("safety", "benefit", "feasibility"):
+        assert axis in scoreboard
+        assert int(scoreboard[axis]["samples"]) >= 1


### PR DESCRIPTION
### Motivation
- `_build_synthesis_report()` consumes `proposal.extra["_po_core"]["axis_scores"]` but the standard pipeline did not populate it, leaving synthesized scoreboards semantically weak.
- Provide a deterministic, lightweight baseline to project free-form proposal text onto the AxisSpec (v1) dimensions (`safety`, `benefit`, `feasibility`) so the synthesis report scoreboard is meaningful without changing goldens or adding dependencies.

### Description
- Added `src/po_core/axis/scoring.py` implementing `score_text(text: str, spec: AxisSpec) -> Dict[str, float]` that returns per-dimension scores computed as normalized keyword-hit ratios over a fixed EN+JA keyword set, with `total_hits==0` returning a uniform distribution; docstring clarifies this is a "keyword-ratio relative emphasis" heuristic.
- Wired scoring into the standard pipeline by loading `axis_spec = load_axis_spec()` once and, during the policy-enrichment loop in `_run_phase_post` (`src/po_core/ensemble.py`), computing and attaching `extra[PO_CORE]["axis_scores"]` for each proposal and also adding `extra[PO_CORE]["axis_name"]` and `extra[PO_CORE]["axis_spec_version"]` without altering existing `POLICY`/`TRACEQ`/`FREEDOM_PRESSURE` metadata.
- Exported `score_text` from `po_core.axis` via `src/po_core/axis/__init__.py`.
- Added tests: `tests/test_axis_scoring_v1.py` (unit tests for safety/feasibility emphasis) and `tests/test_synthesis_report_scoreboard.py` (end-to-end check that `PoSelf(enable_trace=True).generate()` with `PO_STRUCTURED_OUTPUT=1` yields a `synthesis_report.scoreboard` containing `safety/benefit/feasibility` with at least one sample each).
- Implementation is lightweight, deterministic, and introduces no new dependencies or schema/golden changes.

### Testing
- Ran targeted tests: `pytest -q tests/test_axis_scoring_v1.py tests/test_synthesis_report_scoreboard.py`, result: `3 passed`.
- Ran full test suite: `pytest -q`, result: `3448 passed, 134 skipped` (no failures).
- All added tests passed and the change is additive to existing PO_CORE metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45c4f738483288c004b73141a75e0)