### PR TITLE
Export tradeoff map JSON/Markdown from trace

### DIFF
--- a/scripts/export_tradeoff_map.py
+++ b/scripts/export_tradeoff_map.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Export trade-off map artifacts (JSON + Markdown) from PoSelf trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from po_core.po_self import PoSelf
+from po_core.viewer.tradeoff_map import build_tradeoff_map
+
+
+def _render_axis_table(scoreboard: Dict[str, Any]) -> str:
+    if not scoreboard:
+        return "No axis scoreboard available."
+
+    lines: List[str] = [
+        "| axis | mean | variance | samples |",
+        "|---|---:|---:|---:|",
+    ]
+    for axis in sorted(scoreboard.keys()):
+        entry = scoreboard.get(axis)
+        if not isinstance(entry, dict):
+            continue
+        lines.append(
+            "| {axis} | {mean} | {variance} | {samples} |".format(
+                axis=axis,
+                mean=entry.get("mean", ""),
+                variance=entry.get("variance", ""),
+                samples=entry.get("samples", ""),
+            )
+        )
+    return "\n".join(lines) if len(lines) > 2 else "No axis scoreboard available."
+
+
+def _render_disagreements(disagreements: List[Any]) -> str:
+    if not disagreements:
+        return "No disagreements captured."
+
+    lines: List[str] = []
+    for item in disagreements:
+        if isinstance(item, dict):
+            axis = item.get("axis", "unknown")
+            spread = item.get("spread", "")
+            kind = item.get("kind", "")
+            n_stances = item.get("n_stances", "")
+            lines.append(
+                f"- axis={axis}, spread={spread}, kind={kind}, n_stances={n_stances}"
+            )
+        else:
+            lines.append(f"- {item}")
+    return "\n".join(lines)
+
+
+def _node_id(label: Any) -> str:
+    text = str(label or "unknown")
+    safe = re.sub(r"[^A-Za-z0-9_]", "_", text)
+    return safe or "unknown"
+
+
+def _render_mermaid(influence_graph: List[Any]) -> str:
+    lines: List[str] = ["```mermaid", "graph LR"]
+
+    added = False
+    for edge in influence_graph:
+        if not isinstance(edge, dict):
+            continue
+        src = edge.get("from") or edge.get("source") or edge.get("philosopher_a")
+        dst = edge.get("to") or edge.get("target") or edge.get("philosopher_b")
+        weight = edge.get("weight")
+        if weight is None:
+            weight = edge.get("influence")
+        if src and dst:
+            src_text = str(src)
+            dst_text = str(dst)
+            src_id = _node_id(src_text)
+            dst_id = _node_id(dst_text)
+            label = "" if weight is None else f"|{weight}|"
+            lines.append(f"  {src_id}[\"{src_text}\"] -->{label} {dst_id}[\"{dst_text}\"]")
+            added = True
+
+    if not added:
+        lines.append("  Empty[No influence edges found]")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
+    meta = tradeoff_map.get("meta", {})
+    axis = tradeoff_map.get("axis", {})
+    influence = tradeoff_map.get("influence", {})
+
+    scoreboard = axis.get("scoreboard", {})
+    disagreements = axis.get("disagreements", [])
+    influence_graph = influence.get("influence_graph", [])
+
+    lines = [
+        "# Trade-off Map Report",
+        "",
+        "## Meta",
+        f"- request_id: `{meta.get('request_id', '')}`",
+        f"- status: `{meta.get('status', '')}`",
+        f"- degraded: `{meta.get('degraded', '')}`",
+        f"- consensus_leader: `{meta.get('consensus_leader', '')}`",
+        f"- mode: `{meta.get('mode', '')}`",
+        f"- prompt: {meta.get('prompt', '')}",
+        "",
+        "## Axis Scoreboard",
+        _render_axis_table(scoreboard if isinstance(scoreboard, dict) else {}),
+        "",
+        "## Disagreements",
+        _render_disagreements(disagreements if isinstance(disagreements, list) else []),
+        "",
+        "## Influence Graph",
+        _render_mermaid(influence_graph if isinstance(influence_graph, list) else []),
+        "",
+        "## Influence Disclaimer",
+        "Influence scores are a proxy derived from cosine-distance movement across revisions, not causal proof.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", required=True, help="Prompt for PoSelf")
+    parser.add_argument(
+        "--out-json", default="tradeoff_map.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="tradeoff_map.md", help="Output Markdown path"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    os.environ.setdefault("PO_STRUCTURED_OUTPUT", "1")
+
+    po = PoSelf(enable_trace=True)
+    response = po.generate(args.prompt)
+    tracer = po.get_trace()
+
+    tradeoff_map = build_tradeoff_map(response=response, tracer=tracer)
+
+    out_json = Path(args.out_json)
+    out_json.write_text(
+        json.dumps(tradeoff_map, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    out_md = Path(args.out_md)
+    out_md.write_text(_render_markdown(tradeoff_map), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/po_core/viewer/tradeoff_map.py
+++ b/src/po_core/viewer/tradeoff_map.py
@@ -1,0 +1,93 @@
+"""Trade-off map builder from PoSelf response + trace events."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from po_core.domain.trace_event import TraceEvent
+
+
+
+def _safe_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+
+def _safe_list(value: Any) -> List[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+
+def _events_from_tracer(tracer: Any) -> List[TraceEvent]:
+    if isinstance(tracer, list):
+        return [e for e in tracer if isinstance(e, TraceEvent)]
+
+    events = getattr(tracer, "events", None)
+    if isinstance(events, list):
+        return [e for e in events if isinstance(e, TraceEvent)]
+
+    if isinstance(tracer, Sequence):
+        return [e for e in tracer if isinstance(e, TraceEvent)]
+
+    return []
+
+
+
+def _find_first_payload(events: Sequence[TraceEvent], event_type: str) -> Dict[str, Any]:
+    for event in events:
+        if event.event_type == event_type and isinstance(event.payload, dict):
+            return dict(event.payload)
+    return {}
+
+
+
+def build_tradeoff_map(response: Any, tracer: Any) -> Dict[str, Any]:
+    """Build trade-off map artifact from PoSelf response and trace events."""
+    metadata = _safe_dict(getattr(response, "metadata", {}))
+    synthesis_report = _safe_dict(metadata.get("synthesis_report"))
+
+    events = _events_from_tracer(tracer)
+    deliberation_payload = _find_first_payload(events, "DeliberationCompleted")
+    selected_payload = _find_first_payload(events, "PhilosophersSelected")
+
+    meta: Dict[str, Any] = {
+        "request_id": metadata.get("request_id"),
+        "status": metadata.get("status"),
+        "degraded": metadata.get("degraded"),
+        "consensus_leader": getattr(response, "consensus_leader", None),
+        "prompt": getattr(response, "prompt", ""),
+    }
+    if selected_payload:
+        for key in ("ids", "mode", "workers"):
+            if key in selected_payload:
+                meta[key] = selected_payload.get(key)
+
+    axis = {
+        "scoreboard": _safe_dict(synthesis_report.get("scoreboard")),
+        "disagreements": _safe_list(synthesis_report.get("disagreements")),
+        "stance_distribution": _safe_dict(synthesis_report.get("stance_distribution")),
+    }
+
+    influence = {
+        "influence_graph": _safe_list(deliberation_payload.get("influence_graph")),
+        "top_influencers": _safe_list(deliberation_payload.get("top_influencers")),
+        "rounds": _safe_list(deliberation_payload.get("rounds")),
+        "interaction_summary": _safe_dict(
+            deliberation_payload.get("interaction_summary")
+        ),
+    }
+
+    timeline = [
+        {
+            "event_type": event.event_type,
+            "ts": event.occurred_at.isoformat(),
+        }
+        for event in events
+    ]
+
+    return {
+        "meta": meta,
+        "axis": axis,
+        "influence": influence,
+        "timeline": timeline,
+    }

--- a/tests/unit/test_tradeoff_map.py
+++ b/tests/unit/test_tradeoff_map.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+from po_core.domain.trace_event import TraceEvent
+from po_core.po_self import PoSelfResponse
+from po_core.viewer.tradeoff_map import build_tradeoff_map
+
+
+class _FakeTracer:
+    def __init__(self, events):
+        self.events = events
+
+
+def test_build_tradeoff_map_serializable_and_keys() -> None:
+    response = PoSelfResponse(
+        prompt="How should I choose?",
+        text="result",
+        philosophers=["kant", "aristotle"],
+        metrics={},
+        responses=[],
+        log={},
+        consensus_leader="kant",
+        metadata={
+            "request_id": "req-1",
+            "status": "ok",
+            "degraded": False,
+            "synthesis_report": {
+                "scoreboard": {"safety": {"mean": 0.7, "variance": 0.02, "samples": 2}},
+                "disagreements": [{"axis": "safety", "spread": 0.3}],
+                "stance_distribution": {"pro": 1, "con": 1},
+            },
+        },
+    )
+
+    events = [
+        TraceEvent.now(
+            "PhilosophersSelected",
+            "req-1",
+            {"ids": ["kant", "aristotle"], "mode": "NORMAL", "workers": 2},
+        ),
+        TraceEvent.now(
+            "DeliberationCompleted",
+            "req-1",
+            {
+                "influence_graph": [{"from": "kant", "to": "aristotle", "weight": 0.23}],
+                "top_influencers": [{"philosopher": "kant", "influence": 0.23}],
+                "rounds": [{"round": 1, "n_proposals": 2, "n_revised": 0}],
+                "interaction_summary": {"mean_harmony": 0.8},
+                "n_rounds": 1,
+                "total_proposals": 2,
+            },
+        ),
+    ]
+
+    tradeoff_map = build_tradeoff_map(response=response, tracer=_FakeTracer(events))
+
+    assert set(tradeoff_map.keys()) == {"meta", "axis", "influence", "timeline"}
+    assert tradeoff_map["meta"]["request_id"] == "req-1"
+    assert tradeoff_map["axis"]["scoreboard"]["safety"]["samples"] == 2
+    assert tradeoff_map["influence"]["influence_graph"][0]["from"] == "kant"
+    assert tradeoff_map["timeline"][0]["event_type"] == "PhilosophersSelected"
+
+    # Must be JSON serializable
+    json.dumps(tradeoff_map, ensure_ascii=False)


### PR DESCRIPTION
### Motivation
- Provide a compact, deterministic "trade-off map" artifact that surfaces which axes were split and who influenced whom by combining the `synthesis_report` with deliberation trace events.
- Make it easy to export the artifact as both machine-readable JSON and a human-friendly Markdown report (with Mermaid graph) for review in GitHub and external tooling.

### Description
- Added `src/po_core/viewer/tradeoff_map.py` with `build_tradeoff_map(response, tracer)`, which extracts `synthesis_report` from `PoSelfResponse.metadata`, the first `DeliberationCompleted` payload and optional `PhilosophersSelected` payload from trace events, and returns a deterministic dict with `meta`, `axis`, `influence`, and `timeline` sections; missing parts yield empty dicts/lists.
- Added CLI `scripts/export_tradeoff_map.py` which ensures `PO_STRUCTURED_OUTPUT=1`, runs `PoSelf(enable_trace=True).generate(prompt)`, obtains the tracer via `po.get_trace()`, writes pretty JSON (`--out-json`) and a Markdown report (`--out-md`) that includes an axis scoreboard table, disagreements, a sanitized Mermaid directed graph for influence edges, and a clear disclaimer that influence is a cosine-distance proxy.
- Added unit test `tests/unit/test_tradeoff_map.py` that builds a fake tracer with `TraceEvent.now(...)` events and a `PoSelfResponse`, verifies top-level keys and key fields from the produced tradeoff map, and asserts JSON serializability.

### Testing
- Ran the new unit test: `pytest -q tests/unit/test_tradeoff_map.py` which passed.
- Ran the full test suite: `pytest -q` produced `3450 passed, 1 failed, 134 skipped` and the single failing test was the benchmark `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` (performance regression in this environment), all other tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab98dab08328b9bba2db5b2fc76e)