### PR TITLE
test: stabilize M1-A acceptance harness with shared schema validation

### DIFF
--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,17 @@
+# Acceptance tests (M1-A)
+
+`tests/acceptance/` hosts AT-001〜AT-010 acceptance tests for the M1 milestone.
+
+## Execution model
+
+- The suite runs against `StubComposer` (`po_core.app.composer.StubComposer`).
+- Scenarios are loaded from `scenarios/case_*.yaml` via shared fixtures in `conftest.py`.
+- Every acceptance test enforces `AT-OUT-001` by validating output against `docs/spec/output_schema_v1.json` through the shared `validate_output_schema` fixture.
+
+## Run
+
+```bash
+pytest tests/acceptance/ -v -m acceptance
+```
+
+This command is the required gate for Phase M1-A.

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 import json
 import pathlib
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 import yaml
+from jsonschema import Draft202012Validator
 
 from po_core.app.composer import StubComposer
 
@@ -25,13 +26,16 @@ _SCHEMA_PATH = (
 )
 
 
-def _load_scenario(case_id: str) -> dict[str, Any]:
-    """Load a scenario YAML file by case prefix (e.g., 'case_001')."""
-    pattern = f"{case_id}*.yaml"
-    matches = list(_SCENARIOS_DIR.glob(pattern))
+def _load_scenario_by_pattern(pattern: str) -> dict[str, Any]:
+    """Load a scenario YAML/JSON file by glob pattern."""
+    matches = sorted(_SCENARIOS_DIR.glob(pattern))
     if not matches:
         raise FileNotFoundError(f"Scenario file not found: {_SCENARIOS_DIR / pattern}")
-    with matches[0].open(encoding="utf-8") as fh:
+
+    scenario_path = matches[0]
+    with scenario_path.open(encoding="utf-8") as fh:
+        if scenario_path.suffix.lower() == ".json":
+            return json.load(fh)  # type: ignore[no-any-return]
         return yaml.safe_load(fh)  # type: ignore[no-any-return]
 
 
@@ -51,6 +55,32 @@ def output_schema() -> dict[str, Any]:
 
 
 @pytest.fixture(scope="session")
+def validate_output_schema(output_schema: dict[str, Any]) -> Callable[[dict[str, Any], str], None]:
+    """Return a reusable output-schema validator for acceptance tests."""
+
+    validator = Draft202012Validator(output_schema)
+
+    def _validate(output: dict[str, Any], test_id: str) -> None:
+        errors = sorted(validator.iter_errors(output), key=lambda err: list(err.path))
+        if errors:
+            msg = f"[{test_id}] AT-OUT-001 FAIL — schema validation errors:\n"
+            msg += "\n".join(f"  • {e.message} (path: {list(e.path)})" for e in errors)
+            pytest.fail(msg)
+
+    return _validate
+
+
+@pytest.fixture(scope="session")
+def scenario_loader() -> Callable[[str], dict[str, Any]]:
+    """Load scenario files from scenarios/ by case prefix (e.g., 'case_001')."""
+
+    def _load(case_id: str) -> dict[str, Any]:
+        return _load_scenario_by_pattern(f"{case_id}*.yaml")
+
+    return _load
+
+
+@pytest.fixture(scope="session")
 def composer() -> StubComposer:
     """Shared StubComposer with deterministic seed=42."""
     return StubComposer(seed=42)
@@ -60,50 +90,50 @@ def composer() -> StubComposer:
 
 
 @pytest.fixture()
