### PR TITLE
Phase 13: automate config_version traceability lock and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
       run: |
         pytest tests/test_golden_e2e.py tests/test_input_schema.py tests/test_output_schema.py -v
 
+    - name: Run traceability config lock check (must pass)
+      run: |
+        python scripts/update_traceability.py --check
+
     - name: Run acceptance tests — AT-001 to AT-010 (must pass, M1)
       run: |
         pytest tests/acceptance/ -v -m acceptance

--- a/docs/traceability/config_versions.lock.yaml
+++ b/docs/traceability/config_versions.lock.yaml
@@ -1,0 +1,8 @@
+version: 1
+tracked_configs:
+- path: 02_architecture/philosophy/pareto_table.yaml
+  config_version: '1'
+  sha256: c62af7645998d40859f9ba15216b1240cfff4737139755c07226c401ff9218bd
+- path: 02_architecture/philosophy/battalion_table.yaml
+  config_version: '1'
+  sha256: c2cae85b55cb72edb239ac7d3baa3e17132ad92ac0bb0a05d7f0299cf6baf934

--- a/scripts/update_traceability.py
+++ b/scripts/update_traceability.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONFIG_FILES = (
+    "02_architecture/philosophy/pareto_table.yaml",
+    "02_architecture/philosophy/battalion_table.yaml",
+)
+DEFAULT_LOCK_FILE = "docs/traceability/config_versions.lock.yaml"
+
+
+@dataclass(frozen=True)
+class ConfigFingerprint:
+    path: str
+    config_version: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "config_version": self.config_version,
+            "sha256": self.sha256,
+        }
+
+
+def _load_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload: Any = json.loads(text)
+    except json.JSONDecodeError:
+        payload = yaml.safe_load(text)
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"Config must be mapping: {path}")
+    if "version" not in payload:
+        raise ValueError(f"Missing 'version' in config: {path}")
+    return str(payload["version"])
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def collect_fingerprints(repo_root: Path) -> list[ConfigFingerprint]:
+    rows: list[ConfigFingerprint] = []
+    for rel_path in CONFIG_FILES:
+        full_path = repo_root / rel_path
+        rows.append(
+            ConfigFingerprint(
+                path=rel_path,
+                config_version=_load_version(full_path),
+                sha256=_sha256(full_path),
+            )
+        )
+    return rows
+
+
+def _render_yaml(rows: list[ConfigFingerprint]) -> str:
+    payload = {
+        "version": 1,
+        "tracked_configs": [row.to_dict() for row in rows],
+    }
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+
+def write_lock(lock_file: Path, rows: list[ConfigFingerprint]) -> None:
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.write_text(_render_yaml(rows), encoding="utf-8")
+
+
+def check_lock(lock_file: Path, rows: list[ConfigFingerprint]) -> bool:
+    expected = _render_yaml(rows)
+    if not lock_file.exists():
+        print(f"Traceability lock file missing: {lock_file}")
+        return False
+
+    current = lock_file.read_text(encoding="utf-8")
+    if current != expected:
+        print("Traceability lock file is stale.")
+        print("Run: python scripts/update_traceability.py")
+        return False
+
+    print("Traceability lock file is up to date.")
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update/check config_version traceability lock file."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root path",
+    )
+    parser.add_argument(
+        "--lock-file",
+        type=Path,
+        default=Path(DEFAULT_LOCK_FILE),
+        help="Lock file path (relative to repo root unless absolute)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate lock file only (non-zero exit if stale)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    lock_file = args.lock_file
+    if not lock_file.is_absolute():
+        lock_file = repo_root / lock_file
+
+    rows = collect_fingerprints(repo_root)
+    if args.check:
+        return 0 if check_lock(lock_file, rows) else 1
+
+    write_lock(lock_file, rows)
+    print(f"Updated traceability lock file: {lock_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_traceability_config_lock.py
+++ b/tests/test_traceability_config_lock.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_FILE = ROOT / "docs/traceability/config_versions.lock.yaml"
+
+
+def test_update_traceability_check_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/update_traceability.py", "--check"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_traceability_lock_tracks_config_versions() -> None:
+    payload = yaml.safe_load(LOCK_FILE.read_text(encoding="utf-8"))
+    tracked = payload.get("tracked_configs", [])
+    tracked_paths = {row["path"] for row in tracked}
+
+    assert "02_architecture/philosophy/pareto_table.yaml" in tracked_paths
+    assert "02_architecture/philosophy/battalion_table.yaml" in tracked_paths
+    for row in tracked:
+        assert str(row.get("config_version", ""))
+        assert len(str(row.get("sha256", ""))) == 64


### PR DESCRIPTION
### Motivation
- Ensure config_version changes to Pareto/battalion settings are tracked and cause CI failures if lock is not updated, completing PHASE 13 (M4-C) governance requirement. 
- Provide a deterministic, auditable lock that maps each tracked config file to its `version` and file SHA-256 so unreflected edits are detected automatically. 

### Description
- Add `scripts/update_traceability.py` which collects `version` and SHA-256 for tracked files and can `write` a lock or `--check` against `docs/traceability/config_versions.lock.yaml`. 
- Add `docs/traceability/config_versions.lock.yaml` containing current fingerprints for `02_architecture/philosophy/pareto_table.yaml` and `02_architecture/philosophy/battalion_table.yaml`. 
- Add `tests/test_traceability_config_lock.py` that asserts `scripts/update_traceability.py --check` succeeds and the lock contains expected paths/fields. 
- Inject a CI step into the test job to run `python scripts/update_traceability.py --check` so PR/merge runs will fail when the lock is stale. 

### Testing
- Ran `python scripts/update_traceability.py` which updated/created `docs/traceability/config_versions.lock.yaml` successfully. 
- Ran `pytest tests/test_traceability.py tests/test_traceability_config_lock.py -v` and both traceability tests passed (`7 passed`). 
- Ran a broader `pytest tests/ -v --maxfail=1` to sanity-check regressions which revealed one unrelated benchmark failure (`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`), otherwise the suite exercised existing tests; the traceability change itself did not break traceability or schema tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a585aa72848328957f5f05c5d9a62f)