### PR TITLE
Expose per-proposal axis_vectors in synthesis report and tradeoff map

### DIFF
--- a/scripts/export_tradeoff_map.py
+++ b/scripts/export_tradeoff_map.py
@@ -43,6 +43,38 @@ def _render_axis_table(scoreboard: Dict[str, Any]) -> str:
     return "\n".join(lines) if len(lines) > 2 else "No axis scoreboard available."
 
 
+
+
+def _render_axis_vectors_table(axis_vectors: List[Any]) -> str:
+    if not axis_vectors:
+        return "No axis vectors available."
+
+    lines: List[str] = [
+        "| author | safety | benefit | feasibility | confidence | policy |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+
+    rows: List[Dict[str, Any]] = []
+    for item in axis_vectors:
+        if isinstance(item, dict):
+            rows.append(item)
+
+    for item in sorted(rows, key=lambda row: str(row.get("author") or "")):
+        scores = item.get("axis_scores", {})
+        scores = scores if isinstance(scores, dict) else {}
+        lines.append(
+            "| {author} | {safety} | {benefit} | {feasibility} | {confidence} | {policy} |".format(
+                author=item.get("author", ""),
+                safety=scores.get("safety", ""),
+                benefit=scores.get("benefit", ""),
+                feasibility=scores.get("feasibility", ""),
+                confidence=item.get("confidence", ""),
+                policy=item.get("policy", ""),
+            )
+        )
+
+    return "\n".join(lines) if len(lines) > 2 else "No axis vectors available."
+
 def _render_disagreements(disagreements: List[Any]) -> str:
     if not disagreements:
         return "No disagreements captured."
@@ -103,6 +135,7 @@ def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
 
     scoreboard = axis.get("scoreboard", {})
     disagreements = axis.get("disagreements", [])
+    axis_vectors = axis.get("axis_vectors", [])
     influence_graph = influence.get("influence_graph", [])
 
     lines = [
@@ -121,6 +154,9 @@ def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
         "",
         "## Disagreements",
         _render_disagreements(disagreements if isinstance(disagreements, list) else []),
+        "",
+        "## Axis Vectors",
+        _render_axis_vectors_table(axis_vectors if isinstance(axis_vectors, list) else []),
         "",
         "## Influence Graph",
         _render_mermaid(influence_graph if isinstance(influence_graph, list) else []),

--- a/src/po_core/viewer/tradeoff_map.py
+++ b/src/po_core/viewer/tradeoff_map.py
@@ -66,6 +66,7 @@ def build_tradeoff_map(response: Any, tracer: Any) -> Dict[str, Any]:
         "scoreboard": _safe_dict(synthesis_report.get("scoreboard")),
         "disagreements": _safe_list(synthesis_report.get("disagreements")),
         "stance_distribution": _safe_dict(synthesis_report.get("stance_distribution")),
+        "axis_vectors": _safe_list(synthesis_report.get("axis_vectors")),
     }
 
     influence = {

--- a/tests/unit/test_export_tradeoff_map.py
+++ b/tests/unit/test_export_tradeoff_map.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "export_tradeoff_map.py"
+_SPEC = importlib.util.spec_from_file_location("export_tradeoff_map", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_render_markdown_contains_axis_vectors_table_header() -> None:
+    markdown = _MODULE._render_markdown(
+        {
+            "meta": {},
+            "axis": {
+                "scoreboard": {},
+                "disagreements": [],
+                "axis_vectors": [
+                    {
+                        "author": "kant",
+                        "axis_scores": {
+                            "safety": 0.7,
+                            "benefit": 0.5,
+                            "feasibility": 0.6,
+                        },
+                        "confidence": 0.8,
+                        "policy": "allow",
+                    }
+                ],
+            },
+            "influence": {"influence_graph": []},
+        }
+    )
+
+    assert "| author | safety | benefit | feasibility | confidence | policy |" in markdown

--- a/tests/unit/test_synthesis_report_axis_vectors.py
+++ b/tests/unit/test_synthesis_report_axis_vectors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from po_core.domain.keys import AUTHOR, PO_CORE, POLICY
+from po_core.domain.proposal import Proposal
+from po_core.ensemble import _build_synthesis_report
+
+
+def test_build_synthesis_report_includes_axis_vectors() -> None:
+    proposals = [
+        Proposal(
+            proposal_id="p-1",
+            action_type="answer",
+            content="First",
+            confidence=0.8,
+            extra={
+                PO_CORE: {
+                    AUTHOR: "kant",
+                    "axis_scores": {"safety": 0.7, "benefit": 0.6},
+                    POLICY: {"decision": "allow"},
+                }
+            },
+        ),
+        Proposal(
+            proposal_id="p-2",
+            action_type="answer",
+            content="Second",
+            confidence=0.4,
+            extra={PO_CORE: {AUTHOR: "nietzsche", "axis_scores": {"safety": 0.2}}},
+        ),
+    ]
+
+    report = _build_synthesis_report(proposals)
+
+    assert "axis_vectors" in report
+    assert report["axis_vectors"] == [
+        {
+            "author": "kant",
+            "proposal_id": "p-1",
+            "confidence": 0.8,
+            "axis_scores": {"safety": 0.7, "benefit": 0.6},
+            "policy": "allow",
+        },
+        {
+            "author": "nietzsche",
+            "proposal_id": "p-2",
+            "confidence": 0.4,
+            "axis_scores": {"safety": 0.2},
+            "policy": None,
+        },
+    ]

--- a/tests/unit/test_tradeoff_map.py
+++ b/tests/unit/test_tradeoff_map.py
@@ -29,6 +29,7 @@ def test_build_tradeoff_map_serializable_and_keys() -> None:
                 "scoreboard": {"safety": {"mean": 0.7, "variance": 0.02, "samples": 2}},
                 "disagreements": [{"axis": "safety", "spread": 0.3}],
                 "stance_distribution": {"pro": 1, "con": 1},
+                "axis_vectors": [{"author": "kant", "axis_scores": {"safety": 0.7}}],
             },
         },
     )
