### PR TITLE
Freeze tradeoff_map v1 contract and add lightweight validator

### DIFF
--- a/tests/unit/test_tradeoff_map.py
+++ b/tests/unit/test_tradeoff_map.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 
 from po_core.domain.trace_event import TraceEvent
 from po_core.po_self import PoSelfResponse
-from po_core.viewer.tradeoff_map import build_tradeoff_map
+from po_core.viewer.tradeoff_map import build_tradeoff_map, validate_tradeoff_map_v1
 
 
 class _FakeTracer:
@@ -12,7 +13,8 @@ class _FakeTracer:
         self.events = events
 
 
-def test_build_tradeoff_map_serializable_and_keys() -> None:
+def test_build_tradeoff_map_serializable_and_keys(monkeypatch) -> None:
+    monkeypatch.setenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", "/tmp/calibration.json")
     response = PoSelfResponse(
         prompt="How should I choose?",
         text="result",
@@ -26,6 +28,8 @@ def test_build_tradeoff_map_serializable_and_keys() -> None:
             "status": "ok",
             "degraded": False,
             "synthesis_report": {
+                "axis_name": "decision_axis",
+                "axis_spec_version": "axis_spec_v1",
                 "scoreboard": {"safety": {"mean": 0.7, "variance": 0.02, "samples": 2}},
                 "disagreements": [{"axis": "safety", "spread": 0.3}],
                 "stance_distribution": {"pro": 1, "con": 1},
@@ -55,11 +59,67 @@ def test_build_tradeoff_map_serializable_and_keys() -> None:
 
     tradeoff_map = build_tradeoff_map(response=response, tracer=_FakeTracer(events))
 
-    assert set(tradeoff_map.keys()) == {"meta", "axis", "influence", "timeline"}
+    assert set(tradeoff_map.keys()) == {
+        "schema_version",
+        "meta",
+        "axis",
+        "influence",
+        "timeline",
+    }
+    assert tradeoff_map["schema_version"] == "tradeoff_map_v1"
     assert tradeoff_map["meta"]["request_id"] == "req-1"
+    assert tradeoff_map["meta"]["axis_name"] == "decision_axis"
+    assert tradeoff_map["meta"]["axis_spec_version"] == "axis_spec_v1"
+    assert tradeoff_map["meta"]["axis_scoring_calibration_enabled"] is True
     assert tradeoff_map["axis"]["scoreboard"]["safety"]["samples"] == 2
     assert tradeoff_map["influence"]["influence_graph"][0]["from"] == "kant"
     assert tradeoff_map["timeline"][0]["event_type"] == "PhilosophersSelected"
 
     # Must be JSON serializable
     json.dumps(tradeoff_map, ensure_ascii=False)
+
+
+def test_validate_tradeoff_map_v1_accepts_minimal_valid_payload() -> None:
+    tradeoff_map = {
+        "schema_version": "tradeoff_map_v1",
+        "meta": {},
+        "axis": {},
+        "influence": {},
+        "timeline": [],
+    }
+
+    validate_tradeoff_map_v1(tradeoff_map)
+
+
+def test_validate_tradeoff_map_v1_rejects_missing_or_invalid_required_keys() -> None:
+    valid = {
+        "schema_version": "tradeoff_map_v1",
+        "meta": {},
+        "axis": {},
+        "influence": {},
+        "timeline": [],
+    }
+    required = {
+        "schema_version": 1,
+        "meta": [],
+        "axis": [],
+        "influence": [],
+        "timeline": {},
+    }
+
+    for key, bad_value in required.items():
+        missing = deepcopy(valid)
+        missing.pop(key)
+        try:
+            validate_tradeoff_map_v1(missing)
+            raise AssertionError(f"expected ValueError for missing key: {key}")
+        except ValueError as exc:
+            assert key in str(exc)
+
+        wrong_type = deepcopy(valid)
+        wrong_type[key] = bad_value
+        try:
+            validate_tradeoff_map_v1(wrong_type)
+            raise AssertionError(f"expected ValueError for wrong type: {key}")
+        except ValueError as exc:
+            assert key in str(exc)


### PR DESCRIPTION
### Motivation

- Establish a frozen, minimal v1 contract for tradeoff map artifacts by adding an explicit schema version to outputs. 
- Surface lightweight, deterministic metadata needed by consumers (`axis_name`, `axis_spec_version`, calibration flag) without breaking existing consumers. 
- Provide a small, dependency-free validator to catch integration errors early and keep the contract stable.

### Description

- Add top-level `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f631a89883289ead64e86c03db7e)