### PR TITLE
docs: harden external reproducibility and onboarding for Phase 25

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,11 @@
 ## Validation
 - [ ] `pytest -q` を実行し全通
 
+## Determinism & Compatibility Checklist
+- [ ] 凍結golden（`case_001` / `case_009`）を変更していない
+- [ ] schema互換性を確認した（`tests/test_input_schema.py` / `tests/test_output_schema.py`）
+- [ ] golden契約を確認した（`tests/test_golden_e2e.py`）
+- [ ] 互換性に影響がある場合、`docs/operations/migration_guide_v1.md` を更新した
+
 ## Notes
 - 追加の注意事項・制約:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,20 @@ Po_core welcomes contributions across multiple dimensions:
 
 ## Getting Started
 
+### ✅ Contributor Onboarding (Fast Track)
+
+Phase 25 では外部再現性を重視するため、最初に以下を実行してください。
+
+```bash
+python scripts/phase25_reproduce.py --profile external
+```
+
+加えて、次の運用ドキュメントを先に読むことを推奨します。
+
+- `docs/operations/compatibility_policy_v1.md`
+- `docs/operations/migration_guide_v1.md`
+- `docs/operations/reproducibility_runbook.md`
+
 ### Prerequisites
 
 **Required:**

--- a/docs/operations/compatibility_policy_v1.md
+++ b/docs/operations/compatibility_policy_v1.md
@@ -1,0 +1,68 @@
+# Compatibility Policy v1
+
+Po_core を外部参照実装として運用するための互換性ポリシー。
+
+## 1. Scope
+
+このポリシーは以下に適用する。
+
+- `docs/spec/input_schema_v1.json`
+- `docs/spec/output_schema_v1.json`
+- `scenarios/*_expected.json`（golden）
+- `src/pocore/**` の deterministic contract
+
+## 2. Versioning Rules
+
+### 2.1 Semantic intent
+
+- **Patch** (`x.y.Z`): バグ修正のみ。既存スキーマ互換を維持。
+- **Minor** (`x.Y.z`): 後方互換な追加（optional field 追加、新ruleset等）。
+- **Major** (`X.y.z`): 後方互換を破る変更（必ず ADR + migration guide 更新）。
+
+### 2.2 Schema compatibility
+
+- `output_schema_v1` の既存必須キー削除は禁止。
+- enum の既存値削除/変更は禁止。
+- 追加は原則 optional から開始する。
+- 破壊的変更が必要な場合は `*_v2` を新設し、v1 を deprecation 期間中サポートする。
+
+## 3. Golden Contract
+
+- `scenarios/case_001_expected.json`
+- `scenarios/case_009_expected.json`
+
+上記 2 ファイルは凍結対象。更新は「凍結解除ADR」なしでは不可。
+
+既存golden更新時は必須:
+
+1. 仕様変更根拠（ADR/SRS）
+2. 変更理由（何が、なぜ妥当か）
+3. `pytest -q` 全通
+
+## 4. Determinism Contract
+
+同一入力 + 同一 `seed` + 同一 `now` + 同一version で JSON 完全一致を保証する。
+
+禁止:
+
+- wall-clock 直接参照
+- UUID / random の直接出力
+- 実行環境依存値の出力混入
+
+## 5. Deprecation Policy
+
+- 非推奨化は最低 1 minor cycle 告知する。
+- 告知先:
+  - `CHANGELOG.md`
+  - `docs/operations/migration_guide_v1.md`
+  - PR本文
+- deprecation warning は「代替手段」と「撤去時期」を含める。
+
+## 6. Required Validation
+
+互換性を触るPRでは最低以下を実行する。
+
+- `pytest -q tests/test_input_schema.py`
+- `pytest -q tests/test_output_schema.py`
+- `pytest -q tests/test_golden_e2e.py`
+- `pytest -q`

