### PR TITLE
Phase 17: Add persistent TraceStore (SQLite) and trace history API

### DIFF
--- a/src/po_core/app/rest/config.py
+++ b/src/po_core/app/rest/config.py
@@ -57,6 +57,8 @@ class APISettings(BaseSettings):
 
     # Trace storage
     max_trace_sessions: int = 1000
+    trace_store_backend: str = "sqlite"  # sqlite | memory
+    trace_db_path: str = ".po_core/trace_store.sqlite3"
 
     class Config:
         env_prefix = "PO_"

--- a/src/po_core/app/rest/models.py
+++ b/src/po_core/app/rest/models.py
@@ -143,6 +143,21 @@ class TraceResponse(BaseModel):
     events: List[TraceEventOut]
 
 
+class TraceHistoryItem(BaseModel):
+    """Summary row for persisted trace history."""
+
+    session_id: str
+    event_count: int
+    last_occurred_at: datetime
+
+
+class TraceHistoryResponse(BaseModel):
+    """Response body for trace history endpoint."""
+
+    total: int
+    items: List[TraceHistoryItem]
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/health
 # ---------------------------------------------------------------------------

--- a/src/po_core/app/rest/routers/trace.py
+++ b/src/po_core/app/rest/routers/trace.py
@@ -4,13 +4,42 @@ GET /v1/trace/{session_id} — Trace Retrieval
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from po_core.app.rest.auth import require_api_key
-from po_core.app.rest.models import TraceEventOut, TraceResponse
-from po_core.app.rest.store import get_trace_store
+from po_core.app.rest.models import (
+    TraceEventOut,
+    TraceHistoryItem,
+    TraceHistoryResponse,
+    TraceResponse,
+)
+from po_core.app.rest.store import TraceStore, get_trace_store
 
 router = APIRouter(tags=["trace"])
