### PR TITLE
Phase 24: add philosopher plugin spec, contributing guide, template and contract tests

### DIFF
--- a/docs/CONTRIBUTING_PHILOSOPHER.md
+++ b/docs/CONTRIBUTING_PHILOSOPHER.md
@@ -1,0 +1,51 @@
+# Contributing a Philosopher Plugin
+
+このガイドは、外部/内部の新規哲学者を最短で追加する手順を示す。
+
+## 1. Start from template
+`src/po_core/philosophers/template.py` をコピーして新しいモジュールを作る。
+
+例:
+- `src/po_core/philosophers/my_philosopher.py`
+- クラス名: `MyPhilosopher`
+
+## 2. Implement minimal contract
+最低限、以下を実装する。
+- `__init__`（`name`, `description`, `tradition`, `key_concepts`）
+- `reason(prompt, context=None)`
+
+返り値は少なくとも:
+- `reasoning` (str)
+- `perspective` (str)
+- `metadata.philosopher`
+
+## 3. Register philosopher
+### Option A: Runtime injection
+`PhilosopherSpec` を作って `PhilosopherRegistry(specs=...)` に渡す。
+
+### Option B: Repository manifest
+`src/po_core/philosophers/manifest.py` の `SPECS` に追記する。
+
+## 4. Add tests (required)
+最低限この2種類を推奨:
+- 契約テスト: `reason()` の必須キー
+- パイプラインテスト: `propose()` が `Proposal` を返す
+
+このリポジトリでは `tests/test_philosopher_plugin_template.py` が
+テンプレ契約の実例になっている。
+
+## 5. Determinism requirements
+- `datetime.now()` / ランダム値を `reason()` 出力に直接埋め込まない
+- 同一入力で同一出力を返す
+
+## 6. Quick self-check commands
+```bash
+pytest -q tests/test_philosopher_plugin_template.py
+pytest -q
+```
+
+## 7. PR checklist
+- [ ] 仕様: `docs/philosopher_plugin_spec.md` に整合
+- [ ] テスト追加/更新済み
+- [ ] `pytest -q` 全通
+- [ ] output schema を破壊していない

--- a/docs/philosopher_plugin_spec.md
+++ b/docs/philosopher_plugin_spec.md
@@ -1,0 +1,58 @@
+# Philosopher Plugin Specification (Phase 24)
+
+## Goal
+Po_core に外部哲学者を追加するための **最小契約** を固定する。
+この仕様は `src/po_core/philosophers/template.py` と整合する。
+
+## Compatibility Targets
+- Python: 3.10+
+- Po_core: current `main` branch API
+- Interface level:
+  - Legacy `reason(prompt, context=None) -> dict`
+  - Native `PhilosopherProtocol.propose(...) -> List[Proposal]`（`Philosopher` 基底クラス経由）
+
+## Required Contract
+プラグイン哲学者は `po_core.philosophers.base.Philosopher` を継承し、次を満たす。
+
+1. `__init__` で `name`, `description` を設定する
+2. `tradition`（str）と `key_concepts`（list[str]）を設定する
+3. `reason(prompt, context=None)` を実装し、最低限以下を返す
+   - `reasoning: str`
+   - `perspective: str`
+4. `reason()` の返り値は **決定的** である（同一入力で同一出力）
+5. `metadata` は dict を返し、`metadata["philosopher"]` を含める
+
+> `tension`, `rationale`, `confidence`, `action_type`, `citations` は任意だが、
+> `normalize_response()` により規約へ正規化される。
+
+## Runtime Guarantees (via base.Philosopher)
+`Philosopher` 継承実装は `propose()` 経由で次が保証される。
+- `Proposal.confidence` は `[0.0, 1.0]`
+- `Proposal.action_type` は許可済み集合へ正規化
+- `Proposal.extra["_po_core"]["rationale"]` が存在
+- `Proposal.extra["_po_core"]["citations"]` が存在
+
+## Registration Paths
+外部哲学者を有効化する方法は2通り。
+
+### A. Runtime injection（推奨、fork不要）
+`PhilosopherRegistry(specs=[...])` に `PhilosopherSpec` を注入する。
+- `module`: import 可能なモジュールパス
+- `symbol`: クラス名（またはファクトリ）
+- `philosopher_id`: 一意ID
+
+### B. Manifest edit（repo内追加）
+`src/po_core/philosophers/manifest.py` の `SPECS` に追加する。
+この方法はリポジトリ変更を伴う。
+
+## Non-goals in this phase
+- エントリポイント自動発見（setuptools entry points 等）は未導入
+- sandboxed plugin execution は未導入
+- schema (`docs/spec/output_schema_v1.json`) の変更は行わない
+
+## Validation Checklist for Plugin Authors
+- [ ] `reason()` が dict を返す
+- [ ] `reasoning` と `perspective` を返す
+- [ ] `metadata.philosopher` が入る
+- [ ] 同一入力で出力が一致する
+- [ ] `propose()` が `List[Proposal]` を返す（基底実装利用可）