--- a/docs/operations/migration_guide_v1.md
+++ b/docs/operations/migration_guide_v1.md
@@ -1,0 +1,52 @@
+# Migration Guide v1 (for External Integrators)
+
+本ガイドは、Po_core を外部利用するチーム向けの移行手順。
+
+## 1. Who should read this
+
+- `output_schema_v1.json` へ依存する downstream 実装
+- golden 比較で回帰検知している CI
+- `run_case_file()` をバッチ実行している運用
+
+## 2. Safe Upgrade Checklist
+
+1. 新バージョンの `CHANGELOG.md` を読む
+2. `docs/operations/compatibility_policy_v1.md` の breaking 判定を確認
+3. staging で以下を固定値で実行
+   - `seed=0`
+   - `deterministic=True`
+   - `now="2026-02-22T00:00:00Z"`
+4. 既存goldenとの差分をレビュー
+5. 本番へ段階投入
+
+## 3. If output adds optional fields
+
+- downstream の JSON parser は unknown key を許容する
+- strict validation の場合は `additionalProperties` 方針を確認
+- 既存必須キーの意味変更がないことを確認
+
+## 4. If arbitration behavior changes
+
+以下を監視する。
+
+- `recommendation.arbitration_code`
+- `trace[*].compose_output.metrics.arbitration_code`
+- ethics `rules_fired`
+
+差分が出た場合は、仕様変更（ADR）に紐づくことを確認する。
+
+## 5. Rollback Plan
+
+- 直前安定タグを保持する（例: `v0.2.0b3`）
+- CIで `pytest -q tests/test_golden_e2e.py` を gate にする
+- 互換性問題時は直前タグへロールバックし、ADRに再計画を記載
+
+## 6. One-command verification
+
+以下 1 コマンドで再現チェックを実行可能。
+
+```bash
+python scripts/phase25_reproduce.py --profile external
+```
+
+詳細は `docs/operations/reproducibility_runbook.md` を参照。

--- a/docs/operations/reproducibility_runbook.md
+++ b/docs/operations/reproducibility_runbook.md
@@ -1,0 +1,49 @@
+# Reproducibility Runbook (Bench / Paper / Trace)
+
+Phase 25 向けに、再現手順を 1 コマンド実行にまとめた運用手順。
+
+## Quick start
+
+```bash
+python scripts/phase25_reproduce.py --profile external
+```
+
+## Profiles
+
+- `external`: 外部利用者向け最小検証（schema + golden + traceability）
+- `full`: 開発者向け包括検証（external + full pytest）
+
+## What each profile runs
+
+### external
+
+1. `pytest -q tests/test_input_schema.py`
+2. `pytest -q tests/test_output_schema.py`
+3. `pytest -q tests/test_golden_e2e.py`
+4. `pytest -q tests/test_traceability.py`
+
+### full
+
+- `external` の全項目
+- `pytest -q`
+
+## Optional bench/paper commands
+
+必要に応じて、以下を別途実行する。
+
+- ベンチ: `pytest -q tests/benchmarks/test_pipeline_perf.py::test_bench_smoke_critical -s`
+- 実験パイプライン smoke: `pytest -q tests/integration/test_experiment_pipeline.py`
+
+## Dry run (command preview)
+
+```bash
+python scripts/phase25_reproduce.py --profile full --dry-run
+```
+
+## CI embedding example
+
+```bash
+python scripts/phase25_reproduce.py --profile full
+```
+
+失敗時は最初の failing command を表示し、即時終了する。