+
+
+@router.get(
+    "/v1/trace/history",
+    response_model=TraceHistoryResponse,
+    summary="Retrieve persisted trace history",
+    description="Returns recent trace sessions with event counts.",
+)
+async def get_trace_history(
+    limit: int = Query(default=50, ge=1, le=500),
+    _: None = Depends(require_api_key),
+    store: TraceStore = Depends(get_trace_store),
+) -> TraceHistoryResponse:
+    """Return recent trace session summaries in descending recency order."""
+    summaries = store.history(limit=limit)
+    items = [
+        TraceHistoryItem(
+            session_id=str(s["session_id"]),
+            event_count=int(s["event_count"]),
+            last_occurred_at=s["last_occurred_at"],
+        )
+        for s in summaries
+    ]
+    return TraceHistoryResponse(total=len(items), items=items)
 
 
 @router.get(
@@ -26,7 +55,7 @@ router = APIRouter(tags=["trace"])
 async def get_trace(
     session_id: str,
     _: None = Depends(require_api_key),
-    store: dict = Depends(get_trace_store),
+    store: TraceStore = Depends(get_trace_store),
 ) -> TraceResponse:
     """Return trace events for the given session_id."""
     events = store.get(session_id)

--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -1,37 +1,267 @@
-"""
-In-process Trace Store
-=======================
-
-Maintains an LRU-bounded dict mapping session_id → list[TraceEvent].
-Used by the trace router and populated by the reason endpoint.
-
-This is intentionally simple (in-memory, single-process).
-For multi-process deployments swap this out with a Redis adapter.
-"""
-
 from __future__ import annotations
 
+import json
+import sqlite3
+from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Dict, List
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+from typing import List
 
 from po_core.app.rest.config import get_api_settings
 from po_core.domain.trace_event import TraceEvent
 
-# Module-level singleton
-_store: OrderedDict[str, List[TraceEvent]] = OrderedDict()
+
+class TraceStore(ABC):
+    """Abstract storage backend for trace events."""
+
+    @abstractmethod
+    def get(self, session_id: str) -> List[TraceEvent] | None:
+        """Return trace events for a session, or None when missing."""
+
+    @abstractmethod
+    def save(self, session_id: str, events: List[TraceEvent]) -> None:
+        """Persist trace events for a session."""
+
+    @abstractmethod
+    def history(self, limit: int = 50) -> List[dict[str, object]]:
+        """Return recent session summaries sorted by newest first."""
 
 
-def get_trace_store() -> Dict[str, List[TraceEvent]]:
-    """FastAPI dependency returning the trace store dict."""
-    return _store
+class InMemoryTraceStore(TraceStore):
+    """In-process LRU-bounded trace store (legacy backend)."""
 
+    def __init__(self) -> None:
+        self._store: OrderedDict[str, List[TraceEvent]] = OrderedDict()
+        self._sessions: OrderedDict[str, datetime] = OrderedDict()
+
+    def clear(self) -> None:
+        self._store.clear()
+        self._sessions.clear()
+
+    def get(self, session_id: str) -> List[TraceEvent] | None:
+        if session_id in self._store:
+            return list(self._store[session_id])
+        if session_id in self._sessions:
+            return []
+        return None
+
+    def save(self, session_id: str, events: List[TraceEvent]) -> None:
+        settings = get_api_settings()
+        if session_id in self._store:
+            del self._store[session_id]
+        if session_id in self._sessions:
+            del self._sessions[session_id]
+        self._store[session_id] = list(events)
+        updated_at = events[-1].occurred_at if events else datetime.utcnow()
+        self._sessions[session_id] = updated_at
+        while len(self._sessions) > settings.max_trace_sessions:
+            stale_id, _ = self._sessions.popitem(last=False)
+            self._store.pop(stale_id, None)
+
+    def history(self, limit: int = 50) -> List[dict[str, object]]:
+        items = list(self._sessions.items())[-limit:]
+        summaries: List[dict[str, object]] = []
+        for session_id, updated_at in reversed(items):
+            events = self._store.get(session_id, [])
+            summaries.append(
+                {
+                    "session_id": session_id,
+                    "event_count": len(events),
+                    "last_occurred_at": events[-1].occurred_at if events else updated_at,
+                }
+            )
+        return summaries
+
+
+class SQLiteTraceStore(TraceStore):
+    """SQLite-backed persistent trace store."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = Path(db_path)
+        if self._db_path.parent != Path(""):
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = Lock()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path), detect_types=sqlite3.PARSE_DECLTYPES)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trace_sessions (
+                    session_id TEXT PRIMARY KEY,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trace_events (
+                    session_id TEXT NOT NULL,
+                    event_idx INTEGER NOT NULL,
+                    event_type TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL,
+                    correlation_id TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    PRIMARY KEY (session_id, event_idx)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_trace_events_session ON trace_events(session_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_trace_events_occurred ON trace_events(occurred_at DESC)"
+            )
+            conn.commit()
+
+    def get(self, session_id: str) -> List[TraceEvent] | None:
+        with self._connect() as conn:
+            session_exists = conn.execute(
+                "SELECT 1 FROM trace_sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT event_type, occurred_at, correlation_id, payload_json
+                FROM trace_events
+                WHERE session_id = ?
+                ORDER BY event_idx ASC
+                """,
+                (session_id,),
+            ).fetchall()
+        if not rows:
+            return [] if session_exists else None
+        return [
+            TraceEvent(
+                event_type=row["event_type"],
+                occurred_at=datetime.fromisoformat(row["occurred_at"]),
+                correlation_id=row["correlation_id"],
+                payload=json.loads(row["payload_json"]),
+            )
+            for row in rows
+        ]
+
+    def save(self, session_id: str, events: List[TraceEvent]) -> None:
+        settings = get_api_settings()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT OR REPLACE INTO trace_sessions(session_id, updated_at) VALUES (?, ?)",
+                    (session_id, (events[-1].occurred_at.isoformat() if events else datetime.utcnow().isoformat())),
+                )
+                conn.execute("DELETE FROM trace_events WHERE session_id = ?", (session_id,))
+                conn.executemany(
+                    """
+                    INSERT INTO trace_events (
+                        session_id, event_idx, event_type, occurred_at, correlation_id, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        (
+                            session_id,
+                            idx,
+                            event.event_type,
+                            event.occurred_at.isoformat(),
+                            event.correlation_id,
+                            json.dumps(dict(event.payload), ensure_ascii=False, sort_keys=True),
+                        )
+                        for idx, event in enumerate(events)
+                    ],
+                )
+                self._evict_if_needed(conn, settings.max_trace_sessions)
+                conn.commit()
+
+    def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
+        if max_sessions <= 0:
+            return
+        rows = conn.execute(
+            """
+            SELECT session_id
+            FROM trace_sessions
+            ORDER BY updated_at DESC
+            """
+        ).fetchall()
+        stale_session_ids = [row["session_id"] for row in rows[max_sessions:]]
+        if stale_session_ids:
+            conn.executemany(
+                "DELETE FROM trace_events WHERE session_id = ?",
+                [(sid,) for sid in stale_session_ids],
+            )
+            conn.executemany(
+                "DELETE FROM trace_sessions WHERE session_id = ?",
+                [(sid,) for sid in stale_session_ids],
+            )
+
+    def history(self, limit: int = 50) -> List[dict[str, object]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT s.session_id AS session_id,
+                       COUNT(e.event_idx) AS event_count,
+                       COALESCE(MAX(e.occurred_at), s.updated_at) AS last_occurred_at
+                FROM trace_sessions s
+                LEFT JOIN trace_events e ON e.session_id = s.session_id
+                GROUP BY s.session_id, s.updated_at
+                ORDER BY s.updated_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "session_id": row["session_id"],
+                "event_count": int(row["event_count"]),
+                "last_occurred_at": datetime.fromisoformat(row["last_occurred_at"]),
+            }
+            for row in rows
+        ]
+
+
+_trace_store_singleton: TraceStore | None = None
+
+
+def _build_store() -> TraceStore:
+    settings = get_api_settings()
+    backend = settings.trace_store_backend.strip().lower()
+    if backend == "memory":
+        return InMemoryTraceStore()
+    return SQLiteTraceStore(settings.trace_db_path)
+
+
+def get_trace_store() -> TraceStore:
+    """FastAPI dependency returning the configured trace store."""
+    global _trace_store_singleton
+    if _trace_store_singleton is None:
+        _trace_store_singleton = _build_store()
+    return _trace_store_singleton
+
+
+def reset_trace_store() -> None:
+    """Reset module-level trace store singleton (used in tests)."""
+    global _trace_store_singleton
+    _trace_store_singleton = None
+
+
+
+class _LegacyStoreCompat:
+    """Compatibility shim for tests importing module-level _store."""
+
+    def clear(self) -> None:
+        store = get_trace_store()
+        if isinstance(store, InMemoryTraceStore):
+            store.clear()
+        reset_trace_store()
+
+
+_store = _LegacyStoreCompat()
 
 def save_trace(session_id: str, events: List[TraceEvent]) -> None:
-    """Persist trace events for a session, evicting oldest when full."""
-    settings = get_api_settings()
-    if session_id in _store:
-        del _store[session_id]
-    _store[session_id] = events
-    # LRU eviction
-    while len(_store) > settings.max_trace_sessions:
-        _store.popitem(last=False)
+    """Persist trace events for a session via configured store backend."""
+    get_trace_store().save(session_id, events)

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -23,7 +23,7 @@ from fastapi.testclient import TestClient
 
 from po_core.app.rest.config import APISettings
 from po_core.app.rest.server import create_app
-from po_core.app.rest.store import _store
+from po_core.app.rest.store import get_trace_store, reset_trace_store
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -32,38 +32,42 @@ from po_core.app.rest.store import _store
 
 @pytest.fixture(autouse=True)
 def clear_trace_store():
-    """Clear the in-memory trace store before each test."""
-    _store.clear()
+    """Reset the trace store singleton before each test."""
+    reset_trace_store()
     yield
-    _store.clear()
+    reset_trace_store()
 
 
 @pytest.fixture()
-def client_no_auth():
+def client_no_auth(tmp_path):
     """TestClient with auth disabled (dev mode)."""
 
-    def _override_settings() -> APISettings:
-        return APISettings(skip_auth=True, api_key="")
+    app = create_app(
+        APISettings(
+            skip_auth=True,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+    from po_core.app.rest import auth
 
-    app = create_app()
-    from po_core.app.rest import auth, config
-
-    app.dependency_overrides[config.get_api_settings] = _override_settings
     app.dependency_overrides[auth.require_api_key] = lambda: None
     return TestClient(app, raise_server_exceptions=True)
 
 
 @pytest.fixture()
-def client_with_auth():
+def client_with_auth(tmp_path):
     """TestClient with API key authentication enabled."""
 
-    def _override_settings() -> APISettings:
-        return APISettings(skip_auth=False, api_key="test-secret-key")
-
-    from po_core.app.rest import config
-
-    app = create_app()
-    app.dependency_overrides[config.get_api_settings] = _override_settings
+    app = create_app(
+        APISettings(
+            skip_auth=False,
+            api_key="test-secret-key",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
     return TestClient(app, raise_server_exceptions=True)
 
 
@@ -236,8 +240,8 @@ def test_reason_saves_trace(client_no_auth):
             json={"input": "What is beauty?", "session_id": "trace-test-session"},
         )
     assert resp.status_code == 200
-    # Trace store should have this session
-    assert "trace-test-session" in _store
+    stored = get_trace_store().get("trace-test-session")
+    assert stored is not None
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +274,76 @@ def test_trace_found_after_reason(client_no_auth):
     assert body["session_id"] == session_id
     assert "event_count" in body
     assert "events" in body
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_trace_history_lists_sessions(client_no_auth):
+    """Trace history endpoint returns persisted sessions in recency order."""
+    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT):
+        client_no_auth.post(
+            "/v1/reason",
+            json={"input": "First", "session_id": "history-1"},
+        )
+        client_no_auth.post(
+            "/v1/reason",
+            json={"input": "Second", "session_id": "history-2"},
+        )
+
+    resp = client_no_auth.get("/v1/trace/history?limit=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] >= 2
+    assert [item["session_id"] for item in body["items"][:2]] == ["history-2", "history-1"]
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_trace_persists_across_store_reinitialization(tmp_path):
+    """SQLite trace store survives singleton reset (simulated restart)."""
+    db_path = tmp_path / "trace_store.sqlite3"
+
+    app = create_app(
+        APISettings(
+            skip_auth=True,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(db_path),
+        )
+    )
+    from po_core.app.rest import auth
+
+    app.dependency_overrides[auth.require_api_key] = lambda: None
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT):
+            reason_resp = client.post(
+                "/v1/reason",
+                json={"input": "Persist me", "session_id": "restart-session"},
+            )
+        assert reason_resp.status_code == 200
+
+    reset_trace_store()
+
+    app2 = create_app(
+        APISettings(
+            skip_auth=True,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(db_path),
+        )
+    )
+    app2.dependency_overrides[auth.require_api_key] = lambda: None
+
+    with TestClient(app2, raise_server_exceptions=True) as client2:
+        trace_resp = client2.get("/v1/trace/restart-session")
+        assert trace_resp.status_code == 200
+        body = trace_resp.json()
+        assert body["session_id"] == "restart-session"
+        assert body["event_count"] >= 0
+        hist_resp = client2.get("/v1/trace/history?limit=10")
+        assert hist_resp.status_code == 200
+        assert any(i["session_id"] == "restart-session" for i in hist_resp.json()["items"])
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation
- Provide durable audit trails so traces survive process reinitialization and support session history queries for Phase 17 (3‑A 永続化). 

### Description
- Introduce a `TraceStore` abstraction and two backends in `src/po_core/app/rest/store.py`: `SQLiteTraceStore` (default) and `InMemoryTraceStore`, plus a factory `get_trace_store()` and `reset_trace_store()` for tests. 
- Persist traces into `trace_sessions` + `trace_events` tables and implement LRU-style eviction in SQL; expose `save_trace()` to delegate to the configured store. 
- Add API settings `trace_store_backend` and `trace_db_path` to `src/po_core/app/rest/config.py` and new Pydantic models `TraceHistoryItem` / `TraceHistoryResponse` in `src/po_core/app/rest/models.py`. 
- Add `GET /v1/trace/history` in `src/po_core/app/rest/routers/trace.py` and switch existing `GET /v1/trace/{session_id}` to use the `TraceStore` dependency. 
- Update tests and fixtures in `tests/unit/test_rest_api.py` to use temporary SQLite DBs, add history and persistence tests, and include a small compatibility shim for legacy `_store.clear()` usage. 

### Testing
- Ran `pytest -q tests/unit/test_rest_api.py` and all tests in that file passed (`27 passed`).
- Ran targeted checks `pytest -q tests/benchmarks/test_rest_perf.py::test_bench_rest_overhead tests/unit/test_rest_api.py` which passed.
- Ran full test suite (`pytest -q`); changes are functional, but one unrelated benchmark test `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` failed due to environment/performance thresholds and is not caused by persistence changes.  All functional/unit tests are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a587c387008328aa00dc570a308326)