--- a/src/po_core/philosophers/template.py
+++ b/src/po_core/philosophers/template.py
@@ -1,0 +1,47 @@
+"""Template philosopher plugin for external contributors.
+
+Copy this file to bootstrap a new philosopher module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from po_core.philosophers.base import Philosopher
+
+
+class TemplatePhilosopher(Philosopher):
+    """Minimal, deterministic philosopher implementation template."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="Template Philosopher",
+            description="Reference implementation for Po_core philosopher plugins.",
+        )
+        self.tradition = "Template"
+        self.key_concepts = ["contract", "determinism", "traceability"]
+
+    def reason(
+        self, prompt: str, context: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Return deterministic reasoning with required contract keys."""
+        normalized_prompt = " ".join(prompt.strip().split())
+
+        return {
+            "reasoning": (
+                "Clarify the decision objective, enumerate assumptions, "
+                f"and test one reversible action first. Prompt={normalized_prompt}"
+            ),
+            "perspective": "Plugin template / contract-first reasoning",
+            "metadata": {
+                "philosopher": self.name,
+                "source": "template",
+                "uses_context": bool(context),
+            },
+            "rationale": "Contract-first structure improves auditability.",
+            "confidence": 0.6,
+            "citations": ["Po_core philosopher plugin spec"],
+        }
+
+
+__all__ = ["TemplatePhilosopher"]

--- a/tests/test_philosopher_plugin_template.py
+++ b/tests/test_philosopher_plugin_template.py
@@ -1,0 +1,33 @@
+from po_core.domain.context import Context
+from po_core.domain.intent import Intent
+from po_core.domain.keys import CITATIONS, PO_CORE, RATIONALE
+from po_core.domain.memory_snapshot import MemorySnapshot
+from po_core.domain.proposal import Proposal
+from po_core.domain.tensor_snapshot import TensorSnapshot
+from po_core.philosophers.template import TemplatePhilosopher
+
+
+def test_template_reason_contract_minimum_keys() -> None:
+    ph = TemplatePhilosopher()
+
+    out = ph.reason("  test prompt  ")
+
+    assert "reasoning" in out
+    assert "perspective" in out
+    assert "metadata" in out
+    assert out["metadata"]["philosopher"] == "Template Philosopher"
+
+
+def test_template_propose_contract_po_core_fields() -> None:
+    ph = TemplatePhilosopher()
+
+    ctx = Context.now(request_id="plugin-template-001", user_input="What should we do?")
+    proposals = ph.propose(ctx, Intent.neutral(), TensorSnapshot.empty(), MemorySnapshot.empty())
+
+    assert proposals
+    proposal = proposals[0]
+    assert isinstance(proposal, Proposal)
+    assert 0.0 <= proposal.confidence <= 1.0
+    assert PO_CORE in proposal.extra
+    assert RATIONALE in proposal.extra[PO_CORE]
+    assert CITATIONS in proposal.extra[PO_CORE]


### PR DESCRIPTION
### Motivation
- Provide a clear, minimal extension path so external contributors can add philosopher plugins with deterministic, auditable outputs.  
- Capture the required contract (legacy `reason()` + native `PhilosopherProtocol`) and registration options to avoid ad-hoc additions that break determinism or tracing.  
- Ship a reference implementation and tests to make the workflow discoverable and verifiable by CI.

### Description
- Add `docs/philosopher_plugin_spec.md` describing the plugin contract, determinism requirement, runtime guarantees via `base.Philosopher`, and registration paths (`PhilosopherRegistry` injection or manifest edit).  
- Add `docs/CONTRIBUTING_PHILOSOPHER.md` with a step-by-step contributor guide from template to registration and required self-checks.  
- Add `src/po_core/philosophers/template.py` implementing `TemplatePhilosopher`, a minimal deterministic `Philosopher` subclass that returns the required keys and metadata.  
- Add `tests/test_philosopher_plugin_template.py` with two contract tests: one asserting `reason()` returns `reasoning`, `perspective`, and `metadata.philosopher`; and one asserting `propose()` yields `Proposal` objects with `_po_core` provenance (`rationale` and `citations`).  
- No changes to output schema or golden files; the template is not auto-registered in the manifest to avoid changing runtime behavior.

### Testing
- Ran `pytest -q tests/test_philosopher_plugin_template.py` and observed `2 passed`.  
- Ran full `pytest -q`: `3482 passed, 1 failed, 134 skipped` (the single failure is a pre-existing benchmark assertion in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` and is unrelated to the docs/template additions).  
- The new template contract tests were included in the full test run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a588cfc1008328ba005d4ee3268a57)