### PR TITLE
PR-30: add axis scoring diagnostics to detect low/no-signal and surface in synthesis & viewer

### DIFF
--- a/scripts/export_tradeoff_map.py
+++ b/scripts/export_tradeoff_map.py
@@ -43,8 +43,6 @@ def _render_axis_table(scoreboard: Dict[str, Any]) -> str:
     return "\n".join(lines) if len(lines) > 2 else "No axis scoreboard available."
 
 
-
-
 def _render_axis_vectors_table(axis_vectors: List[Any]) -> str:
     if not axis_vectors:
         return "No axis vectors available."
@@ -74,6 +72,24 @@ def _render_axis_vectors_table(axis_vectors: List[Any]) -> str:
         )
 
     return "\n".join(lines) if len(lines) > 2 else "No axis vectors available."
+
+
+def _render_axis_scoring_diagnostics(diagnostics: Dict[str, Any]) -> str:
+    if not diagnostics:
+        return "No axis scoring diagnostics available."
+
+    lines: List[str] = [
+        f"- n_vectors: {diagnostics.get('n_vectors', 0)}",
+        f"- hit_rate: {diagnostics.get('hit_rate', 0)}",
+        f"- mean_total_hits: {diagnostics.get('mean_total_hits', 0)}",
+        f"- warn_no_signal: {diagnostics.get('warn_no_signal', False)}",
+    ]
+    if diagnostics.get("warn_no_signal") is True:
+        lines.append(
+            "- ⚠️ Warning: axis scoring appears low-signal; interpret axis trade-offs with care."
+        )
+    return "\n".join(lines)
+
 
 def _render_disagreements(disagreements: List[Any]) -> str:
     if not disagreements:
@@ -170,7 +186,7 @@ def _render_mermaid(influence_edges: List[Any], influence_graph: Any) -> str:
             src_id = _node_id(src_text)
             dst_id = _node_id(dst_text)
             label = "" if weight is None else f"|{weight}|"
-            lines.append(f"  {src_id}[\"{src_text}\"] -->{label} {dst_id}[\"{dst_text}\"]")
+            lines.append(f'  {src_id}["{src_text}"] -->{label} {dst_id}["{dst_text}"]')
             added = True
 
     if not added:
@@ -188,6 +204,7 @@ def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
     scoreboard = axis.get("scoreboard", {})
     disagreements = axis.get("disagreements", [])
     axis_vectors = axis.get("axis_vectors", [])
+    axis_scoring_diagnostics = axis.get("axis_scoring_diagnostics", {})
     influence_graph = influence.get("influence_graph", [])
     influence_edges = influence.get("influence_edges", [])
 
@@ -209,7 +226,16 @@ def _render_markdown(tradeoff_map: Dict[str, Any]) -> str:
         _render_disagreements(disagreements if isinstance(disagreements, list) else []),
         "",
         "## Axis Vectors",
