### PR TITLE
Phase 4 (M2-A): implement ethics_engine v1 and integrate into output adapter

### DIFF
--- a/src/po_core/app/ethics_engine.py
+++ b/src/po_core/app/ethics_engine.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Flying Pig Project
+"""Ethics engine v1 for output_schema_v1 ethics summary.
+
+FR-ETH-001
+    - Produce ethics.principles_used based on case values.
+    - Guarantee at least two principles for minimum ethical coverage.
+
+FR-ETH-002
+    - Produce ethics.tradeoffs when value tensions are present.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Map value keywords (JP/EN) to output schema ethics principles.
+_VALUE_TO_PRINCIPLE: dict[str, str] = {
+    "公平": "justice",
+    "公正": "justice",
+    "平等": "justice",
+    "公平性": "justice",
+    "自律": "autonomy",
+    "自由": "autonomy",
+    "自己決定": "autonomy",
+    "自主": "autonomy",
+    "autonomy": "autonomy",
+    "安全": "nonmaleficence",
+    "無危害": "nonmaleficence",
+    "危害": "nonmaleficence",
+    "リスク回避": "nonmaleficence",
+    "誠実": "integrity",
+    "誠意": "integrity",
+    "正直": "integrity",
+    "透明": "integrity",
+    "説明責任": "accountability",
+    "accountability": "accountability",
+    "責任": "accountability",
+    "透明性": "accountability",
+}
+
+_ALL_PRINCIPLES = [
+    "integrity",
+    "autonomy",
+    "justice",
+    "nonmaleficence",
+    "accountability",
+]
+
+_DECISION_MAP = {
+    "ALLOW": "ALLOW",
+    "ALLOW_WITH_REPAIR": "ALLOW_WITH_REPAIR",
+    "REJECT": "REJECT",
+    "ESCALATE": "ESCALATE",
+    "REVISE": "ALLOW_WITH_REPAIR",  # internal alias
+}
+
+
+def principles_from_values(values: list[str]) -> list[str]:
+    """Infer ethics principles from case values, always returning >=2 entries."""
+    principles: set[str] = set()
+    for value in values:
+        value_lower = value.lower()
+        for keyword, principle in _VALUE_TO_PRINCIPLE.items():
+            if keyword.lower() in value_lower:
+                principles.add(principle)
+                break
+
+    for fallback in _ALL_PRINCIPLES:
+        if len(principles) >= 2:
+            break
+        principles.add(fallback)
+
+    return sorted(principles)
+
+
+def build_ethics_summary(
+    case: dict[str, Any],
+    *,
+    run_result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build top-level ethics summary compliant with output_schema_v1."""
+    values = [str(v) for v in case.get("values", [])]
+    principles = principles_from_values(values)
+
+    tradeoffs: list[dict[str, Any]] = []
+    if len(values) >= 2:
+        tradeoffs.append(
+            {
+                "tension": f"「{values[0]}」vs「{values[1]}」",
+                "between": [values[0], values[1]],
+                "mitigation": "段階的実施と関係者調整により両立を目指す",
+                "severity": "medium",
+            }
+        )
+
+    ethics: dict[str, Any] = {
+        "principles_used": principles,
+        "tradeoffs": tradeoffs,
+        "guardrails": [
+            "医療・法律の最終判断はPo_coreが行わない",
+            "意思決定の主体はユーザーである",
+        ],
+        "notes": "W_Ethics Gateによる3層倫理評価済み",
+    }
+
+    if run_result and isinstance(run_result.get("verdict"), dict):
+        raw_decision = str(run_result["verdict"].get("decision", "")).upper()
+        if raw_decision in _DECISION_MAP:
+            ethics["wethics_verdict"] = _DECISION_MAP[raw_decision]
+
+    return ethics

--- a/src/po_core/app/output_adapter.py
+++ b/src/po_core/app/output_adapter.py
@@ -19,66 +19,16 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Dict, List
 
+from po_core.app.ethics_engine import build_ethics_summary, principles_from_values
+
 _POCORE_VERSION = "0.2.0b4"
 _SCHEMA_VERSION = "1.0"
 _GENERATOR_NAME = "po_core.ensemble.run_turn"
 _GENERATOR_VERSION = "0.2.0"
 
-# ── Value keyword → ethics principle mapping ──────────────────────────────
-
-_VALUE_TO_PRINCIPLE: Dict[str, str] = {
-    # justice
-    "公平": "justice",
-    "公正": "justice",
-    "平等": "justice",
-    "公平性": "justice",
-    # autonomy
-    "自律": "autonomy",
-    "自由": "autonomy",
-    "自己決定": "autonomy",
-    "自主": "autonomy",
-    "autonomy": "autonomy",
-    # nonmaleficence
-    "安全": "nonmaleficence",
-    "無危害": "nonmaleficence",
-    "危害": "nonmaleficence",
-    "リスク回避": "nonmaleficence",
-    # integrity
-    "誠実": "integrity",
-    "誠意": "integrity",
-    "正直": "integrity",
-    "透明": "integrity",
-    # accountability
-    "説明責任": "accountability",
-    "accountability": "accountability",
-    "責任": "accountability",
-    "透明性": "accountability",
-}
-
-_ALL_PRINCIPLES = [
-    "integrity",
-    "autonomy",
-    "justice",
-    "nonmaleficence",
-    "accountability",
-]
-
-
 def _map_values_to_principles(values: List[str]) -> List[str]:
