### PR TITLE
Make axis scoring calibration workflow operational

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ PO_ENABLE_ACTION_GATE=true
 # ---- Trace Store ----
 # Max number of sessions to retain in memory (LRU eviction)
 PO_MAX_TRACE_SESSIONS=1000
+# ---- Output / Calibration (optional) ----
+# Enable structured output formatting (1=true, 0=false)
+PO_STRUCTURED_OUTPUT=1
+# Path to axis scoring calibration params JSON (leave empty to disable)
+PO_AXIS_SCORING_CALIBRATION_PARAMS=
+

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -1,0 +1,78 @@
+# Axis Scoring Calibration Workflow
+
+This directory documents a reproducible workflow for training and applying axis scoring calibration parameters.
+
+## 1) Prepare labeled JSONL
+
+Use JSONL (`.jsonl`) where each line is one record with:
+
+- `text` (string): input text to score
+- `labels` (object): gold labels per axis (numeric, coerced to `float` and clipped to `[0, 1]`)
+- `meta` (object, optional): extra annotation context (ignored by trainer)
+
+Example:
+
+```json
+{"text":"今すぐ決断しないと機会を失うかもしれない。","labels":{"choice":0.8,"responsibility":0.6,"urgency":0.9,"ethics":0.5,"social":0.4,"authenticity":0.7},"meta":{"lang":"ja","domain":"career"}}
+{"text":"時間をかけて関係者に相談してから決めたい。","labels":{"choice":0.5,"responsibility":0.8,"urgency":0.2,"ethics":0.7,"social":0.9,"authenticity":0.6}}
+```
+
+Notes:
+
+- Training requires labels for all axis dimensions defined by the active spec.
+- Keep dataset order stable for reproducibility.
+- See also: `calibration/dataset_format.md`.
+
+## 2) Train calibration parameters
+
+Run the trainer:
+
+```bash
+python scripts/train_axis_scoring_calibration.py \
+  --dataset path/to/axis_labels.jsonl \
+  --output calibration/params_v1.json \
+  --alpha 0.5
+```
+
+Optional:
+
+- `--spec path/to/spec.yaml` to load a non-default axis spec.
+
+The output JSON contains:
+
+- `version`
+- `feature_order`
+- `ridge_alpha`
+- `labels` (`bias` + `weights` per axis)
+- `backend` (`numpy` or `fallback`)
+
+## 3) Enable calibration at runtime
+
+Set this environment variable to the trained params path:
+
+```bash
+export PO_AXIS_SCORING_CALIBRATION_PARAMS=/absolute/path/to/calibration/params_v1.json
+```
+
+When not set, default behavior is unchanged (raw axis scoring).
+
+## 4) Evaluate / sanity-check
+
+If you want holdout MAE metrics, use the evaluation script:
+
+```bash
+python scripts/eval_axis_scoring_calibration.py \
+  --dataset path/to/axis_labels.jsonl \
+  --params calibration/params_v1.json \
+  --seed 0 \
+  --split 0.2
+```
+
+Quick sanity check (runtime load path):
+
+```bash
+PO_AXIS_SCORING_CALIBRATION_PARAMS=calibration/params_v1.json \
+python -c "from po_core.axis.scoring import score_text; print(score_text('テスト入力'))"
+```
+
+For deterministic comparisons, keep dataset/spec/seed/split fixed.

--- a/scripts/eval_axis_scoring_calibration.py
+++ b/scripts/eval_axis_scoring_calibration.py
@@ -55,7 +55,9 @@ def _coerce_label(value: object) -> float:
     return min(max(float(value), 0.0), 1.0)
 
 
-def _load_records(dataset_path: Path, dimension_ids: Sequence[str]) -> list[dict[str, object]]:
+def _load_records(
+    dataset_path: Path, dimension_ids: Sequence[str]
+) -> list[dict[str, object]]:
     records: list[dict[str, object]] = []
     for idx, rec in enumerate(_iter_jsonl(dataset_path), start=1):
         text = rec.get("text")