-def case_001() -> dict[str, Any]:
-    return _load_scenario("case_001")
+def case_001(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_001")
 
 
 @pytest.fixture()
-def case_002() -> dict[str, Any]:
-    return _load_scenario("case_002")
+def case_002(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_002")
 
 
 @pytest.fixture()
-def case_003() -> dict[str, Any]:
-    return _load_scenario("case_003")
+def case_003(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_003")
 
 
 @pytest.fixture()
-def case_004() -> dict[str, Any]:
-    return _load_scenario("case_004")
+def case_004(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_004")
 
 
 @pytest.fixture()
-def case_005() -> dict[str, Any]:
-    return _load_scenario("case_005")
+def case_005(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_005")
 
 
 @pytest.fixture()
-def case_006() -> dict[str, Any]:
-    return _load_scenario("case_006")
+def case_006(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_006")
 
 
 @pytest.fixture()
-def case_007() -> dict[str, Any]:
-    return _load_scenario("case_007")
+def case_007(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_007")
 
 
 @pytest.fixture()
-def case_008() -> dict[str, Any]:
-    return _load_scenario("case_008")
+def case_008(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_008")
 
 
 @pytest.fixture()
-def case_009() -> dict[str, Any]:
-    return _load_scenario("case_009")
+def case_009(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_009")
 
 
 @pytest.fixture()
-def case_010() -> dict[str, Any]:
-    return _load_scenario("case_010")
+def case_010(scenario_loader: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+    return scenario_loader("case_010")

--- a/tests/acceptance/test_acceptance_suite.py
+++ b/tests/acceptance/test_acceptance_suite.py
@@ -21,27 +21,11 @@ from __future__ import annotations
 
 from typing import Any
 
-import jsonschema
 import pytest
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 pytestmark = pytest.mark.acceptance
-
-
-def _validate_schema(
-    output: dict[str, Any], schema: dict[str, Any], test_id: str
-) -> None:
-    """AT-OUT-001 guard: validate output against output_schema_v1.json."""
-    try:
-        validator = jsonschema.Draft202012Validator(schema)
-        errors = list(validator.iter_errors(output))
-        if errors:
-            msg = f"[{test_id}] AT-OUT-001 FAIL — schema validation errors:\n"
-            msg += "\n".join(f"  • {e.message} (path: {list(e.path)})" for e in errors)
-            pytest.fail(msg)
-    except jsonschema.exceptions.SchemaError as exc:
-        pytest.fail(f"[{test_id}] Schema itself is invalid: {exc}")
 
 
 def _assert_option_count(output: dict[str, Any], min_count: int = 2) -> None:
@@ -139,9 +123,9 @@ def _assert_no_forbidden_decision_owner(output: dict[str, Any]) -> None:
 
 
 def _full_must_check(
-    output: dict[str, Any], schema: dict[str, Any], test_id: str
+    output: dict[str, Any], validate_output_schema, test_id: str
 ) -> None:
-    _validate_schema(output, schema, test_id)
+    validate_output_schema(output, test_id)
     _assert_option_count(output)
     _assert_recommendation_present(output)
     _assert_ethics(output)
@@ -155,13 +139,13 @@ def _full_must_check(
 
 
 @pytest.mark.pipeline
-def test_at_001_job_change(case_001, composer, output_schema):
+def test_at_001_job_change(case_001, composer, validate_output_schema):
     """AT-001: 転職：安定企業→スタートアップ
 
     Requirements: FR-OPT-001, FR-REC-001, FR-ETH-001, FR-TR-001
     """
     output = composer.compose(case_001)
-    _full_must_check(output, output_schema, "AT-001")
+    _full_must_check(output, validate_output_schema, "AT-001")
 
     # AT-001 specific: recommended option must have counter (反証)
     rec = output["recommendation"]
@@ -177,13 +161,13 @@ def test_at_001_job_change(case_001, composer, output_schema):
 # ── AT-002: チームの人員整理 ──────────────────────────────────────────────────
 
 
-def test_at_002_headcount_reduction(case_002, composer, output_schema):
+def test_at_002_headcount_reduction(case_002, composer, validate_output_schema):
     """AT-002: チームの人員整理（倫理 + 責任 + 不確実性）
 
     Requirements: FR-ETH-002, FR-RES-001, FR-UNC-001
     """
     output = composer.compose(case_002)
-    _full_must_check(output, output_schema, "AT-002")
+    _full_must_check(output, validate_output_schema, "AT-002")
 
     # Ethics tradeoffs should be present (FR-ETH-002)
     assert output["ethics"]["tradeoffs"], "AT-002: FR-ETH-002 requires tradeoffs"
@@ -194,13 +178,13 @@ def test_at_002_headcount_reduction(case_002, composer, output_schema):
 # ── AT-003: 家族介護の設計 ────────────────────────────────────────────────────
 
 
-def test_at_003_caregiving(case_003, composer, output_schema):
+def test_at_003_caregiving(case_003, composer, validate_output_schema):
     """AT-003: 家族介護（倫理 + 責任 + 不確実性）
 
     Requirements: FR-ETH-001, FR-RES-001, FR-UNC-001
     """
     output = composer.compose(case_003)
-    _full_must_check(output, output_schema, "AT-003")
+    _full_must_check(output, validate_output_schema, "AT-003")
 
     # decision_owner must be the human (not Po_core)
     _assert_no_forbidden_decision_owner(output)
@@ -211,13 +195,13 @@ def test_at_003_caregiving(case_003, composer, output_schema):
 # ── AT-004: 倫理的トレードオフ ────────────────────────────────────────────────
 
 
-def test_at_004_ethical_tradeoffs(case_004, composer, output_schema):
+def test_at_004_ethical_tradeoffs(case_004, composer, validate_output_schema):
     """AT-004: 倫理的トレードオフ（推奨 + 反証 + 代替案）
 
     Requirements: FR-ETH-002, FR-REC-001, FR-UNC-001
     """
     output = composer.compose(case_004)
-    _full_must_check(output, output_schema, "AT-004")
+    _full_must_check(output, validate_output_schema, "AT-004")
     _assert_recommendation_present(output)
     assert output["ethics"]["tradeoffs"], "AT-004: FR-ETH-002 requires tradeoffs"
 
@@ -225,13 +209,13 @@ def test_at_004_ethical_tradeoffs(case_004, composer, output_schema):
 # ── AT-005: 責任主体の明確化 ──────────────────────────────────────────────────
 
 
-def test_at_005_responsibility_owner(case_005, composer, output_schema):
+def test_at_005_responsibility_owner(case_005, composer, validate_output_schema):
     """AT-005: 責任主体の明確化
 
     Requirements: FR-ETH-001, FR-RES-001
     """
     output = composer.compose(case_005)
-    _full_must_check(output, output_schema, "AT-005")
+    _full_must_check(output, validate_output_schema, "AT-005")
 
     # decision_owner must be explicitly set (FR-RES-001)
     assert output["responsibility"]["decision_owner"], "AT-005: decision_owner required"
@@ -243,13 +227,13 @@ def test_at_005_responsibility_owner(case_005, composer, output_schema):
 # ── AT-006: 責任 + トレース重視 ───────────────────────────────────────────────
 
 
-def test_at_006_trace_responsibility(case_006, composer, output_schema):
+def test_at_006_trace_responsibility(case_006, composer, validate_output_schema):
     """AT-006: 責任 + 監査ログ
 
     Requirements: FR-RES-001, FR-TR-001, FR-ETH-001
     """
     output = composer.compose(case_006)
-    _full_must_check(output, output_schema, "AT-006")
+    _full_must_check(output, validate_output_schema, "AT-006")
 
     # All 6 trace steps must be present and have timestamps
     for step in output["trace"]["steps"]:
@@ -262,13 +246,13 @@ def test_at_006_trace_responsibility(case_006, composer, output_schema):
 # ── AT-007: 推奨 + 反証 ────────────────────────────────────────────────────────
 
 
-def test_at_007_recommendation_with_counter(case_007, composer, output_schema):
+def test_at_007_recommendation_with_counter(case_007, composer, validate_output_schema):
     """AT-007: 推奨には反証と代替案が必須
 
     Requirements: FR-ETH-001, FR-REC-001
     """
     output = composer.compose(case_007)
-    _full_must_check(output, output_schema, "AT-007")
+    _full_must_check(output, validate_output_schema, "AT-007")
 
     rec = output["recommendation"]
     if rec["status"] == "recommended":
@@ -288,14 +272,14 @@ def test_at_007_recommendation_with_counter(case_007, composer, output_schema):
 
 
 def test_at_008_combined_ethics_uncertainty_responsibility(
-    case_008, composer, output_schema
+    case_008, composer, validate_output_schema
 ):
     """AT-008: 倫理・不確実性・責任の複合
 
     Requirements: FR-ETH-002, FR-UNC-001, FR-RES-001
     """
     output = composer.compose(case_008)
-    _full_must_check(output, output_schema, "AT-008")
+    _full_must_check(output, validate_output_schema, "AT-008")
 
     # Ethics (FR-ETH-002)
     assert output["ethics"]["tradeoffs"], "AT-008: FR-ETH-002 requires tradeoffs"
@@ -312,14 +296,14 @@ def test_at_008_combined_ethics_uncertainty_responsibility(
 
 
 def test_at_009_values_clarification_questions_generated(
-    case_009, composer, output_schema
+    case_009, composer, validate_output_schema
 ):
     """AT-009: 価値観が不明 → 問いを生成しなければならない
 
     Requirements: FR-Q-001, FR-OUT-001
     """
     output = composer.compose(case_009)
-    _full_must_check(output, output_schema, "AT-009")
+    _full_must_check(output, validate_output_schema, "AT-009")
 
     # FR-Q-001: case_009 has unknowns → questions must be generated
     _assert_questions_present(output)
@@ -337,14 +321,14 @@ def test_at_009_values_clarification_questions_generated(
 
 
 def test_at_010_conflicting_constraints_question_generated(
-    case_010, composer, output_schema
+    case_010, composer, validate_output_schema
 ):
     """AT-010: 制約が矛盾 → 不確実性 high + 問い生成
 
     Requirements: FR-Q-001, FR-UNC-001
     """
     output = composer.compose(case_010)
-    _full_must_check(output, output_schema, "AT-010")
+    _full_must_check(output, validate_output_schema, "AT-010")
 
     # FR-UNC-001: conflicting constraints → uncertainty should be non-trivial
     assert output["uncertainty"]["overall_level"] in {
@@ -369,12 +353,12 @@ def test_at_010_conflicting_constraints_question_generated(
     ],
 )
 def test_at_meta_schema_always_valid(
-    case_fixture_name, request, composer, output_schema
+    case_fixture_name, request, composer, validate_output_schema
 ):
     """AT-META: output_schema_v1 must validate for all parameterised cases."""
     case = request.getfixturevalue(case_fixture_name)
     output = composer.compose(case)
-    _validate_schema(output, output_schema, f"AT-META({case_fixture_name})")
+    validate_output_schema(output, f"AT-META({case_fixture_name})")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- Centralize and harden the M1-A acceptance test infrastructure so AT-001–AT-010 remain stable and maintainable as cases grow.
- Eliminate duplicated schema validation and scenario-loading logic in test modules to reduce drift and increase determinism.
- Document the execution assumptions (StubComposer) and the required gate command for Phase M1-A contributors and reviewers.

### Description
- Added `tests/acceptance/README.md` that documents the acceptance suite scope, `StubComposer` execution model, the `AT-OUT-001` schema guard, and the required run command `pytest tests/acceptance/ -v -m acceptance`.
- Refactored `tests/acceptance/conftest.py` to provide a session-scoped `validate_output_schema` fixture which reuses `docs/spec/output_schema_v1.json` and a `scenario_loader` fixture that loads scenario files (YAML/JSON) and consolidated `case_001`–`case_010` fixtures to use that loader.
- Updated `tests/acceptance/test_acceptance_suite.py` to remove the in-file schema validator and instead call the shared `validate_output_schema` fixture via `_full_must_check`, leaving all acceptance assertions unchanged.
- Changes are limited to `tests/acceptance/*` and test-support helpers, with no production runtime or golden (`scenarios/*_expected.json`) modifications.

### Testing
- Ran `pytest tests/acceptance/ -v -m acceptance` and all acceptance tests passed (`17 passed`).
- Ran full test suite with `pytest -q` which completed with one unrelated benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` while the acceptance suite remained green.
- Verified that no golden files or output schema files were modified and that acceptance fixtures are deterministic via `StubComposer(seed=42)` usage in the fixtures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a583edaef883288776f1ccdc98974f)