### PR TITLE
Add REST endpoint to retrieve tradeoff maps by session

### DIFF
--- a/src/po_core/app/rest/routers/tradeoff_map.py
+++ b/src/po_core/app/rest/routers/tradeoff_map.py
@@ -1,0 +1,37 @@
+"""GET /v1/tradeoff-map/{session_id} — Trade-off map retrieval."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from po_core.app.rest.auth import require_api_key
+from po_core.app.rest.store import get_trace_store
+from po_core.viewer.tradeoff_map import build_tradeoff_map
+
+router = APIRouter(tags=["tradeoff-map"])
+
+
+@router.get(
+    "/v1/tradeoff-map/{session_id}",
+    summary="Retrieve trade-off map for a session",
+    description=(
+        "Builds and returns a trade-off map artifact from stored trace events "
+        "for the specified session."
+    ),
+)
+async def get_tradeoff_map(
+    session_id: str,
+    _: None = Depends(require_api_key),
+    store: dict = Depends(get_trace_store),
+) -> dict[str, Any]:
+    """Return trade-off map generated from trace events for ``session_id``."""
+    events = store.get(session_id)
+    if events is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No trace found for session_id={session_id!r}",
+        )
+
+    return build_tradeoff_map(response=None, tracer=events)

--- a/src/po_core/app/rest/server.py
+++ b/src/po_core/app/rest/server.py
@@ -29,7 +29,13 @@ from slowapi.errors import RateLimitExceeded
 
 from po_core.app.rest.config import APISettings, get_api_settings, set_api_settings
 from po_core.app.rest.rate_limit import limiter
-from po_core.app.rest.routers import health, philosophers, reason, trace
+from po_core.app.rest.routers import (
+    health,
+    philosophers,
+    reason,
+    trace,
+    tradeoff_map,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +119,10 @@ MemoryRead → TensorCompute → SolarWill → IntentionGate → PhilosopherSele
                 "description": "Audit trail and trace event retrieval",
             },
             {
+                "name": "tradeoff-map",
+                "description": "Trade-off map retrieval for recorded sessions",
+            },
+            {
                 "name": "health",
                 "description": "Server health and status",
             },
@@ -144,6 +154,7 @@ MemoryRead → TensorCompute → SolarWill → IntentionGate → PhilosopherSele
     application.include_router(reason.router)
     application.include_router(philosophers.router)
     application.include_router(trace.router)
+    application.include_router(tradeoff_map.router)
     application.include_router(health.router)
 
     @application.on_event("startup")

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -272,6 +272,26 @@ def test_trace_found_after_reason(client_no_auth):
     assert "events" in body
 
 
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_tradeoff_map_found_after_reason(client_no_auth):
+    """Tradeoff-map endpoint returns a v1 artifact after a reason call."""
+    session_id = "tradeoff-map-test"
+    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT):
+        client_no_auth.post(
+            "/v1/reason",
+            json={
+                "input": "How should we balance freedom and safety?",
+                "session_id": session_id,
+            },
+        )
+
+    resp = client_no_auth.get(f"/v1/tradeoff-map/{session_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "tradeoff_map_v1"
+
+
 # ---------------------------------------------------------------------------
 # Streaming (SSE)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Expose the session-level trade-off map as a REST artifact so external UIs can fetch the "tradeoff map of a session" from the in-memory trace store.

### Description
- Added a new authenticated router `GET /v1/tradeoff-map/{session_id}` in `src/po_core/app/rest/routers/tradeoff_map.py` that loads events via the `get_trace_store` dependency and returns `build_tradeoff_map(response=None, tracer=events)`.
- The endpoint returns `404` when no trace is found for the requested `session_id` and uses `require_api_key` for auth.
- Registered the router and OpenAPI tag in `src/po_core/app/rest/server.py` and added a unit test in `tests/unit/test_rest_api.py` which POSTs `/v1/reason` to create a session and then GETs `/v1/tradeoff-map/{session_id}`, asserting the response contains `schema_version == "tradeoff_map_v1"`.
- Applied code formatting with `isort` and `black` to touched files.

### Testing
- Ran `python -m isort` and `python -m black` on the modified files and formatting completed successfully.
- Ran full test suite with `pytest -q`; this surfaced an existing benchmark instability causing `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` to fail (unrelated to the REST change).
- Ran the focused API test `pytest -q tests/unit/test_rest_api.py -k tradeoff_map` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a514b76eec8328880af4de7c324f9a)