### PR TITLE
Phase 7: Add AT-002..008 acceptance goldens, golden-diff test, traceability coverage script & CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       run: |
         pytest tests/acceptance/ -v -m acceptance
 
+    - name: Calculate acceptance golden coverage (M2 gate)
+      run: |
+        python scripts/calc_traceability_coverage.py --min-at 8
+
     - name: Run full test suite (best-effort)
       run: |
         pytest tests/ -v --cov=po_core --cov-report=xml --cov-report=term-missing || true

--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,9 @@ data/processed/
 *.jsonl
 *.parquet
 
+# Keep acceptance golden fixtures
+!tests/acceptance/scenarios/*.json
+
 # Except: Keep small example datasets
 !examples/**/*.csv
 !examples/**/*.json

--- a/docs/traceability/traceability_v1.yaml
+++ b/docs/traceability/traceability_v1.yaml
@@ -15,6 +15,7 @@ principles:
       - REQ-VALUES-001
       - REQ-SESSION-001
       - REQ-SESSION-001
+      - REQ-AT-001
   - id: P-INT-001
     mapped_requirements:
       - REQ-DET-001
@@ -25,6 +26,7 @@ principles:
       - REQ-QST-001
       - REQ-PLAN-001
       - REQ-VALUES-001
+      - REQ-AT-001
   - id: P-AUT-001
     mapped_requirements:
       - REQ-ARB-001
@@ -36,6 +38,7 @@ principles:
       - REQ-QST-001
       - REQ-PLAN-001
       - REQ-VALUES-001
+      - REQ-AT-001
   - id: P-JUS-001
     mapped_requirements:
       - REQ-FEA-001
@@ -269,3 +272,31 @@ requirements:
         value: src/pocore/runner.py
       - kind: module
         value: tests/test_session_replay_e2e.py
+
+  - id: REQ-AT-001
+    principles: [P-ACC-001, P-INT-001, P-NMH-001]
+    adrs: [docs/adr/0002-golden-diff-contract.md]
+    tests:
+      - tests/acceptance/test_acceptance_suite.py::test_at_002_headcount_reduction [AT-002]
+      - tests/acceptance/test_acceptance_suite.py::test_at_003_caregiving [AT-003]
+      - tests/acceptance/test_acceptance_suite.py::test_at_004_ethical_tradeoffs [AT-004]
+      - tests/acceptance/test_acceptance_suite.py::test_at_005_responsibility_owner [AT-005]
+      - tests/acceptance/test_acceptance_suite.py::test_at_006_trace_responsibility [AT-006]
+      - tests/acceptance/test_acceptance_suite.py::test_at_007_recommendation_with_counter [AT-007]
+      - tests/acceptance/test_acceptance_suite.py::test_at_008_combined_ethics_uncertainty_responsibility [AT-008]
+      - tests/acceptance/test_acceptance_suite.py::test_at_010_conflicting_constraints_question_generated [AT-010]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_002_expected] [AT-002]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_003_expected] [AT-003]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_004_expected] [AT-004]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_005_expected] [AT-005]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_006_expected] [AT-006]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_007_expected] [AT-007]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_008_expected] [AT-008]
+      - tests/acceptance/test_acceptance_golden.py::test_acceptance_golden_diff[at_010_expected] [AT-010]
+    code_refs:
+      - kind: module
+        value: tests/acceptance/test_acceptance_suite.py
+      - kind: module
+        value: tests/acceptance/test_acceptance_golden.py
+      - kind: module
+        value: tests/acceptance/scenarios