@@ -81,7 +83,9 @@ def _load_records(dataset_path: Path, dimension_ids: Sequence[str]) -> list[dict
     return records
 
 
-def _select_holdout(records: list[dict[str, object]], split: float, seed: int) -> list[dict[str, object]]:
+def _select_holdout(
+    records: list[dict[str, object]], split: float, seed: int
+) -> list[dict[str, object]]:
     if not (0.0 < split <= 1.0):
         raise ValueError("split must be within (0, 1].")
 
@@ -92,7 +96,9 @@ def _select_holdout(records: list[dict[str, object]], split: float, seed: int) -
     return shuffled[:holdout_size]
 
 
-def _compute_mae(records: list[dict[str, object]], dimension_ids: Sequence[str], spec: object) -> dict[str, object]:
+def _compute_mae(
+    records: list[dict[str, object]], dimension_ids: Sequence[str], spec: object
+) -> dict[str, object]:
     abs_error_sum = {dim: 0.0 for dim in dimension_ids}
     sample_count = len(records)
 
@@ -102,7 +108,9 @@ def _compute_mae(records: list[dict[str, object]], dimension_ids: Sequence[str],
         for dim in dimension_ids:
             abs_error_sum[dim] += abs(float(scores.get(dim, 0.0)) - float(labels[dim]))
 
-    per_dimension_mae = {dim: abs_error_sum[dim] / float(sample_count) for dim in dimension_ids}
+    per_dimension_mae = {
+        dim: abs_error_sum[dim] / float(sample_count) for dim in dimension_ids
+    }
     overall_mae = sum(per_dimension_mae.values()) / float(len(dimension_ids))
     return {
         "per_dimension_mae": per_dimension_mae,
@@ -141,7 +149,9 @@ def evaluate_axis_scoring_calibration(
             dim: calibrated_metrics["per_dimension_mae"][dim] - raw_metrics["per_dimension_mae"][dim]  # type: ignore[index]
             for dim in dimension_ids
         }
-        delta_overall = float(calibrated_metrics["overall_mae"]) - float(raw_metrics["overall_mae"])
+        delta_overall = float(calibrated_metrics["overall_mae"]) - float(
+            raw_metrics["overall_mae"]
+        )
         result["calibrated"] = calibrated_metrics
         result["delta"] = {
             "per_dimension_mae": delta_per_dim,
@@ -152,7 +162,9 @@ def evaluate_axis_scoring_calibration(
 
 
 def _print_metrics(metrics: Mapping[str, object], prefix: str) -> None:
-    print(f"[{prefix}] overall_mae={float(metrics['overall_mae']):.6f} samples={int(metrics['samples'])}")
+    print(
+        f"[{prefix}] overall_mae={float(metrics['overall_mae']):.6f} samples={int(metrics['samples'])}"
+    )
     per_dim = metrics["per_dimension_mae"]
     for dim, value in per_dim.items():
         print(f"[{prefix}] {dim}_mae={float(value):.6f}")
@@ -160,13 +172,17 @@ def _print_metrics(metrics: Mapping[str, object], prefix: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dataset", required=True, help="Path to labeled JSONL dataset")
+    parser.add_argument(
+        "--dataset", required=True, help="Path to labeled JSONL dataset"
+    )
     parser.add_argument(
         "--params",
         default=None,
         help="Optional calibration params JSON path; if omitted evaluates raw only",
     )
-    parser.add_argument("--seed", type=int, default=0, help="Random seed for holdout split")
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Random seed for holdout split"
+    )
     parser.add_argument(
         "--split",
         type=float,

--- a/scripts/train_axis_scoring_calibration.py
+++ b/scripts/train_axis_scoring_calibration.py
@@ -160,7 +160,9 @@ def train(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dataset", required=True, help="Path to JSONL training dataset")
+    parser.add_argument(
+        "--dataset", required=True, help="Path to JSONL training dataset"
+    )
     parser.add_argument(
         "--output",
         default="calibration/axis_scoring_params_v1.json",


### PR DESCRIPTION
### Motivation
- Turn the existing wired axis scoring calibration into a reproducible, operator-run workflow with clear docs and runtime opt-in configuration.
- Provide a simple dataset format, train/eval scripts and a quick sanity-check so parameters can be produced and validated reproducibly.
- Keep default runtime behavior unchanged unless an operator explicitly enables calibration via an environment variable.

### Description
- Add `calibration/README.md` documenting the labeled JSONL format, training via `scripts/train_axis_scoring_calibration.py`, evaluation via `scripts/eval_axis_scoring_calibration.py`, and a quick runtime sanity check.
- Update `.env.example` to include optional calibration-related variables `PO_STRUCTURED_OUTPUT=1` and `PO_AXIS_SCORING_CALIBRATION_PARAMS=` for operators to opt in to calibration.
- Run formatting (`black` / `isort`) on `scripts/train_axis_scoring_calibration.py` and `scripts/eval_axis_scoring_calibration.py`; these are formatting-only changes with no logic modifications.
- Ensure calibration remains opt-in and is only activated when `PO_AXIS_SCORING_CALIBRATION_PARAMS` is set, so there is no default behavior change.

### Testing
- Ran formatting commands `black scripts/train_axis_scoring_calibration.py scripts/eval_axis_scoring_calibration.py` and `isort` successfully.
- Ran smoke tests `pytest -q tests/calibration/test_train_axis_scoring_calibration_smoke.py tests/calibration/test_eval_axis_scoring_calibration_smoke.py tests/test_calibration_params_load.py` and they passed.
- Ran the full test suite via `pytest -q`; the suite largely passed but one benchmark test `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` failed due to an environment performance threshold, which is considered unrelated to the functional changes here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a514cbb6708328bc5ff9907ef0a6b0)