### PR TITLE
Include influence_graph in DeliberationCompleted summary payload

### DIFF
--- a/src/po_core/deliberation/engine.py
+++ b/src/po_core/deliberation/engine.py
@@ -90,6 +90,17 @@ class DeliberationResult:
             key=lambda x: x[1],
             reverse=True,
         )[:3]
+        influence_graph = {
+            name: weight.to_dict() for name, weight in self.influence_weights.items()
+        }
+
+        interference_pairs_top = None
+        if self.interaction_matrix is not None:
+            interference_pairs_top = [
+                pair.to_dict()
+                for pair in self.interaction_matrix.high_interference_pairs(top_k=3)
+            ]
+
         return {
             "n_rounds": self.n_rounds,
             "total_proposals": self.total_proposals,
@@ -113,6 +124,8 @@ class DeliberationResult:
             "top_influencers": [
                 {"philosopher": n, "influence": round(s, 4)} for n, s in top_influencers
             ],
+            "influence_graph": influence_graph,
+            "interference_pairs_top": interference_pairs_top,
             "clustering": (
                 self.cluster_result.to_dict() if self.cluster_result else None
             ),

--- a/tests/test_deliberation_engine.py
+++ b/tests/test_deliberation_engine.py
@@ -8,8 +8,11 @@ Tests for multi-round philosopher dialogue.
 from __future__ import annotations
 
 import uuid
+import json
 
 from po_core.deliberation import DeliberationEngine
+from po_core.deliberation.engine import DeliberationResult, RoundTrace
+from po_core.deliberation.influence import InfluenceWeight
 from po_core.domain.context import Context
 from po_core.domain.intent import Intent
 from po_core.domain.memory_snapshot import MemorySnapshot
@@ -232,6 +235,24 @@ class TestMultiRound:
         )
         assert result.n_rounds >= 2
         assert result.n_rounds <= 3
+
+    def test_summary_includes_influence_graph(self):
+        result = DeliberationResult(
+            proposals=[_proposal("A", "freedom")],
+            rounds=[RoundTrace(round_number=1, n_proposals=1, n_revised=0)],
+            influence_weights={
+                "A": InfluenceWeight(
+                    philosopher_id="A",
+                    influenced={"B": 0.42},
+                )
+            },
+        )
+
+        summary = result.summary()
+
+        assert "influence_graph" in summary
+        assert summary["influence_graph"]["A"]["influenced"] == {"B": 0.42}
+        json.dumps(summary)
 
 
 # ── Integration with real philosophers ───────────────────────────────


### PR DESCRIPTION
### Motivation
- Trace consumers need the full influence graph (who influenced whom) rather than only top influencer aggregates to render influence edges in the viewer.
- The summary payload must remain JSON-serializable and backward-compatible with existing consumers.

### Description
- Added an `influence_graph` field to `DeliberationResult.summary()` built from `self.influence_weights` using `InfluenceWeight.to_dict()` so values are plain dict/list/float and safe for `json.dumps` (no new deps).
- Added an optional `interference_pairs_top` field populated from `interaction_matrix.high_interference_pairs(top_k=3)` when an interaction matrix exists; existing keys (including `top_influencers`) are preserved.
- Modified `src/po_core/deliberation/engine.py` and added a unit test `test_summary_includes_influence_graph` in `tests/test_deliberation_engine.py` which constructs a `DeliberationResult` with an `InfluenceWeight` and asserts the `influence_graph` contains the `influenced` mapping.

### Testing
- Ran `pytest -q tests/test_deliberation_engine.py` and the test file passed successfully.
- Ran the full suite with `pytest -q`; functional/unit tests passed but one benchmark test (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`) failed on the environment due to a performance threshold, resulting in 1 failed, 3450 passed, 134 skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab87402c832896c03525e63ab9f6)