### PR TITLE
Phase 6: unify FR-UNC-001 uncertainty rule generation

### DIFF
--- a/src/po_core/app/output_adapter.py
+++ b/src/po_core/app/output_adapter.py
@@ -96,12 +96,42 @@ def _parse_base(now: str) -> dt.datetime:
 # ── Uncertainty ────────────────────────────────────────────────────────────
 
 
+def _has_constraint_contradiction(constraints: List[str]) -> bool:
+    """Return True when constraints include a deterministic contradiction signal.
+
+    Rule (FR-UNC-001 helper): when one of the following contradictory pairs appears
+    in the same case, uncertainty is escalated regardless of unknown count.
+      - speed vs quality (早く/即時 vs 慎重/品質)
+      - keep-all vs reduce (維持/削減)
+    """
+
+    normalized = " ".join(str(c).lower() for c in constraints)
+    contradiction_pairs = [
+        (("早", "即", "迅速", "speed", "fast"), ("慎重", "品質", "quality")),
+        (("維持", "keep"), ("削減", "減ら", "reduce")),
+    ]
+    for left_terms, right_terms in contradiction_pairs:
+        if any(term in normalized for term in left_terms) and any(
+            term in normalized for term in right_terms
+        ):
+            return True
+    return False
+
+
 def _uncertainty_level(case: Dict[str, Any]) -> str:
-    n_constraints = len(case.get("constraints", []))
-    n_unknowns = len(case.get("unknowns", []))
-    if n_constraints >= 4 or n_unknowns >= 3:
+    constraints = case.get("constraints", [])
+    unknowns = case.get("unknowns", [])
+    n_unknowns = len(unknowns) if isinstance(unknowns, list) else 0
+
+    # FR-UNC-001 level rule (deterministic):
+    #   high   = contradiction exists OR unknowns >= 3
+    #   medium = unknowns in [1, 2]
+    #   low    = unknowns == 0
+    if isinstance(constraints, list) and _has_constraint_contradiction(constraints):
         return "high"
-    if n_constraints >= 2 or n_unknowns >= 1:
+    if n_unknowns >= 3:
+        return "high"
+    if n_unknowns >= 1:
         return "medium"
     return "low"
 
@@ -109,11 +139,13 @@ def _uncertainty_level(case: Dict[str, Any]) -> str:
 def _build_uncertainty(case: Dict[str, Any]) -> Dict[str, Any]:
     unknowns = case.get("unknowns", [])
     constraints = case.get("constraints", [])
+    unknowns_list = list(unknowns[:5]) if isinstance(unknowns, list) else []
+    constraints_list = list(constraints[:2]) if isinstance(constraints, list) else []
     return {
         "overall_level": _uncertainty_level(case),
-        "reasons": list(unknowns[:3]) if unknowns else ["重要情報が未確定"],
-        "assumptions": list(constraints[:2]),
-        "known_unknowns": list(unknowns[:5]),
+        "reasons": unknowns_list[:3] if unknowns_list else ["重要情報が未確定"],
+        "assumptions": constraints_list,
+        "known_unknowns": unknowns_list,
     }
 
 

--- a/tests/unit/test_uncertainty_rules.py
+++ b/tests/unit/test_uncertainty_rules.py
@@ -1,0 +1,46 @@
+"""Unit tests for deterministic uncertainty level rules (FR-UNC-001)."""
+
+from __future__ import annotations
+
+from po_core.app.output_adapter import _build_uncertainty, _uncertainty_level
+
+
+def test_uncertainty_level_high_when_unknowns_are_many() -> None:
+    case = {
+        "constraints": ["予算上限を守る"],
+        "unknowns": ["A", "B", "C"],
+    }
+
+    assert _uncertainty_level(case) == "high"
+
+
+def test_uncertainty_level_high_when_constraints_contradict() -> None:
+    case = {
+        "constraints": [
+            "品質を最優先しつつ、即時にリリースする",
+            "現有人員は維持しつつ、コストを削減する",
+        ],
+        "unknowns": [],
+    }
+
+    assert _uncertainty_level(case) == "high"
+
+
+def test_uncertainty_level_medium_with_small_unknowns() -> None:
+    case = {
+        "constraints": ["予算上限を守る"],
+        "unknowns": ["関係者の同意可否"],
+    }
+
+    assert _uncertainty_level(case) == "medium"
+
+
+def test_build_uncertainty_keeps_schema_shape_for_low_level() -> None:
+    case = {"constraints": "invalid", "unknowns": "invalid"}
+
+    uncertainty = _build_uncertainty(case)
+
+    assert uncertainty["overall_level"] == "low"
+    assert uncertainty["reasons"]
+    assert isinstance(uncertainty["assumptions"], list)
+    assert isinstance(uncertainty["known_unknowns"], list)


### PR DESCRIPTION
### Motivation
- Unify and make deterministic the generation of `uncertainty` in outputs according to FR-UNC-001 so all cases yield a consistent `overall_level` decision rule.
- Escalate uncertainty when constraints contain deterministically detectable contradictions so the adapter reflects contradiction signals in the schema output.

### Description
- Implemented a deterministic contradiction detector and unified level rule in `src/po_core/app/output_adapter.py` where `high` = contradiction OR `unknowns >= 3`, `medium` = `unknowns` in [1,2], and `low` = `unknowns == 0` with the rule documented in function comments.
- Added helper `_has_constraint_contradiction()` in `src/po_core/app/output_adapter.py` to detect keyword-based contradictory constraint pairs.
- Hardened `_build_uncertainty()` to preserve the schema shape (`overall_level`, `reasons`, `assumptions`, `known_unknowns`) even when `unknowns`/`constraints` are non-list types.
- Added unit tests `tests/unit/test_uncertainty_rules.py` to lock the expected behaviors for large unknowns, conflicting constraints, small unknowns, and schema-shape preservation for low-level cases.

### Testing
- Ran `pytest tests/ -v` where the new uncertainty unit tests passed and the suite reported 1 unrelated benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` (environment/performance dependent) while other tests passed.
- Ran `pytest tests/acceptance/ -v -m acceptance` and all 17 acceptance tests passed.
- New unit tests in `tests/unit/test_uncertainty_rules.py` passed during the full test run and verify the implemented FR-UNC-001 rules and schema conformance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5848e70188328b526fa6746efbe49)