### PR TITLE
Phase 3 (M1-C): enforce CI schema & acceptance gates; bump to 0.2.0rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
+        pip install jsonschema
 
     - name: Run pipeline tests (must pass)
       run: |
@@ -72,6 +73,10 @@ jobs:
     - name: Run golden E2E + schema tests (must pass)
       run: |
         pytest tests/test_golden_e2e.py tests/test_input_schema.py tests/test_output_schema.py -v
+
+    - name: Explicit JSON schema validation gate (must pass)
+      run: |
+        python -m pytest tests/test_input_schema.py tests/test_output_schema.py -v
 
     - name: Run acceptance tests — AT-001 to AT-010 (must pass, M1)
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0rc1] - 2026-02-22 (Phase 3: M1-C CI必須ゲート化 + RC版)
+
+### Changed
+
+- CI workflow (`.github/workflows/ci.yml`) now makes schema + golden + acceptance gates explicit in the test job.
+- Added an explicit JSON Schema gate step (`python -m pytest tests/test_input_schema.py tests/test_output_schema.py -v`) and explicit `jsonschema` dependency install in CI setup.
+- Package version bumped from `0.2.0b4` to `0.2.0rc1` in `pyproject.toml` for RC publish readiness.
+
 ## [0.2.0b3] - 2026-02-21 (Phase 5 complete)
 
 ### Phase 5-E: Performance Benchmarks (2026-02-19)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "po-core-flyingpig"
-version = "0.2.0b4"
+version = "0.2.0rc1"
 description = "AI system integrating philosophers as dynamic tensors for responsible meaning generation"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}


### PR DESCRIPTION
### Motivation
- Make schema and acceptance checks explicit and auditable as mandatory CI gates for M1-C readiness. 
- Prepare a release-candidate package version so CI and changelog reflect RC readiness without touching schema or golden files. 

### Description
- Added explicit `jsonschema` install in the `test` job of `.github/workflows/ci.yml` to ensure schema validation dependencies are present. 
- Added an explicit JSON Schema validation gate step that runs `python -m pytest tests/test_input_schema.py tests/test_output_schema.py -v` in `.github/workflows/ci.yml`. 
- Bumped package version in `pyproject.toml` from `0.2.0b4` to `0.2.0rc1` to mark RC readiness. 
- Added a `0.2.0rc1` entry to `CHANGELOG.md` documenting the CI gate hardening and RC bump; no schema or golden files were modified. 

### Testing
- Ran `pytest tests/acceptance/ -v -m acceptance` and all acceptance tests passed (`17 passed`). 
- Ran `pytest tests/test_output_schema.py -v` and all schema/golden validation tests passed (`41 passed`). 
- Attempted `python -m build && twine check dist/*` but the environment lacked the `build` module and network/proxy restrictions prevented installing `build`/`twine`, so package build/check was not completed here (environment-limited failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58429bb2c8328ae105d3aaad07202)