### PR TITLE
PR-27: Make axis score semantics explicit everywhere (salience not evaluation)

### DIFF
--- a/calibration/README.md
+++ b/calibration/README.md
@@ -13,14 +13,15 @@ Use JSONL (`.jsonl`) where each line is one record with:
 Example:
 
 ```json
-{"text":"今すぐ決断しないと機会を失うかもしれない。","labels":{"choice":0.8,"responsibility":0.6,"urgency":0.9,"ethics":0.5,"social":0.4,"authenticity":0.7},"meta":{"lang":"ja","domain":"career"}}
-{"text":"時間をかけて関係者に相談してから決めたい。","labels":{"choice":0.5,"responsibility":0.8,"urgency":0.2,"ethics":0.7,"social":0.9,"authenticity":0.6}}
+{"text":"今すぐ決断しないと機会を失うかもしれない。","labels":{"safety":0.8,"benefit":0.6,"feasibility":0.9},"meta":{"lang":"ja","domain":"career"}}
+{"text":"時間をかけて関係者に相談してから決めたい。","labels":{"safety":0.5,"benefit":0.8,"feasibility":0.2}}
 ```
 
 Notes:
 
-- Training requires labels for all axis dimensions defined by the active spec.
+- Training requires labels for all axis dimensions defined by the active spec (Decision Axis Spec v1: `safety`, `benefit`, `feasibility`).
 - Keep dataset order stable for reproducibility.
+- Labels are salience targets (relative emphasis/keyword-hit ratio), not truth or outcome-quality judgments.
 - See also: `calibration/dataset_format.md`.
 
 ## 2) Train calibration parameters

--- a/scripts/export_tradeoff_map.py
+++ b/scripts/export_tradeoff_map.py
@@ -43,8 +43,6 @@ def _render_axis_table(scoreboard: Dict[str, Any]) -> str:
     return "\n".join(lines) if len(lines) > 2 else "No axis scoreboard available."
 
 
-
-
 def _render_axis_vectors_table(axis_vectors: List[Any]) -> str:
     if not axis_vectors:
         return "No axis vectors available."
@@ -74,6 +72,7 @@ def _render_axis_vectors_table(axis_vectors: List[Any]) -> str:
         )
 
     return "\n".join(lines) if len(lines) > 2 else "No axis vectors available."
+
 
 def _render_disagreements(disagreements: List[Any]) -> str:
     if not disagreements:
@@ -170,7 +169,7 @@ def _render_mermaid(influence_edges: List[Any], influence_graph: Any) -> str:
             src_id = _node_id(src_text)
             dst_id = _node_id(dst_text)
             label = "" if weight is None else f"|{weight}|"
-            lines.append(f"  {src_id}[\"{src_text}\"] -->{label} {dst_id}[\"{dst_text}\"]")
+            lines.append(f'  {src_id}["{src_text}"] -->{label} {dst_id}["{dst_text}"]')
             added = True
 
     if not added:
@@ -205,11 +204,16 @@ def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
         "## Axis Scoreboard",
         _render_axis_table(scoreboard if isinstance(scoreboard, dict) else {}),
         "",
+        "## Axis Scores Disclaimer",
+        "axis_scores represent relative emphasis/salience (keyword-hit ratio), not truth/outcome evaluation.",
+        "",
         "## Disagreements",
         _render_disagreements(disagreements if isinstance(disagreements, list) else []),
         "",
         "## Axis Vectors",
-        _render_axis_vectors_table(axis_vectors if isinstance(axis_vectors, list) else []),
+        _render_axis_vectors_table(
+            axis_vectors if isinstance(axis_vectors, list) else []
+        ),
         "",
         "## Influence Graph",
         _render_mermaid(

--- a/src/po_core/viewer/tradeoff_map.py
+++ b/src/po_core/viewer/tradeoff_map.py
@@ -89,9 +89,10 @@ def _meta_axis_fields(
         axis_spec_version = proposal_po_core.get("axis_spec_version")
 
     fields: Dict[str, Any] = {
+        "axis_score_semantics": "salience",
         "axis_scoring_calibration_enabled": bool(
             os.getenv("PO_AXIS_SCORING_CALIBRATION_PARAMS")
-        )
+        ),
     }
     if axis_name is not None:
         fields["axis_name"] = axis_name

--- a/src/po_core/viewer/web/app.py
+++ b/src/po_core/viewer/web/app.py
@@ -338,6 +338,7 @@ def _build_tradeoff_tab(events: Sequence[TraceEvent]) -> html.Div:
     )
 
     scoreboard = axis.get("scoreboard") if isinstance(axis, dict) else None
+    axis_vectors = axis.get("axis_vectors") if isinstance(axis, dict) else None
     disagreements = axis.get("disagreements") if isinstance(axis, dict) else None
     influence_edges = (
         influence.get("influence_edges") if isinstance(influence, dict) else None
@@ -349,7 +350,14 @@ def _build_tradeoff_tab(events: Sequence[TraceEvent]) -> html.Div:
         children.append(html.P("No tradeoff data available"))
         return html.Div(children, style={"padding": "20px"})
 
-    children.append(html.H4("Axis Scoreboard"))
+    children.append(
+        html.P(
+            "Axis scores indicate relative emphasis (salience/keyword-hit ratio), "
+            "not truth, correctness, or outcome quality."
+        )
+    )
+
+    children.append(html.H4("Axis Salience Scoreboard"))
     if isinstance(scoreboard, dict) and scoreboard:
         rows = []
         for axis_name, values in scoreboard.items():
@@ -381,6 +389,12 @@ def _build_tradeoff_tab(events: Sequence[TraceEvent]) -> html.Div:
                 ]
             )
         )
