### PR TITLE
Support tradeoff_map trace-only mode via SynthesisReportBuilt fallback

### DIFF
--- a/tests/viewer/test_tradeoff_map_trace_only.py
+++ b/tests/viewer/test_tradeoff_map_trace_only.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from po_core.domain.trace_event import TraceEvent
+from po_core.viewer.tradeoff_map import build_tradeoff_map
+
+
+TS = datetime(2026, 2, 22, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _event(event_type: str, payload: dict) -> TraceEvent:
+    return TraceEvent(
+        event_type=event_type,
+        occurred_at=TS,
+        correlation_id="req-trace-only",
+        payload=payload,
+    )
+
+
+def test_build_tradeoff_map_supports_trace_only_mode() -> None:
+    events = [
+        _event(
+            "SynthesisReportBuilt",
+            {
+                "scoreboard": {"kant": 0.6, "aristotle": 0.4},
+                "disagreements": ["duty-vs-virtue"],
+                "axis_vectors": [{"axis": "duty", "kant": 0.9, "aristotle": 0.3}],
+            },
+        ),
+        _event(
+            "DeliberationCompleted",
+            {
+                "influence_graph": {
+                    "kant": {"influenced": {"aristotle": 0.2}},
+                }
+            },
+        ),
+        _event(
+            "DecisionEmitted",
+            {
+                "degraded": True,
+                "final": {"author": "aristotle"},
+            },
+        ),
+    ]
+
+    tradeoff_map = build_tradeoff_map(response=None, tracer=events)
+
+    assert set(tradeoff_map["axis"]["scoreboard"].keys()) == {"kant", "aristotle"}
+    assert tradeoff_map["axis"]["axis_vectors"] == [
+        {"axis": "duty", "kant": 0.9, "aristotle": 0.3}
+    ]
+    assert tradeoff_map["meta"]["consensus_leader"] == "aristotle"
+    assert tradeoff_map["meta"]["request_id"] == "req-trace-only"
+    assert tradeoff_map["meta"]["degraded"] is True


### PR DESCRIPTION
### Motivation
- Allow the tradeoff map viewer to build a complete artifact when there is no `PoSelfResponse` metadata by reconstructing the synthesis report from trace events. 
- Preserve existing behavior for response-driven usage while enabling trace-only inspection for observability and replay scenarios.

### Description
- Change `build_tradeoff_map(response, tracer)` signature to accept `response: Any | None` and treat a missing `synthesis_report` as reconstructable from the first `SynthesisReportBuilt` trace event. 
- Add metadata fallbacks sourced from trace events: `request_id` is taken from the first event `correlation_id` if absent in metadata, `degraded` falls back to `DecisionEmitted.degraded`, and `consensus_leader` falls back to `DecisionEmitted.final.author`. 
- Keep existing influence extraction and timeline behavior unchanged so prior callers remain compatible. 
- Add a new unit test `tests/viewer/test_tradeoff_map_trace_only.py` that assembles minimal `TraceEvent`s (`SynthesisReportBuilt`, `DeliberationCompleted`, `DecisionEmitted`) and asserts axis and meta fields are populated; files were formatted with `black`.

### Testing
- Ran `black src/po_core/viewer/tradeoff_map.py tests/viewer/test_tradeoff_map_trace_only.py` which completed successfully. 
- Ran targeted viewer tests with `pytest -q tests/viewer/test_tradeoff_map_influence_edges.py tests/viewer/test_tradeoff_map_trace_only.py` and both passed. 
- Ran the full test suite with `pytest -q`, which produced one unrelated benchmark assertion failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` due to environment timing variance, while the viewer tests and all functional/unit tests relevant to this change passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5148fc1888328b31bc6358741d6ee)