-    """Map case values → sorted list of ethics principles (always ≥ 2)."""
-    principles: set = set()
-    for v in values:
-        v_lower = v.lower()
-        for kw, principle in _VALUE_TO_PRINCIPLE.items():
-            if kw.lower() in v_lower:
-                principles.add(principle)
-                break
-    # Ensure at least 2
-    for fallback in _ALL_PRINCIPLES:
-        if len(principles) >= 2:
-            break
-        principles.add(fallback)
-    return sorted(principles)
+    """Compatibility wrapper around ethics_engine principle extraction."""
+    return principles_from_values(values)
 
 
 # ── Timestamp helpers ──────────────────────────────────────────────────────
@@ -482,42 +432,7 @@ def adapt_to_schema(
     questions = _build_questions(case)
     uncertainty = _build_uncertainty(case)
 
-    # Top-level ethics summary
-    tradeoffs: List[Dict[str, Any]] = []
-    if len(values) >= 2:
-        tradeoffs.append(
-            {
-                "tension": f"「{values[0]}」vs「{values[1]}」",
-                "between": [str(values[0]), str(values[1])],
-                "mitigation": "段階的実施と関係者調整により両立を目指す",
-                "severity": "medium",
-            }
-        )
-
-    ethics: Dict[str, Any] = {
-        "principles_used": principles,
-        "tradeoffs": tradeoffs,
-        "guardrails": [
-            "医療・法律の最終判断はPo_coreが行わない",
-            "意思決定の主体はユーザーである",
-        ],
-        "notes": "W_Ethics Gateによる3層倫理評価済み",
-    }
-
-    # Optional: wethics_verdict from pipeline (only for blocked/degraded runs)
-    verdict = run_result.get("verdict")
-    if verdict and isinstance(verdict, dict):
-        raw_decision = str(verdict.get("decision", "")).upper()
-        # Map internal decision values to schema enum
-        _decision_map = {
-            "ALLOW": "ALLOW",
-            "ALLOW_WITH_REPAIR": "ALLOW_WITH_REPAIR",
-            "REJECT": "REJECT",
-            "ESCALATE": "ESCALATE",
-            "REVISE": "ALLOW_WITH_REPAIR",  # internal alias
-        }
-        if raw_decision in _decision_map:
-            ethics["wethics_verdict"] = _decision_map[raw_decision]
+    ethics = build_ethics_summary(case, run_result=run_result)
 
     # Top-level responsibility summary
     stakeholders = case.get("stakeholders", [])

--- a/tests/test_ethics_engine.py
+++ b/tests/test_ethics_engine.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from po_core.app.ethics_engine import build_ethics_summary
+
+
+def test_ethics_summary_guarantees_minimum_principles() -> None:
+    case = {
+        "case_id": "case_ethics_001",
+        "title": "価値観が未定義でも最低原則を満たす",
+        "values": [],
+    }
+
+    ethics = build_ethics_summary(case)
+
+    assert len(ethics["principles_used"]) >= 2
+
+
+def test_ethics_summary_emits_tradeoff_for_multi_value_case() -> None:
+    case = {
+        "case_id": "case_ethics_002",
+        "title": "価値衝突あり",
+        "values": ["公平性", "スピード"],
+    }
+
+    ethics = build_ethics_summary(case)
+
+    assert ethics["tradeoffs"], "複数価値がある場合、tradeoffs は非空であるべき"
+    assert ethics["tradeoffs"][0]["between"] == ["公平性", "スピード"]
+
+
+def test_ethics_summary_maps_revise_to_allow_with_repair() -> None:
+    case = {
+        "case_id": "case_ethics_003",
+        "title": "判定マッピング",
+        "values": ["自律", "安全"],
+    }
+
+    ethics = build_ethics_summary(case, run_result={"verdict": {"decision": "REVISE"}})
+
+    assert ethics["wethics_verdict"] == "ALLOW_WITH_REPAIR"


### PR DESCRIPTION
### Motivation
- Implement a dedicated ethics engine to satisfy FR-ETH-001/002 and centralize ethics logic for the output path. 
- Replace ad-hoc in-adapter ethics construction with a testable engine to improve determinism and maintainability. 

### Description
- Added `src/po_core/app/ethics_engine.py` providing `principles_from_values(values)` and `build_ethics_summary(case, run_result=None)` that guarantee `principles_used >= 2`, emit `tradeoffs` when multiple values exist, and map internal verdict alias `REVISE` → `ALLOW_WITH_REPAIR`.
- Wired the engine into the output pipeline by updating `src/po_core/app/output_adapter.py` to call `build_ethics_summary(...)` and to delegate principle extraction to `principles_from_values(...)`.
- Added unit tests `tests/test_ethics_engine.py` covering minimum-principles guarantee, multi-value tradeoff generation, and verdict mapping behavior.
- Changes are limited to ethics generation and adapter integration; no schema changes or golden file edits were made.

### Testing
- Ran `pytest tests/test_ethics_engine.py tests/test_output_schema.py -v` and both test files passed. 
- Ran `pytest tests/acceptance/ -v -m acceptance` and the acceptance markers passed. 
- Ran a broad `pytest tests/ -v`; targeted acceptance/unit tests for this phase passed, while the unrelated benchmark `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` failed during the initial full run (benchmark-only failure), which is out of scope for this phase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58448b2bc8328b1043324d4555d9a)