+    else:
+        children.append(html.P("No tradeoff data available"))
+
+    children.extend([html.Hr(), html.H4("Axis Salience Vectors")])
+    if isinstance(axis_vectors, list) and axis_vectors:
+        children.append(html.Ul([html.Li(str(item)) for item in axis_vectors]))
     else:
         children.append(html.P("No tradeoff data available"))
 

--- a/tests/unit/test_export_tradeoff_map.py
+++ b/tests/unit/test_export_tradeoff_map.py
@@ -39,3 +39,10 @@ def test_render_markdown_contains_axis_vectors_table_header() -> None:
     assert (
         "| author | safety | benefit | feasibility | confidence | policy |" in markdown
     )
+
+
+def test_render_markdown_contains_axis_scores_disclaimer() -> None:
+    markdown = _MODULE._render_markdown({"meta": {}, "axis": {}, "influence": {}})
+
+    assert "## Axis Scores Disclaimer" in markdown
+    assert "relative emphasis/salience" in markdown

--- a/tests/unit/test_tradeoff_map.py
+++ b/tests/unit/test_tradeoff_map.py
@@ -73,6 +73,7 @@ def test_build_tradeoff_map_serializable_and_keys(monkeypatch) -> None:
     assert tradeoff_map["meta"]["request_id"] == "req-1"
     assert tradeoff_map["meta"]["axis_name"] == "decision_axis"
     assert tradeoff_map["meta"]["axis_spec_version"] == "axis_spec_v1"
+    assert tradeoff_map["meta"]["axis_score_semantics"] == "salience"
     assert tradeoff_map["meta"]["axis_scoring_calibration_enabled"] is True
     assert tradeoff_map["axis"]["scoreboard"]["safety"]["samples"] == 2
     assert tradeoff_map["influence"]["influence_graph"][0]["from"] == "kant"

--- a/tests/viewer/test_dash_tradeoff_tab.py
+++ b/tests/viewer/test_dash_tradeoff_tab.py
@@ -25,3 +25,23 @@ def test_create_app_includes_tradeoff_tab_and_builds_layout() -> None:
     tabs = app.layout.children[1]
     labels = [tab.label for tab in tabs.children]
     assert "Trade-off Map" in labels
+
+
+def test_tradeoff_tab_uses_salience_wording() -> None:
+    events = [
+        TraceEvent(
+            event_type="SynthesisReportBuilt",
+            occurred_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+            correlation_id="req-2",
+            payload={
+                "scoreboard": {"safety": {"mean": 0.4, "variance": 0.1, "samples": 2}},
+                "axis_vectors": [{"author": "kant", "axis_scores": {"safety": 0.4}}],
+            },
+        )
+    ]
+    app = create_app(events=events)
+
+    layout_text = str(app.layout)
+    assert "Axis Salience Scoreboard" in layout_text
+    assert "Axis Salience Vectors" in layout_text
+    assert "relative emphasis (salience/keyword-hit ratio)" in layout_text


### PR DESCRIPTION
### Motivation

- Prevent consumers from misinterpreting `axis_scores` as outcome/truth evaluations by making semantics explicit as salience/emphasis (keyword-hit ratio).
- Surface the semantics in all user-facing outputs (UI, exports, docs) while preserving existing metadata keys for backward compatibility.
- Ensure tests capture the new metadata and wording so the change is deterministic and auditable.

### Description

- Add `meta.axis_score_semantics = "salience"` to the tradeoff map metadata via `_meta_axis_fields` in `src/po_core/viewer/tradeoff_map.py` while keeping existing fields unchanged.
- Update the Trade-off Map Dash UI in `src/po_core/viewer/web/app.py` to add a short disclaimer, rename `Axis Scoreboard` → `Axis Salience Scoreboard`, add `Axis Salience Vectors` section, and render axis vectors.
- Add an "Axis Scores Disclaimer" section to the Markdown export in `scripts/export_tradeoff_map.py` that states axis scores are relative emphasis/salience, not truth/outcome evaluation.
- Revise `calibration/README.md` examples to use Decision Axis Spec v1 labels (`safety`, `benefit`, `feasibility`) and clarify that labels are salience targets.
- Add/update unit/integration assertions in `tests/unit/test_tradeoff_map.py`, `tests/unit/test_export_tradeoff_map.py`, and `tests/viewer/test_dash_tradeoff_tab.py` to check `meta.axis_score_semantics` and the new disclaimer/wording, and run formatting via `isort`/`black`.

### Testing

- Ran full test suite with `pytest -q`; all tests related to these changes passed, with one unrelated benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` reported.
- Ran focused tests `pytest -q tests/unit/test_tradeoff_map.py tests/unit/test_export_tradeoff_map.py tests/viewer/test_dash_tradeoff_tab.py`, and they all passed.
- Ran code formatters `isort` and `black` on modified files, and formatting completed successfully.
- No frozen golden scenario files were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54dbc497c8328918815c874e7e5c3)