-        _render_axis_vectors_table(axis_vectors if isinstance(axis_vectors, list) else []),
+        _render_axis_vectors_table(
+            axis_vectors if isinstance(axis_vectors, list) else []
+        ),
+        "",
+        "## Axis Scoring Diagnostics",
+        _render_axis_scoring_diagnostics(
+            axis_scoring_diagnostics
+            if isinstance(axis_scoring_diagnostics, dict)
+            else {}
+        ),
         "",
         "## Influence Graph",
         _render_mermaid(

--- a/src/po_core/axis/scoring.py
+++ b/src/po_core/axis/scoring.py
@@ -12,11 +12,11 @@ from functools import lru_cache
 from typing import Dict, Optional
 
 from po_core.axis.spec import AxisSpec, load_axis_spec
-from po_core.text.normalize import normalize_text
 from po_core.tensors.axis_calibration import (
     AxisCalibrationModel,
     load_calibration_model_from_env,
 )
+from po_core.text.normalize import normalize_text
 
 _SCORING_CALIBRATION_ENV_VAR = "PO_AXIS_SCORING_CALIBRATION_PARAMS"
 
@@ -62,18 +62,23 @@ _KEYWORDS_BY_DIMENSION: dict[str, tuple[str, ...]] = {
 }
 
 
-def score_text(text: str, spec: AxisSpec) -> Dict[str, float]:
-    """Score text across axis dimensions by normalized keyword-hit ratios.
+def score_text_with_debug(
+    text: str, spec: AxisSpec
+) -> tuple[dict[str, float], dict[str, object]]:
+    """Score text and return deterministic scoring diagnostics.
 
-    The score means "how strongly each dimension is emphasized *relative to the
-    other dimensions* by keyword presence". It is intentionally lightweight and
-    deterministic, and should be interpreted as a heuristic projection.
+    Debug payload intentionally contains only aggregate counters to avoid
+    leaking raw content.
     """
 
     normalized = normalize_text(text)
     dimension_ids = [d.dimension_id for d in spec.dimensions]
     if not dimension_ids:
-        return {}
+        return {}, {
+            "total_hits": 0,
+            "hits_by_dimension": {},
+            "calibrated": False,
+        }
 
     hits_by_dimension: dict[str, int] = {}
     for dimension_id in dimension_ids:
@@ -91,9 +96,15 @@ def score_text(text: str, spec: AxisSpec) -> Dict[str, float]:
             for dimension_id in dimension_ids
         }
 
+    debug: dict[str, object] = {
+        "total_hits": int(total_hits),
+        "hits_by_dimension": hits_by_dimension,
+        "calibrated": False,
+    }
+
     model = _load_scoring_calibration_model()
     if model is None:
-        return raw_scores
+        return raw_scores, debug
 
     try:
         features = [float(raw_scores.get(dim, 0.0)) for dim in model.feature_order]
@@ -107,17 +118,34 @@ def score_text(text: str, spec: AxisSpec) -> Dict[str, float]:
             for dimension_id in dimension_ids
         }
     except Exception:
-        return raw_scores
+        return raw_scores, debug
 
     calibrated_total = sum(projected_scores.values())
     if calibrated_total <= 0:
         uniform = 1.0 / float(len(dimension_ids))
-        return {dimension_id: uniform for dimension_id in dimension_ids}
+        debug["calibrated"] = True
+        return {dimension_id: uniform for dimension_id in dimension_ids}, debug
 
-    return {
-        dimension_id: (projected_scores[dimension_id] / float(calibrated_total))
-        for dimension_id in dimension_ids
-    }
+    debug["calibrated"] = True
+    return (
+        {
+            dimension_id: (projected_scores[dimension_id] / float(calibrated_total))
+            for dimension_id in dimension_ids
+        },
+        debug,
+    )
+
+
+def score_text(text: str, spec: AxisSpec) -> Dict[str, float]:
+    """Score text across axis dimensions by normalized keyword-hit ratios.
+
+    The score means "how strongly each dimension is emphasized *relative to the
+    other dimensions* by keyword presence". It is intentionally lightweight and
+    deterministic, and should be interpreted as a heuristic projection.
+    """
+
+    scores, _ = score_text_with_debug(text, spec)
+    return scores
 
 
 @lru_cache(maxsize=1)
@@ -131,6 +159,7 @@ def _clear_scoring_calibration_model_cache() -> None:
 
 __all__ = [
     "score_text",
+    "score_text_with_debug",
     "load_axis_spec",
     "AxisSpec",
     "_clear_scoring_calibration_model_cache",

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Union
 
 from po_core import philosophers
-from po_core.axis.scoring import score_text
+from po_core.axis.scoring import score_text_with_debug
 from po_core.axis.spec import load_axis_spec
 from po_core.deliberation.protocol import run_deliberation
 from po_core.domain.context import Context as DomainContext
@@ -519,7 +519,11 @@ def _run_phase_post(
         }
         precheck_counts[v.decision.value] = precheck_counts.get(v.decision.value, 0) + 1
         pc[FREEDOM_PRESSURE] = fp_str
-        pc["axis_scores"] = score_text(str(p.content), axis_spec)
+        axis_scores, axis_scoring_debug = score_text_with_debug(
+            str(p.content), axis_spec
+        )
+        pc["axis_scores"] = axis_scores
+        pc["axis_scoring_debug"] = axis_scoring_debug
         pc["axis_name"] = axis_spec.axis_name
         pc["axis_spec_version"] = axis_spec.spec_version
         extra[PO_CORE] = pc
@@ -682,6 +686,7 @@ def _build_synthesis_report(proposals: Sequence[Any]) -> Dict[str, Any]:
     cards: List[ArgumentCard] = []
     axis_vectors: List[Dict[str, Any]] = []
     axis_names: set[str] = set()
+    total_hits_values: List[int] = []
     for p in proposals:
         extra = dict(p.extra) if isinstance(p.extra, Mapping) else {}
         po_core_meta = extra.get(PO_CORE, {})
@@ -720,6 +725,17 @@ def _build_synthesis_report(proposals: Sequence[Any]) -> Dict[str, Any]:
                 }
             )
 
+        axis_scoring_debug_raw = pc.get("axis_scoring_debug", {})
+        axis_scoring_debug = (
+            dict(axis_scoring_debug_raw)
+            if isinstance(axis_scoring_debug_raw, Mapping)
+            else {}
+        )
+        try:
+            total_hits_values.append(int(axis_scoring_debug.get("total_hits", 0)))
+        except (TypeError, ValueError):
+            total_hits_values.append(0)
+
         questions = []
         qs = pc.get("open_questions", [])
         if isinstance(qs, Sequence) and not isinstance(qs, (str, bytes)):
@@ -740,6 +756,18 @@ def _build_synthesis_report(proposals: Sequence[Any]) -> Dict[str, Any]:
     report = SynthesisEngine().synthesize(axis_spec=axis_spec, cards=cards)
     report_dict = report.to_dict()
     report_dict["axis_vectors"] = axis_vectors
+    n_vectors = len(total_hits_values)
+    hit_count = sum(1 for v in total_hits_values if v > 0)
+    hit_rate = (float(hit_count) / float(n_vectors)) if n_vectors > 0 else 0.0
+    mean_total_hits = (
+        float(sum(total_hits_values)) / float(n_vectors) if n_vectors > 0 else 0.0
+    )
+    report_dict["axis_scoring_diagnostics"] = {
+        "n_vectors": n_vectors,
+        "hit_rate": hit_rate,
+        "mean_total_hits": mean_total_hits,
+        "warn_no_signal": hit_rate < 0.3,
+    }
     return report_dict
 
 

--- a/src/po_core/trace/synthesis_report_events.py
+++ b/src/po_core/trace/synthesis_report_events.py
@@ -18,6 +18,7 @@ _ALLOWED_KEYS = (
     "disagreements",
     "stance_distribution",
     "axis_vectors",
+    "axis_scoring_diagnostics",
 )
 
 

--- a/src/po_core/viewer/tradeoff_map.py
+++ b/src/po_core/viewer/tradeoff_map.py
@@ -172,6 +172,9 @@ def build_tradeoff_map(response: Any | None, tracer: Any) -> Dict[str, Any]:
         "disagreements": _safe_list(synthesis_report.get("disagreements")),
         "stance_distribution": _safe_dict(synthesis_report.get("stance_distribution")),
         "axis_vectors": _safe_list(synthesis_report.get("axis_vectors")),
+        "axis_scoring_diagnostics": _safe_dict(
+            synthesis_report.get("axis_scoring_diagnostics")
+        ),
     }
 
     influence = {

--- a/src/po_core/viewer/web/app.py
+++ b/src/po_core/viewer/web/app.py
@@ -342,6 +342,9 @@ def _build_tradeoff_tab(events: Sequence[TraceEvent]) -> html.Div:
     influence_edges = (
         influence.get("influence_edges") if isinstance(influence, dict) else None
     )
+    axis_scoring_diagnostics = (
+        axis.get("axis_scoring_diagnostics") if isinstance(axis, dict) else None
+    )
 
     children = [html.H3("Trade-off Map")]
 
@@ -389,6 +392,34 @@ def _build_tradeoff_tab(events: Sequence[TraceEvent]) -> html.Div:
         children.append(
             html.Ul([html.Li(str(item)) for item in disagreements]),
         )
+    else:
+        children.append(html.P("No tradeoff data available"))
+
+    children.extend([html.Hr(), html.H4("Axis Scoring Diagnostics")])
+    if isinstance(axis_scoring_diagnostics, dict) and axis_scoring_diagnostics:
+        children.append(
+            html.Ul(
+                [
+                    html.Li(
+                        f"n_vectors: {axis_scoring_diagnostics.get('n_vectors', 0)}"
+                    ),
+                    html.Li(f"hit_rate: {axis_scoring_diagnostics.get('hit_rate', 0)}"),
+                    html.Li(
+                        f"mean_total_hits: {axis_scoring_diagnostics.get('mean_total_hits', 0)}"
+                    ),
+                    html.Li(
+                        f"warn_no_signal: {axis_scoring_diagnostics.get('warn_no_signal', False)}"
+                    ),
+                ]
+            )
+        )
+        if axis_scoring_diagnostics.get("warn_no_signal") is True:
+            children.append(
+                html.P(
+                    "⚠️ Axis scoring appears low-signal; interpret axis trade-offs with care.",
+                    style={"color": "#f5a623", "fontWeight": "bold"},
+                )
+            )
     else:
         children.append(html.P("No tradeoff data available"))
 

--- a/tests/axis/test_scoring_calibration.py
+++ b/tests/axis/test_scoring_calibration.py
@@ -4,7 +4,11 @@ import json
 
 import pytest
 
-from po_core.axis.scoring import _clear_scoring_calibration_model_cache, score_text
+from po_core.axis.scoring import (
+    _clear_scoring_calibration_model_cache,
+    score_text,
+    score_text_with_debug,
+)
 from po_core.axis.spec import load_axis_spec
 
 
@@ -58,3 +62,53 @@ def test_score_text_with_calibration_env_changes_distribution(
     assert calibrated_scores["safety"] > raw_scores["safety"]
     assert calibrated_scores != raw_scores
     assert sum(calibrated_scores.values()) == pytest.approx(1.0)
+
+
+def test_score_text_with_debug_includes_hit_counts(monkeypatch) -> None:
+    monkeypatch.delenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", raising=False)
+    _clear_scoring_calibration_model_cache()
+
+    spec = load_axis_spec()
+    text = "risk harm value feasible"
+
+    scores, debug = score_text_with_debug(text, spec)
+
+    assert scores == {
+        "safety": 0.5,
+        "benefit": 0.25,
+        "feasibility": 0.25,
+    }
+    assert debug == {
+        "total_hits": 4,
+        "hits_by_dimension": {"safety": 2, "benefit": 1, "feasibility": 1},
+        "calibrated": False,
+    }
+
+
+def test_score_text_with_debug_marks_calibrated_when_model_loaded(
+    tmp_path, monkeypatch
+) -> None:
+    params_path = tmp_path / "axis_scoring_params.json"
+    params_path.write_text(
+        json.dumps(
+            {
+                "version": "axis_scoring_calibration_v1",
+                "feature_order": ["safety", "benefit", "feasibility"],
+                "labels": {
+                    "safety": {"weights": [1.2, 0.0, 0.0], "bias": 0.0},
+                    "benefit": {"weights": [0.0, 1.0, 0.0], "bias": 0.0},
+                    "feasibility": {"weights": [0.0, 0.0, 1.0], "bias": 0.0},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("PO_AXIS_SCORING_CALIBRATION_PARAMS", str(params_path))
+    _clear_scoring_calibration_model_cache()
+
+    spec = load_axis_spec()
+    _, debug = score_text_with_debug("risk value", spec)
+
+    assert debug["total_hits"] == 2
+    assert debug["calibrated"] is True

--- a/tests/trace/test_synthesis_report_built_event.py
+++ b/tests/trace/test_synthesis_report_built_event.py
@@ -115,6 +115,7 @@ def test_synthesis_report_built_payload_is_sanitized() -> None:
         "disagreements",
         "stance_distribution",
         "axis_vectors",
+        "axis_scoring_diagnostics",
     }
     assert set(payload.keys()).issubset(allowed_top_level_keys)
 

--- a/tests/unit/test_export_tradeoff_map.py
+++ b/tests/unit/test_export_tradeoff_map.py
@@ -31,6 +31,12 @@ def test_render_markdown_contains_axis_vectors_table_header() -> None:
                         "policy": "allow",
                     }
                 ],
+                "axis_scoring_diagnostics": {
+                    "n_vectors": 1,
+                    "hit_rate": 0.0,
+                    "mean_total_hits": 0.0,
+                    "warn_no_signal": True,
+                },
             },
             "influence": {"influence_graph": []},
         }
@@ -39,3 +45,6 @@ def test_render_markdown_contains_axis_vectors_table_header() -> None:
     assert (
         "| author | safety | benefit | feasibility | confidence | policy |" in markdown
     )
+
+    assert "## Axis Scoring Diagnostics" in markdown
+    assert "Warning: axis scoring appears low-signal" in markdown

--- a/tests/unit/test_synthesis_report_axis_vectors.py
+++ b/tests/unit/test_synthesis_report_axis_vectors.py
@@ -17,6 +17,7 @@ def test_build_synthesis_report_includes_axis_vectors() -> None:
                     AUTHOR: "kant",
                     "axis_scores": {"safety": 0.7, "benefit": 0.6},
                     POLICY: {"decision": "allow"},
+                    "axis_scoring_debug": {"total_hits": 3},
                 }
             },
         ),
@@ -25,7 +26,13 @@ def test_build_synthesis_report_includes_axis_vectors() -> None:
             action_type="answer",
             content="Second",
             confidence=0.4,
-            extra={PO_CORE: {AUTHOR: "nietzsche", "axis_scores": {"safety": 0.2}}},
+            extra={
+                PO_CORE: {
+                    AUTHOR: "nietzsche",
+                    "axis_scores": {"safety": 0.2},
+                    "axis_scoring_debug": {"total_hits": 0},
+                }
+            },
         ),
     ]
 
@@ -48,3 +55,43 @@ def test_build_synthesis_report_includes_axis_vectors() -> None:
             "policy": None,
         },
     ]
+
+
+def test_build_synthesis_report_includes_axis_scoring_diagnostics() -> None:
+    proposals = [
+        Proposal(
+            proposal_id="p-1",
+            action_type="answer",
+            content="First",
+            confidence=0.8,
+            extra={
+                PO_CORE: {
+                    AUTHOR: "kant",
+                    "axis_scores": {"safety": 0.7},
+                    "axis_scoring_debug": {"total_hits": 2},
+                }
+            },
+        ),
+        Proposal(
+            proposal_id="p-2",
+            action_type="answer",
+            content="Second",
+            confidence=0.4,
+            extra={
+                PO_CORE: {
+                    AUTHOR: "nietzsche",
+                    "axis_scores": {"safety": 0.2},
+                    "axis_scoring_debug": {"total_hits": 0},
+                }
+            },
+        ),
+    ]
+
+    report = _build_synthesis_report(proposals)
+
+    assert report["axis_scoring_diagnostics"] == {
+        "n_vectors": 2,
+        "hit_rate": 0.5,
+        "mean_total_hits": 1.0,
+        "warn_no_signal": False,
+    }

--- a/tests/viewer/test_dash_tradeoff_tab.py
+++ b/tests/viewer/test_dash_tradeoff_tab.py
@@ -25,3 +25,29 @@ def test_create_app_includes_tradeoff_tab_and_builds_layout() -> None:
     tabs = app.layout.children[1]
     labels = [tab.label for tab in tabs.children]
     assert "Trade-off Map" in labels
+
+
+def test_create_app_tradeoff_tab_shows_axis_no_signal_warning() -> None:
+    events = [
+        TraceEvent(
+            event_type="SynthesisReportBuilt",
+            occurred_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+            correlation_id="req-2",
+            payload={
+                "scoreboard": {"safety": {"mean": 0.5, "variance": 0.0, "samples": 1}},
+                "axis_scoring_diagnostics": {
+                    "n_vectors": 1,
+                    "hit_rate": 0.0,
+                    "mean_total_hits": 0.0,
+                    "warn_no_signal": True,
+                },
+            },
+        )
+    ]
+
+    app = create_app(events=events)
+
+    tabs = app.layout.children[1]
+    tradeoff_tab = next(tab for tab in tabs.children if tab.value == "tab-tradeoff")
+    tab_text = str(tradeoff_tab.children)
+    assert "low-signal" in tab_text

--- a/tests/viewer/test_tradeoff_map_trace_only.py
+++ b/tests/viewer/test_tradeoff_map_trace_only.py
@@ -25,6 +25,12 @@ def test_build_tradeoff_map_supports_trace_only_mode() -> None:
                 "scoreboard": {"kant": 0.6, "aristotle": 0.4},
                 "disagreements": ["duty-vs-virtue"],
                 "axis_vectors": [{"axis": "duty", "kant": 0.9, "aristotle": 0.3}],
+                "axis_scoring_diagnostics": {
+                    "n_vectors": 1,
+                    "hit_rate": 0.0,
+                    "mean_total_hits": 0.0,
+                    "warn_no_signal": True,
+                },
             },
         ),
         _event(
@@ -53,3 +59,5 @@ def test_build_tradeoff_map_supports_trace_only_mode() -> None:
     assert tradeoff_map["meta"]["consensus_leader"] == "aristotle"
     assert tradeoff_map["meta"]["request_id"] == "req-trace-only"
     assert tradeoff_map["meta"]["degraded"] is True
+
+    assert tradeoff_map["axis"]["axis_scoring_diagnostics"]["warn_no_signal"] is True


### PR DESCRIPTION
### Motivation

- Provide deterministic diagnostics that detect when axis scoring is effectively blind (no keyword hits), especially after calibration, without leaking raw proposal text.  
- Surface lightweight, privacy-preserving counts into the synthesis pipeline so operators can spot low-signal conditions in aggregate.  
- Keep existing scoring behavior unchanged while enabling viewers and exports to warn when axis scoring is low-signal.

### Description

- Add `score_text_with_debug(text, spec) -> (scores, debug)` in `src/po_core/axis/scoring.py` which returns axis scores plus a debug dict with `total_hits`, `hits_by_dimension`, and `calibrated`, and keep `score_text()` delegating to it.  
- Enrich proposals in `src/po_core/ensemble.py` to include `po_core.axis_scores` and `po_core.axis_scoring_debug`, and aggregate per-proposal diagnostics in `_build_synthesis_report()` into `axis_scoring_diagnostics` containing `n_vectors`, `hit_rate`, `mean_total_hits`, and `warn_no_signal`.  
- Allow the new `axis_scoring_diagnostics` key in `SynthesisReportBuilt` sanitization at `src/po_core/trace/synthesis_report_events.py`, and carry diagnostics into the tradeoff map at `src/po_core/viewer/tradeoff_map.py`.  
- Render diagnostics and a warning in the Dash tradeoff tab (`src/po_core/viewer/web/app.py`) and include an “Axis Scoring Diagnostics” section (with a warning line when `warn_no_signal` is true) in the markdown exporter (`scripts/export_tradeoff_map.py`).

### Testing

- Ran formatting tools via `isort` and `black` successfully.  
- Ran the full test suite with `pytest -q`, where functional/unit/viewer tests passed but one unrelated benchmark assertion (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`) failed; this failure is performance-sensitive and pre-existed in the run.  
- Ran a focused subset with `pytest -q tests/axis/test_scoring_calibration.py tests/unit/test_synthesis_report_axis_vectors.py tests/trace/test_synthesis_report_built_event.py tests/viewer/test_tradeoff_map_trace_only.py tests/unit/test_export_tradeoff_map.py tests/viewer/test_dash_tradeoff_tab.py` and all those tests passed.  
- New/updated unit tests include `score_text_with_debug` behavior (counts and calibrated flag), synthesis diagnostics aggregation, sanitized `SynthesisReportBuilt` allow-list, tradeoff_map propagation, and viewer/markdown warning rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54df7588c8328a905015bf41eb9f9)