### PR TITLE
PR-17: Normalize tradeoff map influence/disagreement rendering

### DIFF
--- a/tests/viewer/test_tradeoff_map_influence_edges.py
+++ b/tests/viewer/test_tradeoff_map_influence_edges.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from po_core.domain.trace_event import TraceEvent
+from po_core.po_self import PoSelfResponse
+from po_core.viewer.tradeoff_map import build_tradeoff_map
+import importlib.util
+from pathlib import Path
+
+
+def _load_render_markdown():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "export_tradeoff_map.py"
+    spec = importlib.util.spec_from_file_location("export_tradeoff_map", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._render_markdown
+
+
+_render_markdown = _load_render_markdown()
+
+
+def _event(event_type: str, payload: dict) -> TraceEvent:
+    return TraceEvent(
+        event_type=event_type,
+        occurred_at=datetime(2026, 2, 22, 0, 0, 0, tzinfo=timezone.utc),
+        correlation_id="req-17",
+        payload=payload,
+    )
+
+
+def test_build_tradeoff_map_adds_influence_edges_from_graph_dict() -> None:
+    response = PoSelfResponse(
+        prompt="test",
+        text="result",
+        philosophers=["kant", "aristotle"],
+        metrics={},
+        responses=[],
+        log={},
+        consensus_leader="kant",
+        metadata={"request_id": "req-17", "synthesis_report": {}},
+    )
+    events = [
+        _event(
+            "DeliberationCompleted",
+            {
+                "influence_graph": {
+                    "kant": {"influenced": {"aristotle": 0.23, "mill": 0.11}},
+                    "aristotle": {"influenced": {"kant": 0.04}},
+                },
+                "interference_pairs_top": [["kant", "aristotle", 0.2]],
+            },
+        )
+    ]
+
+    tradeoff_map = build_tradeoff_map(response=response, tracer=events)
+
+    assert tradeoff_map["influence"]["influence_graph"]["kant"]["influenced"]["mill"] == 0.11
+    assert tradeoff_map["influence"]["interference_pairs_top"] == [["kant", "aristotle", 0.2]]
+    assert {edge["to"] for edge in tradeoff_map["influence"]["influence_edges"]} == {
+        "aristotle",
+        "mill",
+        "kant",
+    }
+
+
+def test_render_markdown_uses_influence_edges_for_mermaid() -> None:
+    tradeoff_map = {
+        "meta": {},
+        "axis": {"scoreboard": {}, "disagreements": []},
+        "influence": {
+            "influence_graph": {
+                "kant": {"influenced": {"aristotle": 0.23}},
+            },
+            "influence_edges": [
+                {"from": "kant", "to": "aristotle", "weight": 0.23},
+            ],
+        },
+        "timeline": [],
+    }
+
+    markdown = _render_markdown(tradeoff_map)
+
+    assert "-->" in markdown
+    assert "kant" in markdown
+    assert "aristotle" in markdown


### PR DESCRIPTION
### Motivation
- `DeliberationResult.summary()` emits `influence_graph` as a dict (philosopher -> InfluenceWeight) while the viewer/export pipeline expected a list, causing silent empty Mermaid graphs. 
- The disagreements renderer assumed older key shapes and missed `type`-based variants like `stance_split` and `axis_variance` emitted by the synthesizer.

### Description
- Updated `src/po_core/viewer/tradeoff_map.py` to preserve dict-form `influence_graph`, add a flattened `influence_edges` list built from `influence_graph`, include `interference_pairs_top` from the `DeliberationCompleted` payload, and add defensive helpers (`_safe_float`, `_flatten_influence_graph`, `_safe_dict_or_list`).
- Updated `scripts/export_tradeoff_map.py` so Mermaid rendering prefers `influence_edges`, falls back to flattening dict-form `influence_graph` if needed, and added `_flatten_influence_graph`/_safe helpers to keep behavior robust and backward-compatible.
- Enhanced disagreements rendering in `scripts/export_tradeoff_map.py` to handle `type` variants (`stance_split` and `axis_variance`) while keeping legacy fallbacks.
- Added unit tests in `tests/viewer/test_tradeoff_map_influence_edges.py` to verify `influence_edges` generation, preservation of `interference_pairs_top`, and that Markdown export emits Mermaid edge syntax.
- No schema or golden files were modified and no new dependencies were introduced; changes are additive and backward-compatible (only new keys added).

### Testing
- Ran `pytest -q tests/viewer/test_tradeoff_map_influence_edges.py tests/unit/test_tradeoff_map.py` and both tests passed.
- Ran `pytest -q -m 'not benchmark'` and the selected test suite passed (`3441 passed, 134 skipped, 15 deselected` in this environment).
- Ran full `pytest -q`; the run passed the vast majority of tests but an unrelated benchmark assertion failed in this environment (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`), otherwise the test suite was green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f603bb308328801dbd11a3f86357)