--- a/scripts/phase25_reproduce.py
+++ b/scripts/phase25_reproduce.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Phase 25 reproducibility runner.
+
+One-command entry point for external verification / full validation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import List
+
+
+EXTERNAL_COMMANDS: List[List[str]] = [
+    ["pytest", "-q", "tests/test_input_schema.py"],
+    ["pytest", "-q", "tests/test_output_schema.py"],
+    ["pytest", "-q", "tests/test_golden_e2e.py"],
+    ["pytest", "-q", "tests/test_traceability.py"],
+]
+
+
+def build_commands(profile: str) -> List[List[str]]:
+    if profile == "external":
+        return EXTERNAL_COMMANDS
+    if profile == "full":
+        return EXTERNAL_COMMANDS + [["pytest", "-q"]]
+    raise ValueError(f"unsupported profile: {profile}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run reproducibility checks for Phase 25")
+    parser.add_argument(
+        "--profile",
+        choices=["external", "full"],
+        default="external",
+        help="Command set to run (default: external)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them",
+    )
+    args = parser.parse_args()
+
+    commands = build_commands(args.profile)
+    for command in commands:
+        printable = " ".join(command)
+        print(f"[phase25] {printable}")
+        if args.dry_run:
+            continue
+        completed = subprocess.run(command, check=False)
+        if completed.returncode != 0:
+            print(
+                f"[phase25] failed: {printable} (exit={completed.returncode})",
+                file=sys.stderr,
+            )
+            return completed.returncode
+
+    print(f"[phase25] profile={args.profile} completed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_phase25_reproduce.py
+++ b/tests/test_phase25_reproduce.py
@@ -1,0 +1,25 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "phase25_reproduce.py"
+SPEC = spec_from_file_location("phase25_reproduce", MODULE_PATH)
+MODULE = module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_build_commands_external():
+    commands = MODULE.build_commands("external")
+    assert commands == [
+        ["pytest", "-q", "tests/test_input_schema.py"],
+        ["pytest", "-q", "tests/test_output_schema.py"],
+        ["pytest", "-q", "tests/test_golden_e2e.py"],
+        ["pytest", "-q", "tests/test_traceability.py"],
+    ]
+
+
+def test_build_commands_full_contains_external_plus_full_pytest():
+    commands = MODULE.build_commands("full")
+    assert commands[:-1] == MODULE.build_commands("external")
+    assert commands[-1] == ["pytest", "-q"]


### PR DESCRIPTION
### Motivation
- Phase 25 の目標である「外部が再現・検証・拡張できる状態」を最小差分で整備して運用コントラクトを明文化するため。 
- downstream が `output_schema_v1` や golden に依存しているため、互換性ルールとワンコマンド再現手順を提供する必要があった。 
- contributor onboarding を整備して外部参加者が迅速に検証ルートを辿れるようにするため。 

### Description
- 互換性ポリシーを新規追加しスキーマ/決定性/凍結golden/非推奨ルールを定義した (`docs/operations/compatibility_policy_v1.md`).
- 移行ガイドを追加し固定パラメータでの検証・ロールバック・監視ポイントを整理した (`docs/operations/migration_guide_v1.md`).
- 再現を1コマンド化するランナーを追加し、`--profile external|full` と `--dry-run` を実装した (`scripts/phase25_reproduce.py`) とその Runbook (`docs/operations/reproducibility_runbook.md`).
- contributor 向けの高速導線を `CONTRIBUTING.md` に追記し、PRテンプレートに決定性/互換性チェックを追加した (`.github/pull_request_template.md`).
- 再現スクリプトのコマンド生成を検証するテストを追加した (`tests/test_phase25_reproduce.py`).
- 実装本体（`src/`）や既存 golden（`scenarios/case_001_expected.json` / `case_009_expected.json`）は変更していない。 

### Testing
- `pytest -q tests/test_phase25_reproduce.py` と `tests/test_phase25_reproduce.py` の2テストは両方とも合格しました (`2 passed`).
- `python scripts/phase25_reproduce.py --profile external` を実行し、内部で実行される `pytest -q tests/test_input_schema.py`, `pytest -q tests/test_output_schema.py`, `pytest -q tests/test_golden_e2e.py`, `pytest -q tests/test_traceability.py` の各コマンドはすべて成功しました.
- フルスイートで `pytest -q` を実行したところ大半は成功しましたが、ベンチマークの1件 `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` が環境依存（スケーリングアサーション）で失敗しており、今回のドキュメント/スクリプト追加による変更ではないと判断しました。
- 推奨運用として外部利用者向けはまず `--profile external` を使用することを明記しています.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a588f108dc8328a472a35f0539edb3)