### PR TITLE
Phase 11: make output schema validation a required CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,34 @@ jobs:
       run: |
         mypy src/po_core/domain/ src/po_core/experiments/ src/po_core/app/ src/po_core/ports/
 
-  test:
+  schema-gate:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run output schema validation tests (required gate)
+      run: |
+        pytest tests/test_output_schema.py -v
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [lint, schema-gate]
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -69,9 +94,9 @@ jobs:
       run: |
         pytest tests/test_run_turn_e2e.py tests/test_philosopher_bridge.py tests/test_po_self_v2.py tests/test_tensor_metrics.py tests/test_golden_regression.py tests/test_smoke_pipeline.py tests/test_philosophers_pipeline.py tests/test_viewer_pipeline.py tests/test_philosopher_contract.py tests/test_semantic_delta.py -v
 
-    - name: Run golden E2E + schema tests (must pass)
+    - name: Run golden E2E + input schema tests (must pass)
       run: |
-        pytest tests/test_golden_e2e.py tests/test_input_schema.py tests/test_output_schema.py -v
+        pytest tests/test_golden_e2e.py tests/test_input_schema.py -v
 
     - name: Run acceptance tests — AT-001 to AT-010 (must pass, M1)
       run: |


### PR DESCRIPTION
### Motivation
- Make output schema validation an explicit mandatory CI gate so schema mismatches fail early and block downstream test stages. 
- Satisfy PHASE 11 (M4-A) requirement to require output schema verification as part of CI flow. 
- Reduce risk of merged changes that break the output contract by failing fast on schema errors.

### Description
- Added a `schema-gate` job to `.github/workflows/ci.yml` that runs `pytest tests/test_output_schema.py -v` across a Python matrix and depends on `lint`.
- Updated the `test` job to `needs: [lint, schema-gate]` and removed `tests/test_output_schema.py` from the `test` job so progression is blocked until the schema gate passes.
- Kept golden and input schema checks in the `test` job and did not modify schema files or golden scenario files.

### Testing
- Ran `pytest tests/test_output_schema.py -v` locally and it passed (`41 passed`).
- Ran the acceptance suite with `pytest tests/acceptance/ -v -m acceptance` locally and it passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58545a0348328bf3474d86f6a512c)