### PR TITLE
Add Trade-off Map tab to Dash viewer

### DIFF
--- a/src/po_core/viewer/web/figures.py
+++ b/src/po_core/viewer/web/figures.py
@@ -399,6 +399,57 @@ def build_interaction_heatmap(events: Sequence[TraceEvent]) -> go.Figure:
     return fig
 
 
+def build_influence_heatmap(tradeoff_map: dict) -> go.Figure:
+    """Heatmap-like table for influence edges in tradeoff map."""
+    influence = (
+        tradeoff_map.get("influence") if isinstance(tradeoff_map, dict) else None
+    )
+    edges = influence.get("influence_edges") if isinstance(influence, dict) else None
+
+    if not isinstance(edges, list) or not edges:
+        fig = go.Figure()
+        fig.add_annotation(
+            text="No influence edge data",
+            showarrow=False,
+            font_size=14,
+        )
+        fig.update_layout(
+            template="plotly_dark",
+            paper_bgcolor=_COLORS["bg"],
+            plot_bgcolor=_COLORS["surface"],
+            height=250,
+        )
+        return fig
+
+    sources = [str(edge.get("from", "?")) for edge in edges if isinstance(edge, dict)]
+    targets = [str(edge.get("to", "?")) for edge in edges if isinstance(edge, dict)]
+    weights = [
+        float(edge.get("weight", 0.0)) for edge in edges if isinstance(edge, dict)
+    ]
+
+    fig = go.Figure(
+        data=[
+            go.Table(
+                header=dict(
+                    values=["From", "To", "Weight"], fill_color=_COLORS["accent"]
+                ),
+                cells=dict(
+                    values=[sources, targets, [f"{weight:.3f}" for weight in weights]],
+                    fill_color=_COLORS["surface"],
+                ),
+            )
+        ]
+    )
+    fig.update_layout(
+        title="Influence Edges",
+        template="plotly_dark",
+        paper_bgcolor=_COLORS["bg"],
+        plot_bgcolor=_COLORS["surface"],
+        height=max(250, 40 * len(weights) + 120),
+    )
+    return fig
+
+
 __all__ = [
     "build_tensor_chart",
     "build_philosopher_chart",
@@ -406,5 +457,6 @@ __all__ = [
     "build_drift_gauge",
     "build_deliberation_round_chart",
     "build_interaction_heatmap",
+    "build_influence_heatmap",
     "decision_badge_style",
 ]

--- a/tests/viewer/test_dash_tradeoff_tab.py
+++ b/tests/viewer/test_dash_tradeoff_tab.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from po_core.domain.trace_event import TraceEvent
+from po_core.viewer.web.app import create_app
+
+
+def test_create_app_includes_tradeoff_tab_and_builds_layout() -> None:
+    events = [
+        TraceEvent(
+            event_type="DeliberationCompleted",
+            occurred_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+            correlation_id="req-1",
+            payload={
+                "influence_graph": {
+                    "kant": {"influenced": {"mill": 0.2}},
+                }
+            },
+        )
+    ]
+
+    app = create_app(events=events)
+
+    tabs = app.layout.children[1]
+    labels = [tab.label for tab in tabs.children]
+    assert "Trade-off Map" in labels


### PR DESCRIPTION
### Motivation
- Expose the internal tradeoff map artifact in the Dash Viewer so the device can “show its map” natively and help operators inspect axis scoreboards, disagreements and influence relationships. 
- Ensure the new UI surface degrades gracefully and respects existing determinism/golden constraints (no frozen golden files were modified). 

### Description
- Add a new main tab `label="Trade-off Map"` (`value="tab-tradeoff"`) to the Dash app created by `create_app` and wired it to a new builder `_build_tradeoff_tab(events)` in `src/po_core/viewer/web/app.py`.
- Implement `_build_tradeoff_tab(events)` to call `po_core.viewer.tradeoff_map.build_tradeoff_map(response=None, tracer=events)` and render an Axis scoreboard table (`mean`, `variance`, `samples`), a Disagreements list, and an Influence Edges table + figure, with empty-state text `"No tradeoff data available"` when data is missing.
- Add `build_influence_heatmap(tradeoff_map: dict) -> plotly.graph_objects.Figure` to `src/po_core/viewer/web/figures.py` which returns an annotated empty Figure if `influence_edges` is empty or a table-like Plotly figure when edges exist, and export it via `__all__`.
- Add a lightweight test `tests/viewer/test_dash_tradeoff_tab.py` that asserts `create_app(events=...)` includes a tab labeled `Trade-off Map`, and apply `black`/`isort` formatting to the modified files.

### Testing
- Ran `pytest -q tests/viewer/test_dash_tradeoff_tab.py`, which passed.
- Ran `pytest -q tests/viewer/test_dash_tradeoff_tab.py tests/unit/test_viewer_web.py tests/unit/test_viewer_figures.py`, which passed (`30 passed`).
- Ran a broad non-benchmark suite with `pytest -q -k 'not benchmark'`, which passed (`3448 passed, 134 skipped`).
- Attempted a full `pytest -q`; one existing benchmark failed in this environment (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`) while the non-benchmark suites passed, indicating a flaky/benchmark timing issue unrelated to the UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a514a00d048328bcd10378ec6347be)