### PR TITLE
Emit sanitized SynthesisReportBuilt TraceEvent

### DIFF
--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -48,6 +48,7 @@ from po_core.trace.decision_events import (
     emit_safety_override_applied,
 )
 from po_core.trace.pareto_events import emit_pareto_debug_events
+from po_core.trace.synthesis_report_events import emit_synthesis_report_built
 
 DEFAULT_PHILOSOPHERS: List[str] = ["aristotle", "confucius", "wittgenstein"]
 
@@ -541,7 +542,15 @@ def _run_phase_post(
     try:
         synthesis_report = _build_synthesis_report(proposals)
     except Exception:
-        synthesis_report = None
+        synthesis_report = {}
+
+    emit_synthesis_report_built(
+        tracer,
+        ctx,
+        synthesis_report,
+        axis_name=axis_spec.axis_name,
+        axis_spec_version=axis_spec.spec_version,
+    )
 
     tracer.emit(
         TraceEvent.now("PolicyPrecheckSummary", ctx.request_id, precheck_counts)
@@ -656,7 +665,7 @@ def _run_phase_post(
         "proposal": final_main.compact(),
     }
 
-    if _structured_output_enabled() and synthesis_report is not None:
+    if _structured_output_enabled() and synthesis_report:
         result["synthesis_report"] = synthesis_report
 
     return result

--- a/src/po_core/trace/synthesis_report_events.py
+++ b/src/po_core/trace/synthesis_report_events.py
@@ -1,0 +1,59 @@
+"""Helpers for synthesis report trace events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping
+
+from po_core.domain.context import Context
+from po_core.domain.trace_event import TraceEvent
+
+if TYPE_CHECKING:
+    from po_core.ports.trace import TracePort
+
+
+_ALLOWED_KEYS = (
+    "axis_name",
+    "axis_spec_version",
+    "scoreboard",
+    "disagreements",
+    "stance_distribution",
+    "axis_vectors",
+)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _sanitized_synthesis_payload(
+    synthesis_report: dict,
+    *,
+    axis_name: str | None = None,
+    axis_spec_version: str | None = None,
+) -> dict[str, Any]:
+    report = _as_dict(synthesis_report)
+    payload = {k: report[k] for k in _ALLOWED_KEYS if k in report}
+    if axis_name is not None:
+        payload["axis_name"] = axis_name
+    if axis_spec_version is not None:
+        payload["axis_spec_version"] = axis_spec_version
+    return payload
+
+
+def emit_synthesis_report_built(
+    tracer: "TracePort",
+    ctx: Context,
+    synthesis_report: dict,
+    *,
+    axis_name: str | None = None,
+    axis_spec_version: str | None = None,
+) -> None:
+    payload = _sanitized_synthesis_payload(
+        synthesis_report,
+        axis_name=axis_name,
+        axis_spec_version=axis_spec_version,
+    )
+    tracer.emit(TraceEvent.now("SynthesisReportBuilt", ctx.request_id, payload))
+
+
+__all__ = ["emit_synthesis_report_built"]

--- a/tests/trace/test_synthesis_report_built_event.py
+++ b/tests/trace/test_synthesis_report_built_event.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+
+from po_core.adapters.memory_poself import InMemoryAdapter
+from po_core.aggregator.pareto import ParetoAggregator
+from po_core.autonomy.solarwill.engine import SolarWillEngine
+from po_core.domain.context import Context
+from po_core.domain.memory_snapshot import MemorySnapshot
+from po_core.domain.pareto_config import ParetoConfig
+from po_core.domain.safety_mode import SafetyMode, SafetyModeConfig
+from po_core.domain.tensor_snapshot import TensorSnapshot
+from po_core.ensemble import EnsembleDeps, run_turn
+from po_core.philosophers.registry import PhilosopherRegistry
+from po_core.runtime.settings import Settings
+from po_core.safety.wethics_gate.action_gate import PolicyActionGate
+from po_core.safety.wethics_gate.intention_gate import PolicyIntentionGate
+from po_core.safety.wethics_gate.policies.presets import (
+    default_action_policies,
+    default_intention_policies,
+)
+from po_core.safety.wethics_gate.policy_gate import PolicyWethicsGate
+from po_core.trace.in_memory import InMemoryTracer
+
+
+class FixedTensorEngine:
+    def __init__(self, freedom_pressure: float):
+        self._fp = freedom_pressure
+
+    def compute(self, ctx: Context, memory: MemorySnapshot) -> TensorSnapshot:
+        return TensorSnapshot.now({"freedom_pressure": self._fp})
+
+
+def _build_deps(
+    *, freedom_pressure: float = 0.0
+) -> tuple[EnsembleDeps, InMemoryTracer]:
+    settings = Settings()
+    mem = InMemoryAdapter()
+    tracer = InMemoryTracer()
+    safety_config = SafetyModeConfig(
+        warn=settings.freedom_pressure_warn,
+        critical=settings.freedom_pressure_critical,
+        missing_mode=settings.freedom_pressure_missing_mode,
+    )
+    registry = PhilosopherRegistry(
+        max_normal=settings.philosophers_max_normal,
+        max_warn=settings.philosophers_max_warn,
+        max_critical=settings.philosophers_max_critical,
+        budget_normal=settings.philosopher_cost_budget_normal,
+        budget_warn=settings.philosopher_cost_budget_warn,
+        budget_critical=settings.philosopher_cost_budget_critical,
+    )
+
+    deps = EnsembleDeps(
+        memory_read=mem,
+        memory_write=mem,
+        tracer=tracer,
+        tensors=FixedTensorEngine(freedom_pressure),
+        solarwill=SolarWillEngine(config=safety_config),
+        gate=PolicyWethicsGate(
+            intention=PolicyIntentionGate(policies=default_intention_policies()),
+            action=PolicyActionGate(policies=default_action_policies()),
+        ),
+        philosophers=registry.select_and_load(SafetyMode.NORMAL),
+        aggregator=ParetoAggregator(
+            mode_config=safety_config,
+            config=ParetoConfig.defaults(),
+        ),
+        aggregator_shadow=None,
+        registry=registry,
+        settings=settings,
+        shadow_guard=None,
+    )
+    return deps, tracer
+
+
+def _make_ctx(user_input: str = "What is justice?") -> Context:
+    return Context.now(
+        request_id=str(uuid.uuid4()),
+        user_input=user_input,
+        meta={"entry": "test"},
+    )
+
+
+def _walk(obj):
+    if isinstance(obj, Mapping):
+        for k, v in obj.items():
+            yield k, v
+            yield from _walk(v)
+    elif isinstance(obj, Sequence) and not isinstance(obj, (str, bytes)):
+        for v in obj:
+            yield from _walk(v)
+
+
+def test_synthesis_report_built_event_is_emitted() -> None:
+    deps, tracer = _build_deps(freedom_pressure=0.1)
+    run_turn(_make_ctx("Explain tradeoffs for a difficult choice"), deps)
+
+    events = [e for e in tracer.events if e.event_type == "SynthesisReportBuilt"]
+    assert len(events) == 1
+
+
+def test_synthesis_report_built_payload_is_sanitized() -> None:
+    deps, tracer = _build_deps(freedom_pressure=0.1)
+    run_turn(_make_ctx("Give guidance for an ethical decision"), deps)
+
+    event = next(e for e in tracer.events if e.event_type == "SynthesisReportBuilt")
+    payload = event.payload
+
+    allowed_top_level_keys = {
+        "axis_name",
+        "axis_spec_version",
+        "scoreboard",
+        "disagreements",
+        "stance_distribution",
+        "axis_vectors",
+    }
+    assert set(payload.keys()).issubset(allowed_top_level_keys)
+
+    banned_keys = {"content", "claims", "reasoning", "rationale", "analysis", "text"}
+    for k, v in _walk(payload):
+        assert k not in banned_keys
+        if isinstance(v, str):
+            assert len(v) <= 200


### PR DESCRIPTION
### Motivation
- Make the system a real "device" by allowing trade-off maps to be reconstructed from trace events without leaking raw proposal text or long reasoning content.
- Provide a deterministic, audit-friendly sanitized synthesis summary that can be consumed by viewers/consumers from the trace alone.

### Description
- Add `src/po_core/trace/synthesis_report_events.py` with `emit_synthesis_report_built(tracer, ctx, synthesis_report, *, axis_name=None, axis_spec_version=None)` and a sanitizer that only allows `axis_name`, `axis_spec_version`, `scoreboard`, `disagreements`, `stance_distribution`, and `axis_vectors` into the emitted payload.
- Wire the ensemble pipeline (`src/po_core/ensemble.py`) to always emit `TraceEvent("SynthesisReportBuilt", ...)` after synthesis construction and pass axis metadata explicitly, while preserving backward compatibility by attaching the full `synthesis_report` to the result only when `PO_STRUCTURED_OUTPUT=1`.
- Add tests `tests/trace/test_synthesis_report_built_event.py` that assert the event is emitted and the payload contains only allowed keys and no raw proposal content or long text.

### Testing
- Ran the new unit tests `pytest -q tests/trace/test_synthesis_report_built_event.py`, which passed (2 passed). 
- Ran a small related selection `pytest -q tests/trace/test_synthesis_report_built_event.py tests/test_synthesis_report_scoreboard.py tests/unit/test_synthesis_report_axis_vectors.py tests/test_run_turn_e2e.py::TestTraceContract::test_minimum_event_count`, which passed (5 passed total).
- Ran the full test suite `pytest -q`, which completed with most tests passing but one unrelated benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` (overall run: 1 failed, 3463 passed, 134 skipped); the failing case appears to be a performance benchmark and is not related to trace payload changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a514828df48328832d163c3ec80e9e)