### PR TITLE
PR-13: Add env-gated axis scoring calibration hook

### DIFF
--- a/calibration/axis_scoring_params_example.json
+++ b/calibration/axis_scoring_params_example.json
@@ -1,0 +1,34 @@
+{
+  "version": "axis_scoring_calibration_v1",
+  "feature_order": [
+    "safety",
+    "benefit",
+    "feasibility"
+  ],
+  "labels": {
+    "safety": {
+      "weights": [
+        1.1,
+        0.0,
+        0.0
+      ],
+      "bias": 0.0
+    },
+    "benefit": {
+      "weights": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "bias": 0.0
+    },
+    "feasibility": {
+      "weights": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "bias": 0.0
+    }
+  }
+}

--- a/tests/axis/test_scoring_calibration.py
+++ b/tests/axis/test_scoring_calibration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from po_core.axis.scoring import _clear_scoring_calibration_model_cache, score_text
+from po_core.axis.spec import load_axis_spec
+
+
+def test_score_text_without_calibration_env_returns_keyword_ratios(monkeypatch) -> None:
+    monkeypatch.delenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", raising=False)
+    _clear_scoring_calibration_model_cache()
+
+    spec = load_axis_spec()
+    text = "risk harm value feasible"
+
+    scores = score_text(text, spec)
+
+    assert scores == {
+        "safety": 0.5,
+        "benefit": 0.25,
+        "feasibility": 0.25,
+    }
+
+
+def test_score_text_with_calibration_env_changes_distribution(
+    tmp_path, monkeypatch
+) -> None:
+    params_path = tmp_path / "axis_scoring_params.json"
+    params_path.write_text(
+        json.dumps(
+            {
+                "version": "axis_scoring_calibration_v1",
+                "feature_order": ["safety", "benefit", "feasibility"],
+                "labels": {
+                    "safety": {"weights": [1.5, 0.0, 0.0], "bias": 0.0},
+                    "benefit": {"weights": [0.0, 1.0, 0.0], "bias": 0.0},
+                    "feasibility": {"weights": [0.0, 0.0, 1.0], "bias": 0.0},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    spec = load_axis_spec()
+    text = "risk harm value feasible"
+
+    monkeypatch.delenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", raising=False)
+    _clear_scoring_calibration_model_cache()
+    raw_scores = score_text(text, spec)
+
+    monkeypatch.setenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", str(params_path))
+    _clear_scoring_calibration_model_cache()
+    calibrated_scores = score_text(text, spec)
+
+    assert set(calibrated_scores.keys()) == set(raw_scores.keys())
+    assert calibrated_scores["safety"] > raw_scores["safety"]
+    assert calibrated_scores != raw_scores
+    assert sum(calibrated_scores.values()) == pytest.approx(1.0)


### PR DESCRIPTION
### Motivation
- Provide an optional, environment-gated calibration step for axis scoring so raw keyword-hit ratios can be linearly adjusted by a pre-trained calibration model when explicitly enabled via env var.
- Keep deterministic, backward-compatible behavior by falling back to the existing keyword-hit-ratio heuristic whenever calibration is absent or invalid.

### Description
- Added support for `PO_AXIS_SCORING_CALIBRATION_PARAMS` in `src/po_core/axis/scoring.py` and a memoized loader using `load_calibration_model_from_env(env_var=...)` with `lru_cache`.
- `score_text` now computes raw keyword-hit ratio scores as before, and when a calibration model is present it builds a feature vector in `model.feature_order`, applies `model.apply(...)`, maps results back to the current axis spec dimensions, clamps and then renormalizes the scores so they sum to `1.0` (with uniform fallback if sum<=0).
- Added an example params file `calibration/axis_scoring_params_example.json` using the same JSON format as `axis_calibration` (version `axis_scoring_calibration_v1`).
- Added unit tests `tests/axis/test_scoring_calibration.py` covering baseline (no env var) and calibrated behavior (env var pointing to a temp params file), and exposed `_clear_scoring_calibration_model_cache()` to allow test isolation.

### Testing
- Ran `pytest -q tests/axis/test_scoring_calibration.py tests/test_axis_scoring_v1.py` and both tests passed.
- Ran the full test suite with `pytest -q`, which executed many tests and reported `3451 passed, 1 failed, 134 skipped`; the single failing test is a pre-existing benchmark assertion (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`) and is unrelated to the axis scoring changes.
- The new tests exercise both the no-env fallback and the env-gated calibration path and verified key preservation and that calibrated scores sum approximately to `1.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab5f98b4832888071a77670fe229)