--- a/scripts/calc_traceability_coverage.py
+++ b/scripts/calc_traceability_coverage.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Calculate acceptance golden coverage from traceability matrix.
+
+Usage:
+  python scripts/calc_traceability_coverage.py
+  python scripts/calc_traceability_coverage.py --min-at 8 --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACEABILITY_PATH = ROOT / "docs" / "traceability" / "traceability_v1.yaml"
+ACCEPTANCE_GOLDEN_DIR = ROOT / "tests" / "acceptance" / "scenarios"
+AT_PATTERN = re.compile(r"AT-\d{3}")
+
+
+def _collect_traceability_at_ids(traceability: dict[str, Any]) -> set[str]:
+    found: set[str] = set()
+    for requirement in traceability.get("requirements", []):
+        for test_ref in requirement.get("tests", []):
+            found.update(AT_PATTERN.findall(str(test_ref)))
+    return found
+
+
+def _collect_golden_at_ids(golden_dir: Path) -> set[str]:
+    at_ids: set[str] = set()
+    for path in sorted(golden_dir.glob("at_*_expected.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        at_id = payload.get("at_id")
+        if isinstance(at_id, str) and AT_PATTERN.fullmatch(at_id):
+            at_ids.add(at_id)
+    return at_ids
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min-at", type=int, default=8)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    traceability = yaml.safe_load(TRACEABILITY_PATH.read_text(encoding="utf-8"))
+    traceability_at_ids = _collect_traceability_at_ids(traceability)
+    golden_at_ids = _collect_golden_at_ids(ACCEPTANCE_GOLDEN_DIR)
+
+    covered = sorted(traceability_at_ids & golden_at_ids)
+    uncovered = sorted(traceability_at_ids - golden_at_ids)
+
+    report = {
+        "traceability_path": str(TRACEABILITY_PATH.relative_to(ROOT)),
+        "golden_dir": str(ACCEPTANCE_GOLDEN_DIR.relative_to(ROOT)),
+        "traceability_at_ids": sorted(traceability_at_ids),
+        "golden_at_ids": sorted(golden_at_ids),
+        "covered_at_ids": covered,
+        "uncovered_at_ids": uncovered,
+        "covered_count": len(covered),
+        "required_min_at": args.min_at,
+        "threshold_passed": len(covered) >= args.min_at,
+    }
+
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(f"Traceability Matrix: {report['traceability_path']}")
+        print(f"Acceptance golden dir: {report['golden_dir']}")
+        print(f"Covered AT IDs ({len(covered)}): {', '.join(covered) or '(none)'}")
+        print(f"Uncovered AT IDs ({len(uncovered)}): {', '.join(uncovered) or '(none)'}")
+        print(
+            f"Threshold: covered_count >= {args.min_at} -> {'PASS' if report['threshold_passed'] else 'FAIL'}"
+        )
+
+    return 0 if report["threshold_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/scenarios/at_002_expected.json
+++ b/tests/acceptance/scenarios/at_002_expected.json
@@ -1,0 +1,332 @@
+{
+  "at_id": "AT-002",
+  "case_id": "case_002",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "dcb13e7c-4397-c96c-884e-03dc266f9640",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_002_headcount_reduction",
+      "title": "チームの人員整理：1名を異動/退職にする判断",
+      "input_digest": "402cbdb2312db1b400047a141ea97cd6f1d6f64fcd4d534d5c62edba5a0437a8"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "チームの人員整理：1名を異動/退職にする判断",
+        "description": "道元禅師（1200-1253）は問う：「而今の山水は、古仏の道現成なり」。今ここに現れているこの問い、この状況そのものが、仏道の現成（げんじょう）である。修証一如（しゅしょういちにょ）——この問いに向き合うこと自体が修行であり悟りである。只管打坐（しかんたざ）の精神：結論を急がず、この問いの中に完全に在れ。有時（うじ）：今この状況を抱えているこの瞬間が、分割できない存在・時間の全体である。現成公案（げんじょうこうあん）：答えは遠くにあるのではなく、問い続けるこの場に、すでに現れている。無常（むじょう）を忘れるな——固定した答えへの執着を手放すことで、仏性の光が差し込む余地が生まれる。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 会社規定・法令順守（手続き違反は不可）"
+          },
+          {
+            "step": "制約を考慮: プロジェクト納期は変更困難"
+          },
+          {
+            "step": "制約を考慮: 評価の恣意性を避け、説明可能な基準にする"
+          }
+        ],
+        "pros": [
+          "価値観「公平性」の実現に資する",
+          "価値観「無危害（個人へのダメージ最小化）」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 削減の許容手段（異動・契約変更・採用凍結など）",
+          "不確実性: 各メンバーの直近の成果と将来の適性（客観データ）"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "integrity",
+            "justice"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "自分",
+          "stakeholders": [
+            {
+              "name": "自分",
+              "role": "意思決定と説明責任の主体",
+              "impact": "判断の正当性・信頼に影響"
+            },
+            {
+              "name": "チームメンバーA〜F",
+              "role": "影響当事者",
+              "impact": "雇用・生活・精神的負荷に影響"
+            },
+            {
+              "name": "HR",
+              "role": "手続きと法令の担保",
+              "impact": "運用ミスのリスクを負う"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-03-10",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "削減の許容手段（異動・契約変更・採用凍結など）",
+            "各メンバーの直近の成果と将来の適性（客観データ）",
+            "本人の希望（異動可否、家庭事情）"
+          ],
+          "assumptions": [
+            "会社規定・法令順守（手続き違反は不可）",
+            "プロジェクト納期は変更困難"
+          ],
+          "known_unknowns": [
+            "削減の許容手段（異動・契約変更・採用凍結など）",
+            "各メンバーの直近の成果と将来の適性（客観データ）",
+            "本人の希望（異動可否、家庭事情）"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "integrity",
+            "justice"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "自分",
+          "stakeholders": [
+            {
+              "name": "自分",
+              "role": "意思決定と説明責任の主体",
+              "impact": "判断の正当性・信頼に影響"
+            },
+            {
+              "name": "チームメンバーA〜F",
+              "role": "影響当事者",
+              "impact": "雇用・生活・精神的負荷に影響"
+            },
+            {
+              "name": "HR",
+              "role": "手続きと法令の担保",
+              "impact": "運用ミスのリスクを負う"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "削減の許容手段（異動・契約変更・採用凍結など）",
+            "各メンバーの直近の成果と将来の適性（客観データ）",
+            "本人の希望（異動可否、家庭事情）"
+          ],
+          "assumptions": [
+            "会社規定・法令順守（手続き違反は不可）",
+            "プロジェクト納期は変更困難"
+          ],
+          "known_unknowns": [
+            "削減の許容手段（異動・契約変更・採用凍結など）",
+            "各メンバーの直近の成果と将来の適性（客観データ）",
+            "本人の希望（異動可否、家庭事情）"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "integrity",
+        "justice",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「公平性」vs「無危害（個人へのダメージ最小化）」",
+          "between": [
+            "公平性",
+            "無危害（個人へのダメージ最小化）"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "自分",
+      "stakeholders": [
+        {
+          "name": "自分",
+          "role": "意思決定と説明責任の主体",
+          "impact": "判断の正当性・信頼に影響"
+        },
+        {
+          "name": "チームメンバーA〜F",
+          "role": "影響当事者",
+          "impact": "雇用・生活・精神的負荷に影響"
+        },
+        {
+          "name": "HR",
+          "role": "手続きと法令の担保",
+          "impact": "運用ミスのリスクを負う"
+        },
+        {
+          "name": "顧客",
+          "role": "成果物の受益者",
+          "impact": "品質・納期・サポートに影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "削減の許容手段（異動・契約変更・採用凍結など）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（削減の許容手段（異動・契約変更・採用凍結など））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "各メンバーの直近の成果と将来の適性（客観データ）はどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（各メンバーの直近の成果と将来の適性（客観データ））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "本人の希望（異動可否、家庭事情）はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（本人の希望（異動可否、家庭事情））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "削減の許容手段（異動・契約変更・採用凍結など）",
+        "各メンバーの直近の成果と将来の適性（客観データ）",
+        "本人の希望（異動可否、家庭事情）"
+      ],
+      "assumptions": [
+        "会社規定・法令順守（手続き違反は不可）",
+        "プロジェクト納期は変更困難"
+      ],
+      "known_unknowns": [
+        "削減の許容手段（異動・契約変更・採用凍結など）",
+        "各メンバーの直近の成果と将来の適性（客観データ）",
+        "本人の希望（異動可否、家庭事情）"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_003_expected.json
+++ b/tests/acceptance/scenarios/at_003_expected.json
@@ -1,0 +1,331 @@
+{
+  "at_id": "AT-003",
+  "case_id": "case_003",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "f0114944-ebbc-2093-4b9d-82d9311de68d",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_003_caregiving",
+      "title": "家族介護：親のケアをどう設計するか",
+      "input_digest": "e39a0a3bf9202be781faabdf66ee43e9185e5b9435c7366ee5616be012be1df9"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "家族介護：親のケアをどう設計するか",
+        "description": "道元の教えにおいて、関係性は個我の外部にあるものではない。有時（うじ）：関係とは時間の中に存在するのではなく、関係そのものが時間・存在である。仏性（ぶっしょう）は一切衆生に宿る——他者の中に仏性を見ることは、自己の仏性を見ることと不二（ふに）である。身心脱落（しんじんだつらく）の精神で関係に向かうとは、自己への執着を手放し、相手と共に「今ここ」に在ることである。只管打坐（しかんたざ）の如く関係に向かえ——成果や見返りを求めず、関係そのものに全身全霊で在ること。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 月の追加負担予算：最大12万円"
+          },
+          {
+            "step": "制約を考慮: 平日は介護に割ける時間が限られる"
+          },
+          {
+            "step": "制約を考慮: 親の意思（自立・尊厳）を無視しない"
+          }
+        ],
+        "pros": [
+          "価値観「尊厳（親の自律）」の実現に資する",
+          "価値観「安全」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 医師の見立て（進行予測、必要ケアレベル）",
+          "不確実性: 利用可能なサービス枠・施設の空き"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "autonomy",
+            "nonmaleficence"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "親",
+          "stakeholders": [
+            {
+              "name": "親",
+              "role": "当事者",
+              "impact": "生活の質・安全・尊厳に直結"
+            },
+            {
+              "name": "自分",
+              "role": "意思決定主体（支援者）",
+              "impact": "時間・お金・精神負荷に影響"
+            },
+            {
+              "name": "兄弟姉妹（いる場合）",
+              "role": "協力者候補",
+              "impact": "負担分担・合意形成に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-04-01",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "医師の見立て（進行予測、必要ケアレベル）",
+            "利用可能なサービス枠・施設の空き",
+            "兄弟姉妹の協力度合い"
+          ],
+          "assumptions": [
+            "月の追加負担予算：最大12万円",
+            "平日は介護に割ける時間が限られる"
+          ],
+          "known_unknowns": [
+            "医師の見立て（進行予測、必要ケアレベル）",
+            "利用可能なサービス枠・施設の空き",
+            "兄弟姉妹の協力度合い"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "autonomy",
+            "nonmaleficence"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "親",
+          "stakeholders": [
+            {
+              "name": "親",
+              "role": "当事者",
+              "impact": "生活の質・安全・尊厳に直結"
+            },
+            {
+              "name": "自分",
+              "role": "意思決定主体（支援者）",
+              "impact": "時間・お金・精神負荷に影響"
+            },
+            {
+              "name": "兄弟姉妹（いる場合）",
+              "role": "協力者候補",
+              "impact": "負担分担・合意形成に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "医師の見立て（進行予測、必要ケアレベル）",
+            "利用可能なサービス枠・施設の空き",
+            "兄弟姉妹の協力度合い"
+          ],
+          "assumptions": [
+            "月の追加負担予算：最大12万円",
+            "平日は介護に割ける時間が限られる"
+          ],
+          "known_unknowns": [
+            "医師の見立て（進行予測、必要ケアレベル）",
+            "利用可能なサービス枠・施設の空き",
+            "兄弟姉妹の協力度合い"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "autonomy",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「尊厳（親の自律）」vs「安全」",
+          "between": [
+            "尊厳（親の自律）",
+            "安全"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "親",
+      "stakeholders": [
+        {
+          "name": "親",
+          "role": "当事者",
+          "impact": "生活の質・安全・尊厳に直結"
+        },
+        {
+          "name": "自分",
+          "role": "意思決定主体（支援者）",
+          "impact": "時間・お金・精神負荷に影響"
+        },
+        {
+          "name": "兄弟姉妹（いる場合）",
+          "role": "協力者候補",
+          "impact": "負担分担・合意形成に影響"
+        },
+        {
+          "name": "ケアマネ/介護事業者",
+          "role": "実行者",
+          "impact": "プランの品質に影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "医師の見立て（進行予測、必要ケアレベル）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（医師の見立て（進行予測、必要ケアレベル））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "利用可能なサービス枠・施設の空きはどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（利用可能なサービス枠・施設の空き）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "兄弟姉妹の協力度合いはどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（兄弟姉妹の協力度合い）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "医師の見立て（進行予測、必要ケアレベル）",
+        "利用可能なサービス枠・施設の空き",
+        "兄弟姉妹の協力度合い"
+      ],
+      "assumptions": [
+        "月の追加負担予算：最大12万円",
+        "平日は介護に割ける時間が限られる"
+      ],
+      "known_unknowns": [
+        "医師の見立て（進行予測、必要ケアレベル）",
+        "利用可能なサービス枠・施設の空き",
+        "兄弟姉妹の協力度合い"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_004_expected.json
+++ b/tests/acceptance/scenarios/at_004_expected.json
@@ -1,0 +1,332 @@
+{
+  "at_id": "AT-004",
+  "case_id": "case_004",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "f0bed7ad-aedf-ccc6-281e-412886722b47",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_004_security_disclosure",
+      "title": "研究公開：脆弱性をどのタイミングで公表するか",
+      "input_digest": "b8028f01e58f5c4ad30f4b8c256421a23da9861e44bedb57c3c483340bfc8438"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "研究公開：脆弱性をどのタイミングで公表するか",
+        "description": "道元禅師（1200-1253）は問う：「而今の山水は、古仏の道現成なり」。今ここに現れているこの問い、この状況そのものが、仏道の現成（げんじょう）である。修証一如（しゅしょういちにょ）——この問いに向き合うこと自体が修行であり悟りである。只管打坐（しかんたざ）の精神：結論を急がず、この問いの中に完全に在れ。有時（うじ）：今この状況を抱えているこの瞬間が、分割できない存在・時間の全体である。現成公案（げんじょうこうあん）：答えは遠くにあるのではなく、問い続けるこの場に、すでに現れている。無常（むじょう）を忘れるな——固定した答えへの執着を手放すことで、仏性の光が差し込む余地が生まれる。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 悪用リスクを増やす行為は避ける"
+          },
+          {
+            "step": "制約を考慮: 法令・契約・所属組織ポリシーを順守"
+          },
+          {
+            "step": "制約を考慮: ユーザー保護（パッチ提供）を優先"
+          }
+        ],
+        "pros": [
+          "価値観「公共の安全」の実現に資する",
+          "価値観「透明性」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: ベンダーの初動対応速度",
+          "不確実性: 既に悪用されているか"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "利用者",
+          "stakeholders": [
+            {
+              "name": "利用者",
+              "role": "潜在被害者",
+              "impact": "情報漏えい・乗っ取りのリスク"
+            },
+            {
+              "name": "ベンダー",
+              "role": "修正主体",
+              "impact": "対応負荷・評判・法的リスク"
+            },
+            {
+              "name": "自分",
+              "role": "発見者・公開主体",
+              "impact": "信用・法的リスク・研究成果"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-04-15",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "ベンダーの初動対応速度",
+            "既に悪用されているか",
+            "影響範囲の正確な特定方法"
+          ],
+          "assumptions": [
+            "悪用リスクを増やす行為は避ける",
+            "法令・契約・所属組織ポリシーを順守"
+          ],
+          "known_unknowns": [
+            "ベンダーの初動対応速度",
+            "既に悪用されているか",
+            "影響範囲の正確な特定方法"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "利用者",
+          "stakeholders": [
+            {
+              "name": "利用者",
+              "role": "潜在被害者",
+              "impact": "情報漏えい・乗っ取りのリスク"
+            },
+            {
+              "name": "ベンダー",
+              "role": "修正主体",
+              "impact": "対応負荷・評判・法的リスク"
+            },
+            {
+              "name": "自分",
+              "role": "発見者・公開主体",
+              "impact": "信用・法的リスク・研究成果"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "ベンダーの初動対応速度",
+            "既に悪用されているか",
+            "影響範囲の正確な特定方法"
+          ],
+          "assumptions": [
+            "悪用リスクを増やす行為は避ける",
+            "法令・契約・所属組織ポリシーを順守"
+          ],
+          "known_unknowns": [
+            "ベンダーの初動対応速度",
+            "既に悪用されているか",
+            "影響範囲の正確な特定方法"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "accountability",
+        "integrity",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「公共の安全」vs「透明性」",
+          "between": [
+            "公共の安全",
+            "透明性"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "利用者",
+      "stakeholders": [
+        {
+          "name": "利用者",
+          "role": "潜在被害者",
+          "impact": "情報漏えい・乗っ取りのリスク"
+        },
+        {
+          "name": "ベンダー",
+          "role": "修正主体",
+          "impact": "対応負荷・評判・法的リスク"
+        },
+        {
+          "name": "自分",
+          "role": "発見者・公開主体",
+          "impact": "信用・法的リスク・研究成果"
+        },
+        {
+          "name": "研究コミュニティ",
+          "role": "再現・検証者",
+          "impact": "知見の共有と悪用の境界に影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "ベンダーの初動対応速度はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（ベンダーの初動対応速度）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "既に悪用されているかはどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（既に悪用されているか）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "影響範囲の正確な特定方法はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（影響範囲の正確な特定方法）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "ベンダーの初動対応速度",
+        "既に悪用されているか",
+        "影響範囲の正確な特定方法"
+      ],
+      "assumptions": [
+        "悪用リスクを増やす行為は避ける",
+        "法令・契約・所属組織ポリシーを順守"
+      ],
+      "known_unknowns": [
+        "ベンダーの初動対応速度",
+        "既に悪用されているか",
+        "影響範囲の正確な特定方法"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_005_expected.json
+++ b/tests/acceptance/scenarios/at_005_expected.json
@@ -1,0 +1,327 @@
+{
+  "at_id": "AT-005",
+  "case_id": "case_005",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "2dea63ef-4bd3-fc1c-af45-b5c2f16b4f4c",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_005_promise_vs_safety",
+      "title": "約束：秘密保持と安全の衝突",
+      "input_digest": "ad0328c093bb72da64a35560c032b73080b075a505ad353ad25c49733ca56530"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "約束：秘密保持と安全の衝突",
+        "description": "道元の教えにおいて、関係性は個我の外部にあるものではない。有時（うじ）：関係とは時間の中に存在するのではなく、関係そのものが時間・存在である。仏性（ぶっしょう）は一切衆生に宿る——他者の中に仏性を見ることは、自己の仏性を見ることと不二（ふに）である。身心脱落（しんじんだつらく）の精神で関係に向かうとは、自己への執着を手放し、相手と共に「今ここ」に在ることである。只管打坐（しかんたざ）の如く関係に向かえ——成果や見返りを求めず、関係そのものに全身全霊で在ること。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 軽率に暴露して友人を追い詰めない"
+          },
+          {
+            "step": "制約を考慮: 他者への実害（事故）のリスクを軽視しない"
+          },
+          {
+            "step": "制約を考慮: できるだけ本人の自律的改善を促す"
+          }
+        ],
+        "pros": [
+          "価値観「安全（無危害）」の実現に資する",
+          "価値観「信頼関係」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 頻度（1回だけか、習慣か）",
+          "不確実性: 本人の改善意思の強さ"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "友人",
+          "stakeholders": [
+            {
+              "name": "友人",
+              "role": "当事者",
+              "impact": "信頼・生活・安全に影響"
+            },
+            {
+              "name": "第三者（道路利用者）",
+              "role": "潜在被害者",
+              "impact": "事故リスクの当事者"
+            },
+            {
+              "name": "自分",
+              "role": "意思決定主体",
+              "impact": "後悔・責任感・関係性に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-02-28",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "頻度（1回だけか、習慣か）",
+            "本人の改善意思の強さ",
+            "代替手段（タクシー、代行、支援）の利用可能性"
+          ],
+          "assumptions": [
+            "軽率に暴露して友人を追い詰めない",
+            "他者への実害（事故）のリスクを軽視しない"
+          ],
+          "known_unknowns": [
+            "頻度（1回だけか、習慣か）",
+            "本人の改善意思の強さ",
+            "代替手段（タクシー、代行、支援）の利用可能性"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "友人",
+          "stakeholders": [
+            {
+              "name": "友人",
+              "role": "当事者",
+              "impact": "信頼・生活・安全に影響"
+            },
+            {
+              "name": "第三者（道路利用者）",
+              "role": "潜在被害者",
+              "impact": "事故リスクの当事者"
+            },
+            {
+              "name": "自分",
+              "role": "意思決定主体",
+              "impact": "後悔・責任感・関係性に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "頻度（1回だけか、習慣か）",
+            "本人の改善意思の強さ",
+            "代替手段（タクシー、代行、支援）の利用可能性"
+          ],
+          "assumptions": [
+            "軽率に暴露して友人を追い詰めない",
+            "他者への実害（事故）のリスクを軽視しない"
+          ],
+          "known_unknowns": [
+            "頻度（1回だけか、習慣か）",
+            "本人の改善意思の強さ",
+            "代替手段（タクシー、代行、支援）の利用可能性"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "accountability",
+        "integrity",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「安全（無危害）」vs「信頼関係」",
+          "between": [
+            "安全（無危害）",
+            "信頼関係"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "友人",
+      "stakeholders": [
+        {
+          "name": "友人",
+          "role": "当事者",
+          "impact": "信頼・生活・安全に影響"
+        },
+        {
+          "name": "第三者（道路利用者）",
+          "role": "潜在被害者",
+          "impact": "事故リスクの当事者"
+        },
+        {
+          "name": "自分",
+          "role": "意思決定主体",
+          "impact": "後悔・責任感・関係性に影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "頻度（1回だけか、習慣か）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（頻度（1回だけか、習慣か））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "本人の改善意思の強さはどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（本人の改善意思の強さ）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "代替手段（タクシー、代行、支援）の利用可能性はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（代替手段（タクシー、代行、支援）の利用可能性）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "頻度（1回だけか、習慣か）",
+        "本人の改善意思の強さ",
+        "代替手段（タクシー、代行、支援）の利用可能性"
+      ],
+      "assumptions": [
+        "軽率に暴露して友人を追い詰めない",
+        "他者への実害（事故）のリスクを軽視しない"
+      ],
+      "known_unknowns": [
+        "頻度（1回だけか、習慣か）",
+        "本人の改善意思の強さ",
+        "代替手段（タクシー、代行、支援）の利用可能性"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_006_expected.json
+++ b/tests/acceptance/scenarios/at_006_expected.json
@@ -1,0 +1,327 @@
+{
+  "at_id": "AT-006",
+  "case_id": "case_006",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "9c7f481d-fb3c-3db1-b46f-f8993170ea04",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_006_data_leak_response",
+      "title": "インシデント対応：データ漏えい疑いの初動",
+      "input_digest": "41a0405808e6bc0613369afabe68e1742609a4afdb5e119e5e0f8de4cf9422db"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "インシデント対応：データ漏えい疑いの初動",
+        "description": "道元の教えにおいて、関係性は個我の外部にあるものではない。有時（うじ）：関係とは時間の中に存在するのではなく、関係そのものが時間・存在である。仏性（ぶっしょう）は一切衆生に宿る——他者の中に仏性を見ることは、自己の仏性を見ることと不二（ふに）である。身心脱落（しんじんだつらく）の精神で関係に向かうとは、自己への執着を手放し、相手と共に「今ここ」に在ることである。只管打坐（しかんたざ）の如く関係に向かえ——成果や見返りを求めず、関係そのものに全身全霊で在ること。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 事実未確定の断言は禁止（誠実）"
+          },
+          {
+            "step": "制約を考慮: 法令・規制（通知期限など）を順守"
+          },
+          {
+            "step": "制約を考慮: 被害拡大の防止（即時封じ込め）を最優先"
+          }
+        ],
+        "pros": [
+          "価値観「透明性」の実現に資する",
+          "価値観「説明責任」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 実際に外部閲覧があったか（ログ分析）",
+          "不確実性: 漏えい範囲（対象ユーザー数、項目）"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "ユーザー",
+          "stakeholders": [
+            {
+              "name": "ユーザー",
+              "role": "被害者候補",
+              "impact": "プライバシー・金銭被害リスク"
+            },
+            {
+              "name": "自社（経営・法務・広報・開発）",
+              "role": "対応主体",
+              "impact": "信用・法的リスク・運用負荷"
+            },
+            {
+              "name": "規制当局/監督機関",
+              "role": "通知先",
+              "impact": "手続き不備で制裁の可能性"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-02-24",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "実際に外部閲覧があったか（ログ分析）",
+            "漏えい範囲（対象ユーザー数、項目）",
+            "再発防止に必要な改修範囲"
+          ],
+          "assumptions": [
+            "事実未確定の断言は禁止（誠実）",
+            "法令・規制（通知期限など）を順守"
+          ],
+          "known_unknowns": [
+            "実際に外部閲覧があったか（ログ分析）",
+            "漏えい範囲（対象ユーザー数、項目）",
+            "再発防止に必要な改修範囲"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "ユーザー",
+          "stakeholders": [
+            {
+              "name": "ユーザー",
+              "role": "被害者候補",
+              "impact": "プライバシー・金銭被害リスク"
+            },
+            {
+              "name": "自社（経営・法務・広報・開発）",
+              "role": "対応主体",
+              "impact": "信用・法的リスク・運用負荷"
+            },
+            {
+              "name": "規制当局/監督機関",
+              "role": "通知先",
+              "impact": "手続き不備で制裁の可能性"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "実際に外部閲覧があったか（ログ分析）",
+            "漏えい範囲（対象ユーザー数、項目）",
+            "再発防止に必要な改修範囲"
+          ],
+          "assumptions": [
+            "事実未確定の断言は禁止（誠実）",
+            "法令・規制（通知期限など）を順守"
+          ],
+          "known_unknowns": [
+            "実際に外部閲覧があったか（ログ分析）",
+            "漏えい範囲（対象ユーザー数、項目）",
+            "再発防止に必要な改修範囲"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "accountability",
+        "integrity",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「透明性」vs「説明責任」",
+          "between": [
+            "透明性",
+            "説明責任"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "ユーザー",
+      "stakeholders": [
+        {
+          "name": "ユーザー",
+          "role": "被害者候補",
+          "impact": "プライバシー・金銭被害リスク"
+        },
+        {
+          "name": "自社（経営・法務・広報・開発）",
+          "role": "対応主体",
+          "impact": "信用・法的リスク・運用負荷"
+        },
+        {
+          "name": "規制当局/監督機関",
+          "role": "通知先",
+          "impact": "手続き不備で制裁の可能性"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "実際に外部閲覧があったか（ログ分析）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（実際に外部閲覧があったか（ログ分析））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "漏えい範囲（対象ユーザー数、項目）はどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（漏えい範囲（対象ユーザー数、項目））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "再発防止に必要な改修範囲はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（再発防止に必要な改修範囲）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "実際に外部閲覧があったか（ログ分析）",
+        "漏えい範囲（対象ユーザー数、項目）",
+        "再発防止に必要な改修範囲"
+      ],
+      "assumptions": [
+        "事実未確定の断言は禁止（誠実）",
+        "法令・規制（通知期限など）を順守"
+      ],
+      "known_unknowns": [
+        "実際に外部閲覧があったか（ログ分析）",
+        "漏えい範囲（対象ユーザー数、項目）",
+        "再発防止に必要な改修範囲"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_007_expected.json
+++ b/tests/acceptance/scenarios/at_007_expected.json
@@ -1,0 +1,326 @@
+{
+  "at_id": "AT-007",
+  "case_id": "case_007",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "6a4af85e-e922-2e39-be6e-a9508d0639d0",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_007_lie_or_admit",
+      "title": "仕事のミス：嘘で隠すか、認めて修正するか",
+      "input_digest": "0b066b7bd2b953773312a2f02fcb2c2b9d9cbdcbbe41403786dc6064f3689a0f"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "仕事のミス：嘘で隠すか、認めて修正するか",
+        "description": "修証一如（しゅしょういちにょ）——修行と悟りは別ではない。「どちらを選ぶべきか」を問う前に、「今この選択の場に、どう在るか」を問え。只管打坐（しかんたざ）の精神で言えば、判断そのものが修行の場であり、選択のプロセス自体が悟りの現れである。有時（うじ）が示すように、この問いを抱えている今この瞬間が仏性の現れであり、「今・ここ」から逃れた選択など存在しない。無常（むじょう）——いかなる選択肢も固定した安定を保証しない。現成公案（げんじょうこうあん）：問いそのものが答えであり、選択の迷いを「問題」として排除するのではなく、その迷いの中に仏道の現れを見出せ。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 虚偽の断言はしない"
+          },
+          {
+            "step": "制約を考慮: 修正可能なら早期に被害を止める"
+          },
+          {
+            "step": "制約を考慮: 責任転嫁はしない"
+          }
+        ],
+        "pros": [
+          "価値観「誠実（integrity）」の実現に資する",
+          "価値観「説明責任（accountability）」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 誤りの影響範囲（どの意思決定に影響するか）",
+          "不確実性: 修正に必要な時間"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "上司",
+          "stakeholders": [
+            {
+              "name": "上司",
+              "role": "意思決定者",
+              "impact": "判断の品質に影響"
+            },
+            {
+              "name": "チーム",
+              "role": "実行者",
+              "impact": "手戻り・信頼に影響"
+            },
+            {
+              "name": "自分",
+              "role": "当事者",
+              "impact": "信用・評価・学習に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-02-25",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "誤りの影響範囲（どの意思決定に影響するか）",
+            "修正に必要な時間",
+            "既に外部に共有済みか"
+          ],
+          "assumptions": [
+            "虚偽の断言はしない",
+            "修正可能なら早期に被害を止める"
+          ],
+          "known_unknowns": [
+            "誤りの影響範囲（どの意思決定に影響するか）",
+            "修正に必要な時間",
+            "既に外部に共有済みか"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "integrity"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "上司",
+          "stakeholders": [
+            {
+              "name": "上司",
+              "role": "意思決定者",
+              "impact": "判断の品質に影響"
+            },
+            {
+              "name": "チーム",
+              "role": "実行者",
+              "impact": "手戻り・信頼に影響"
+            },
+            {
+              "name": "自分",
+              "role": "当事者",
+              "impact": "信用・評価・学習に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "誤りの影響範囲（どの意思決定に影響するか）",
+            "修正に必要な時間",
+            "既に外部に共有済みか"
+          ],
+          "assumptions": [
+            "虚偽の断言はしない",
+            "修正可能なら早期に被害を止める"
+          ],
+          "known_unknowns": [
+            "誤りの影響範囲（どの意思決定に影響するか）",
+            "修正に必要な時間",
+            "既に外部に共有済みか"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "accountability",
+        "integrity"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「誠実（integrity）」vs「説明責任（accountability）」",
+          "between": [
+            "誠実（integrity）",
+            "説明責任（accountability）"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "上司",
+      "stakeholders": [
+        {
+          "name": "上司",
+          "role": "意思決定者",
+          "impact": "判断の品質に影響"
+        },
+        {
+          "name": "チーム",
+          "role": "実行者",
+          "impact": "手戻り・信頼に影響"
+        },
+        {
+          "name": "自分",
+          "role": "当事者",
+          "impact": "信用・評価・学習に影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "誤りの影響範囲（どの意思決定に影響するか）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（誤りの影響範囲（どの意思決定に影響するか））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "修正に必要な時間はどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（修正に必要な時間）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "既に外部に共有済みかはどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（既に外部に共有済みか）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "誤りの影響範囲（どの意思決定に影響するか）",
+        "修正に必要な時間",
+        "既に外部に共有済みか"
+      ],
+      "assumptions": [
+        "虚偽の断言はしない",
+        "修正可能なら早期に被害を止める"
+      ],
+      "known_unknowns": [
+        "誤りの影響範囲（どの意思決定に影響するか）",
+        "修正に必要な時間",
+        "既に外部に共有済みか"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_008_expected.json
+++ b/tests/acceptance/scenarios/at_008_expected.json
@@ -1,0 +1,326 @@
+{
+  "at_id": "AT-008",
+  "case_id": "case_008",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "95b51cca-16fe-6261-5bba-a05cd94e8a35",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_008_deadline_tradeoff",
+      "title": "納期固定：速度 vs 品質のトレードオフ",
+      "input_digest": "a7d7011ad552c73c5bc6ecbd52062b3107436773bf6fbd43a2444a274c9dd529"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "納期固定：速度 vs 品質のトレードオフ",
+        "description": "道元の教えにおいて、関係性は個我の外部にあるものではない。有時（うじ）：関係とは時間の中に存在するのではなく、関係そのものが時間・存在である。仏性（ぶっしょう）は一切衆生に宿る——他者の中に仏性を見ることは、自己の仏性を見ることと不二（ふに）である。身心脱落（しんじんだつらく）の精神で関係に向かうとは、自己への執着を手放し、相手と共に「今ここ」に在ることである。只管打坐（しかんたざ）の如く関係に向かえ——成果や見返りを求めず、関係そのものに全身全霊で在ること。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: リリース日を動かせない（外部告知済み）"
+          },
+          {
+            "step": "制約を考慮: 重大障害・安全問題は許容しない"
+          },
+          {
+            "step": "制約を考慮: チームの過重労働を前提にしない"
+          }
+        ],
+        "pros": [
+          "価値観「ユーザー安全（nonmaleficence）」の実現に資する",
+          "価値観「信頼」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 最低限守るべき品質ライン（SLO/重大バグ定義）",
+          "不確実性: 段階リリース（限定公開）が可能か"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "integrity",
+            "nonmaleficence"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "ユーザー",
+          "stakeholders": [
+            {
+              "name": "ユーザー",
+              "role": "受益者/被害者候補",
+              "impact": "体験・安全・信頼に影響"
+            },
+            {
+              "name": "開発チーム",
+              "role": "実行者",
+              "impact": "負荷・燃え尽き・品質に影響"
+            },
+            {
+              "name": "事業責任者",
+              "role": "期待管理",
+              "impact": "売上・評判に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-02-25",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "最低限守るべき品質ライン（SLO/重大バグ定義）",
+            "段階リリース（限定公開）が可能か",
+            "延期の代替（告知文、補償）"
+          ],
+          "assumptions": [
+            "リリース日を動かせない（外部告知済み）",
+            "重大障害・安全問題は許容しない"
+          ],
+          "known_unknowns": [
+            "最低限守るべき品質ライン（SLO/重大バグ定義）",
+            "段階リリース（限定公開）が可能か",
+            "延期の代替（告知文、補償）"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "integrity",
+            "nonmaleficence"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "ユーザー",
+          "stakeholders": [
+            {
+              "name": "ユーザー",
+              "role": "受益者/被害者候補",
+              "impact": "体験・安全・信頼に影響"
+            },
+            {
+              "name": "開発チーム",
+              "role": "実行者",
+              "impact": "負荷・燃え尽き・品質に影響"
+            },
+            {
+              "name": "事業責任者",
+              "role": "期待管理",
+              "impact": "売上・評判に影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "最低限守るべき品質ライン（SLO/重大バグ定義）",
+            "段階リリース（限定公開）が可能か",
+            "延期の代替（告知文、補償）"
+          ],
+          "assumptions": [
+            "リリース日を動かせない（外部告知済み）",
+            "重大障害・安全問題は許容しない"
+          ],
+          "known_unknowns": [
+            "最低限守るべき品質ライン（SLO/重大バグ定義）",
+            "段階リリース（限定公開）が可能か",
+            "延期の代替（告知文、補償）"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "integrity",
+        "nonmaleficence"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「ユーザー安全（nonmaleficence）」vs「信頼」",
+          "between": [
+            "ユーザー安全（nonmaleficence）",
+            "信頼"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "ユーザー",
+      "stakeholders": [
+        {
+          "name": "ユーザー",
+          "role": "受益者/被害者候補",
+          "impact": "体験・安全・信頼に影響"
+        },
+        {
+          "name": "開発チーム",
+          "role": "実行者",
+          "impact": "負荷・燃え尽き・品質に影響"
+        },
+        {
+          "name": "事業責任者",
+          "role": "期待管理",
+          "impact": "売上・評判に影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": [
+        "影響を受けるすべての関係者に変更内容・リスクを事前に説明する",
+        "重大なリスクが残る場合は関係者の同意を得てから進める"
+      ]
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "最低限守るべき品質ライン（SLO/重大バグ定義）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（最低限守るべき品質ライン（SLO/重大バグ定義））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "段階リリース（限定公開）が可能かはどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（段階リリース（限定公開）が可能か）が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "延期の代替（告知文、補償）はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（延期の代替（告知文、補償））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "最低限守るべき品質ライン（SLO/重大バグ定義）",
+        "段階リリース（限定公開）が可能か",
+        "延期の代替（告知文、補償）"
+      ],
+      "assumptions": [
+        "リリース日を動かせない（外部告知済み）",
+        "重大障害・安全問題は許容しない"
+      ],
+      "known_unknowns": [
+        "最低限守るべき品質ライン（SLO/重大バグ定義）",
+        "段階リリース（限定公開）が可能か",
+        "延期の代替（告知文、補償）"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/scenarios/at_010_expected.json
+++ b/tests/acceptance/scenarios/at_010_expected.json
@@ -1,0 +1,323 @@
+{
+  "at_id": "AT-010",
+  "case_id": "case_010",
+  "expected": {
+    "meta": {
+      "schema_version": "1.0",
+      "pocore_version": "0.2.0b4",
+      "run_id": "6afe20af-63c1-3ee0-5bf3-48e1e8b29d9d",
+      "seed": 42,
+      "deterministic": true,
+      "generator": {
+        "name": "po_core.ensemble.run_turn",
+        "version": "0.2.0",
+        "mode": "rule_based"
+      }
+    },
+    "case_ref": {
+      "case_id": "case_010_conflicting_constraints",
+      "title": "制約の矛盾：やりたいが、条件が同時に成立しない",
+      "input_digest": "f1b904a0915a946a6c93129dd8757b6725224b7fae2c84d2bbf157b4fc31ae23"
+    },
+    "options": [
+      {
+        "option_id": "opt_001",
+        "title": "制約の矛盾：やりたいが、条件が同時に成立しない",
+        "description": "道元の教えにおいて、関係性は個我の外部にあるものではない。有時（うじ）：関係とは時間の中に存在するのではなく、関係そのものが時間・存在である。仏性（ぶっしょう）は一切衆生に宿る——他者の中に仏性を見ることは、自己の仏性を見ることと不二（ふに）である。身心脱落（しんじんだつらく）の精神で関係に向かうとは、自己への執着を手放し、相手と共に「今ここ」に在ることである。只管打坐（しかんたざ）の如く関係に向かえ——成果や見返りを求めず、関係そのものに全身全霊で在ること。",
+        "action_plan": [
+          {
+            "step": "制約を考慮: 半年以内に起業を本格始動（週20時間以上投入したい）"
+          },
+          {
+            "step": "制約を考慮: 収入は一切落とせない（生活費の都合）"
+          },
+          {
+            "step": "制約を考慮: 貯金も増やしたい"
+          }
+        ],
+        "pros": [
+          "価値観「自律（autonomy）」の実現に資する",
+          "価値観「経済的安定」の実現に資する"
+        ],
+        "cons": [
+          "不確実性: 副業規定の詳細（許容範囲）",
+          "不確実性: 起業の初期モデル（必要時間・初期投資）"
+        ],
+        "risks": [
+          {
+            "risk": "情報不足による判断ミスのリスク",
+            "severity": "medium",
+            "mitigation": "追加調査を行い不確実性を低減する"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "autonomy"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "自分",
+          "stakeholders": [
+            {
+              "name": "自分",
+              "role": "意思決定主体",
+              "impact": "時間・収入・健康に影響"
+            },
+            {
+              "name": "家族/同居人",
+              "role": "生活共同体",
+              "impact": "家計・時間配分・不確実性の影響"
+            },
+            {
+              "name": "現職",
+              "role": "雇用主",
+              "impact": "副業規定・パフォーマンスに影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "中程度",
+          "timeline": "期限: 2026-08-31",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "high",
+          "reasons": [
+            "副業規定の詳細（許容範囲）",
+            "起業の初期モデル（必要時間・初期投資）",
+            "収入維持の代替策（段階投入、検証期間）"
+          ],
+          "assumptions": [
+            "半年以内に起業を本格始動（週20時間以上投入したい）",
+            "収入は一切落とせない（生活費の都合）"
+          ],
+          "known_unknowns": [
+            "副業規定の詳細（許容範囲）",
+            "起業の初期モデル（必要時間・初期投資）",
+            "収入維持の代替策（段階投入、検証期間）"
+          ]
+        }
+      },
+      {
+        "option_id": "opt_002",
+        "title": "慎重路線：情報収集後に再判断",
+        "description": "主要な不明点を解消してから判断する選択肢。リスクを最小化しながら次の判断機会を設ける。",
+        "action_plan": [
+          {
+            "step": "不明点を優先度順に列挙し、調査計画を立てる"
+          },
+          {
+            "step": "関係者へ現状と懸念を共有し認識を合わせる"
+          },
+          {
+            "step": "判断に必要な情報が揃った時点で再検討する"
+          }
+        ],
+        "pros": [
+          "情報が揃った状態での判断が可能",
+          "リスクを最小化できる",
+          "関係者の同意を得やすい"
+        ],
+        "cons": [
+          "判断の先送りによる機会損失の可能性",
+          "時間的コストが発生する"
+        ],
+        "risks": [
+          {
+            "risk": "判断保留による機会損失",
+            "severity": "low",
+            "mitigation": "タイムボックスを設定し判断期限を明確にする"
+          }
+        ],
+        "ethics_review": {
+          "principles_applied": [
+            "accountability",
+            "autonomy"
+          ],
+          "tradeoffs": [],
+          "concerns": [],
+          "confidence": "medium"
+        },
+        "responsibility_review": {
+          "decision_owner": "自分",
+          "stakeholders": [
+            {
+              "name": "自分",
+              "role": "意思決定主体",
+              "impact": "時間・収入・健康に影響"
+            },
+            {
+              "name": "家族/同居人",
+              "role": "生活共同体",
+              "impact": "家計・時間配分・不確実性の影響"
+            },
+            {
+              "name": "現職",
+              "role": "雇用主",
+              "impact": "副業規定・パフォーマンスに影響"
+            }
+          ],
+          "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+          "confidence": "medium"
+        },
+        "feasibility": {
+          "effort": "低〜中程度",
+          "timeline": "1〜4週間の調査期間",
+          "confidence": "medium"
+        },
+        "uncertainty": {
+          "overall_level": "medium",
+          "reasons": [
+            "副業規定の詳細（許容範囲）",
+            "起業の初期モデル（必要時間・初期投資）",
+            "収入維持の代替策（段階投入、検証期間）"
+          ],
+          "assumptions": [
+            "半年以内に起業を本格始動（週20時間以上投入したい）",
+            "収入は一切落とせない（生活費の都合）"
+          ],
+          "known_unknowns": [
+            "副業規定の詳細（許容範囲）",
+            "起業の初期モデル（必要時間・初期投資）",
+            "収入維持の代替策（段階投入、検証期間）"
+          ]
+        }
+      }
+    ],
+    "recommendation": {
+      "status": "recommended",
+      "recommended_option_id": "opt_001",
+      "reason": "価値観と制約を踏まえた哲学的考察により、主要選択肢が最もバランスが取れていると判断されます。",
+      "counter": "ただし不明点が残るため、慎重路線（opt_002）も検討に値します。情報が揃っていない状態での決定にはリスクが伴います。",
+      "alternatives": [
+        {
+          "option_id": "opt_002",
+          "when_to_choose": "重要な不明点が解消できない場合、またはリスク許容度が低い場合"
+        }
+      ],
+      "confidence": "medium"
+    },
+    "ethics": {
+      "principles_used": [
+        "accountability",
+        "autonomy"
+      ],
+      "tradeoffs": [
+        {
+          "tension": "「自律（autonomy）」vs「経済的安定」",
+          "between": [
+            "自律（autonomy）",
+            "経済的安定"
+          ],
+          "mitigation": "段階的実施と関係者調整により両立を目指す",
+          "severity": "medium"
+        }
+      ],
+      "guardrails": [
+        "医療・法律の最終判断はPo_coreが行わない",
+        "意思決定の主体はユーザーである"
+      ],
+      "notes": "W_Ethics Gateによる3層倫理評価済み"
+    },
+    "responsibility": {
+      "decision_owner": "自分",
+      "stakeholders": [
+        {
+          "name": "自分",
+          "role": "意思決定主体",
+          "impact": "時間・収入・健康に影響"
+        },
+        {
+          "name": "家族/同居人",
+          "role": "生活共同体",
+          "impact": "家計・時間配分・不確実性の影響"
+        },
+        {
+          "name": "現職",
+          "role": "雇用主",
+          "impact": "副業規定・パフォーマンスに影響"
+        }
+      ],
+      "accountability_notes": "意思決定と結果責任はユーザー。Po_coreは問いと構造化を提供する。",
+      "consent_considerations": []
+    },
+    "questions": [
+      {
+        "question_id": "q_001",
+        "question": "副業規定の詳細（許容範囲）はどのような状況ですか？",
+        "priority": 1,
+        "why_needed": "この不明点（副業規定の詳細（許容範囲））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_002",
+        "question": "起業の初期モデル（必要時間・初期投資）はどのような状況ですか？",
+        "priority": 2,
+        "why_needed": "この不明点（起業の初期モデル（必要時間・初期投資））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": false
+      },
+      {
+        "question_id": "q_003",
+        "question": "収入維持の代替策（段階投入、検証期間）はどのような状況ですか？",
+        "priority": 3,
+        "why_needed": "この不明点（収入維持の代替策（段階投入、検証期間））が判断に直接影響するため",
+        "assumption_if_unanswered": "最も慎重な仮定を採用します",
+        "optional": true
+      }
+    ],
+    "uncertainty": {
+      "overall_level": "high",
+      "reasons": [
+        "副業規定の詳細（許容範囲）",
+        "起業の初期モデル（必要時間・初期投資）",
+        "収入維持の代替策（段階投入、検証期間）"
+      ],
+      "assumptions": [
+        "半年以内に起業を本格始動（週20時間以上投入したい）",
+        "収入は一切落とせない（生活費の都合）"
+      ],
+      "known_unknowns": [
+        "副業規定の詳細（許容範囲）",
+        "起業の初期モデル（必要時間・初期投資）",
+        "収入維持の代替策（段階投入、検証期間）"
+      ]
+    },
+    "trace": {
+      "version": "1.0",
+      "steps": [
+        {
+          "name": "parse_input",
+          "summary": "入力YAMLを解析し、case_id・problem・values・constraints等を抽出した"
+        },
+        {
+          "name": "generate_options",
+          "summary": "39人の哲学者による審議を経て選択肢を生成した"
+        },
+        {
+          "name": "ethics_review",
+          "summary": "W_Ethics Gateによる3層倫理評価を適用した"
+        },
+        {
+          "name": "responsibility_review",
+          "summary": "意思決定主体と利害関係者の責任構造を検証した"
+        },
+        {
+          "name": "question_layer",
+          "summary": "不明点から優先度付き質問リストを生成した"
+        },
+        {
+          "name": "compose_output",
+          "summary": "推奨・反証・代替案を含む出力を組み立てた"
+        }
+      ]
+    }
+  }
+}

--- a/tests/acceptance/test_acceptance_golden.py
+++ b/tests/acceptance/test_acceptance_golden.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Golden diff tests for acceptance scenarios.
+
+Phase 7 contract:
+- Ensure AT-002..AT-008 (+AT-010 for >=8 total) are pinned with golden outputs.
+- Keep comparisons deterministic by stripping volatile timestamps generated at runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from po_core.app.composer import StubComposer
+
+pytestmark = pytest.mark.acceptance
+
+ROOT = Path(__file__).resolve().parents[2]
+GOLDEN_DIR = Path(__file__).resolve().parent / "scenarios"
+SCENARIOS_DIR = ROOT / "scenarios"
+
+
+def _canonicalize(output: dict[str, Any]) -> dict[str, Any]:
+    """Remove volatile fields (wall-clock-derived timestamps) before diff."""
+    canonical = json.loads(json.dumps(output, ensure_ascii=False))
+    canonical.get("meta", {}).pop("created_at", None)
+    for step in canonical.get("trace", {}).get("steps", []):
+        step.pop("started_at", None)
+        step.pop("ended_at", None)
+    return canonical
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize(
+    "golden_path",
+    sorted(GOLDEN_DIR.glob("at_*_expected.json")),
+    ids=lambda p: p.stem,
+)
+def test_acceptance_golden_diff(golden_path: Path) -> None:
+    golden = _load_json(golden_path)
+    case_id = golden["case_id"]
+    case = _load_yaml(SCENARIOS_DIR / f"{case_id}.yaml")
+
+    composer = StubComposer(seed=42)
+    actual = _canonicalize(composer.compose(case))
+
+    assert actual == golden["expected"], (
+        f"Golden mismatch for {golden['at_id']} ({case_id}). "
+        f"To regenerate, update {golden_path.relative_to(ROOT)} with deterministic output."
+    )


### PR DESCRIPTION
### Motivation
- Pin acceptance outputs for Phase 7 (M2-D) so AT-002..AT-008 (plus AT-010 to reach ≥8) are reproducible and auditable via golden fixtures. 
- Provide a machine-checkable mapping from traceability matrix → acceptance golden coverage so M2 gate can be enforced automatically. 
- Keep determinism contract intact by canonicalizing volatile wall-clock fields during golden comparisons. 

### Description
- Added acceptance golden JSON fixtures under `tests/acceptance/scenarios/` for `AT-002`..`AT-008` and `AT-010` to pin expected outputs for those cases. 
- Added `tests/acceptance/test_acceptance_golden.py` which canonicalizes volatile fields (`meta.created_at`, trace step timestamps) and compares `StubComposer(seed=42)` output to the pinned golden fixtures. 
- Added `scripts/calc_traceability_coverage.py` which parses `docs/traceability/traceability_v1.yaml`, extracts `AT-xxx` IDs referenced by the traceability matrix, compares them to available golden IDs, and returns non-zero exit when coverage < `--min-at` (default 8). 
- Updated `docs/traceability/traceability_v1.yaml` to include `REQ-AT-001` (mapping AT tests and golden references) and updated CI (`.github/workflows/ci.yml`) to run the coverage script as an M2 gate; updated `.gitignore` to allow tracking acceptance golden JSON fixtures. 

### Testing
- Ran `pytest tests/acceptance/ -v -m acceptance` and the acceptance suite plus new golden-diff tests passed (25 passed, 0 failed in acceptance run). 
- Ran `python scripts/calc_traceability_coverage.py --min-at 8` which reported 8 covered AT IDs and exited with success (PASS). 
- Ran `pytest -q` (full test suite); this change did not introduce regressions in functional tests, but an existing benchmark test `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` failed in this environment (performance measurement failure unrelated to the acceptance golden additions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a584af0e808328aaf4c59dfef6bd44)