@@ -59,6 +60,7 @@ def test_build_tradeoff_map_serializable_and_keys() -> None:
     assert tradeoff_map["meta"]["request_id"] == "req-1"
     assert tradeoff_map["axis"]["scoreboard"]["safety"]["samples"] == 2
     assert tradeoff_map["influence"]["influence_graph"][0]["from"] == "kant"
+    assert tradeoff_map["axis"]["axis_vectors"][0]["author"] == "kant"
     assert tradeoff_map["timeline"][0]["event_type"] == "PhilosophersSelected"
 
     # Must be JSON serializable


### PR DESCRIPTION
### Motivation
- Allow the UI to show which philosopher/author is on which side of each axis by exposing per-proposal axis score vectors (author -> scores) in the synthesized report used by the tradeoff map.

### Description
- Extended `src/po_core/ensemble.py::_build_synthesis_report` to collect per-proposal `axis_vectors` containing `author` (from `proposal.extra[_po_core][author]`), `proposal_id`, `confidence`, parsed numeric `axis_scores`, and optional policy decision from `proposal.extra[_po_core][policy][decision]`, and append it to `report.to_dict()` as `axis_vectors`.
- Updated `src/po_core/viewer/tradeoff_map.py` to forward `synthesis_report["axis_vectors"]` into `tradeoff_map["axis"]["axis_vectors"]`.
- Added a deterministic export in `scripts/export_tradeoff_map.py` that renders an `Axis Vectors` markdown table with header `| author | safety | benefit | feasibility | confidence | policy |` and sorts rows by `author` for stable output.
- Added unit tests and a small test tweak: new `tests/unit/test_synthesis_report_axis_vectors.py` and `tests/unit/test_export_tradeoff_map.py`, and updated `tests/unit/test_tradeoff_map.py` to assert propagation of `axis_vectors`.

### Testing
- Ran `pytest -q tests/unit/test_synthesis_report_axis_vectors.py tests/unit/test_tradeoff_map.py tests/unit/test_export_tradeoff_map.py` and all passed.
- Ran the full test suite with `pytest -q`; the suite largely passed but one benchmark test failed: `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` (performance threshold breach), otherwise no regressions detected.
- No new dependencies were added and axis-vector markdown ordering is deterministic via author sort.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f64166c883288629ec5fa8c42711)