### PR TITLE
docs: add Phase 5-F TestPyPI publish + smoke verification runbook

### DIFF
--- a/docs/operations/reproducibility_runbook.md
+++ b/docs/operations/reproducibility_runbook.md
@@ -47,3 +47,56 @@ python scripts/phase25_reproduce.py --profile full
 ```
 
 失敗時は最初の failing command を表示し、即時終了する。
+
+
+## TestPyPI publish verification (v0.2.0rc1)
+
+Phase 5-F（PyPI公開）の運用手順。`publish.yml` は `workflow_dispatch` で `target=testpypi` を受け取り、TestPyPI 公開ジョブを起動する。
+
+### 1) GitHub Actions で公開実行
+
+```bash
+# GitHub CLI 利用時（推奨）
+gh workflow run publish.yml -f target=testpypi
+
+# 互換運用: environment 入力を使う運用をしている場合
+#（現行 workflow は target 入力）
+gh workflow run publish.yml -f environment=testpypi
+```
+
+実行後に Actions UI で `Publish to TestPyPI` ジョブ成功を確認する。
+
+### 2) TestPyPI から install/import smoke test
+
+```bash
+python -m venv .venv-testpypi
+source .venv-testpypi/bin/activate
+python -m pip install --upgrade pip
+
+# TestPyPI を優先しつつ依存は PyPI を参照
+pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple \
+  po-core-flyingpig==0.2.0rc1
+
+python -c "import po_core; print(po_core.__name__)"
+```
+
+期待値:
+- `pip install` が成功する
+- import コマンドで `po_core` が表示される
+
+### 3) 失敗時の切り分け（PR記載テンプレ）
+
+PR本文に以下3点を必ず残す。
+
+- **原因 (Cause):** どのステップで失敗したか（build / trusted publishing / install / import）
+- **対策 (Fix):** その場で行った修正（workflow入力値、環境設定、依存関係など）
+- **再発防止 (Prevention):** 次回の事前チェック（release tag運用、workflow_dispatch入力、twine check、smoke test自動化）
+
+#### よくある失敗例
+
+- OIDC trusted publishing 未設定（PyPI/TestPyPI 側の project settings mismatch）
+- `workflow_dispatch` 入力名の不一致（`target` と `environment` の取り違え）
+- TestPyPIに同一バージョンが既に存在（`skip_existing` で公開はスキップされる）
+- install時に `--extra-index-url https://pypi.org/simple` を付け忘れ依存解決失敗


### PR DESCRIPTION
### Motivation
- Provide a deterministic, reviewable runbook for publishing `0.2.0rc1` to TestPyPI and verifying package installation/import, and to align operator steps with the existing `publish.yml` workflow inputs.

### Description
- Added a `TestPyPI publish verification (v0.2.0rc1)` section to `docs/operations/reproducibility_runbook.md` that documents the `gh workflow run publish.yml -f target=testpypi` dispatch command (with a compatibility note for `environment=testpypi`), a TestPyPI `pip install`/import smoke test, a failure-triage template (`Cause`/`Fix`/`Prevention`), and common failure patterns; no code, schema, golden, or test files were modified.

### Testing
- Ran `pytest -q` (result: 3523 passed, 2 failed, 134 skipped); the two failures are `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` (benchmark threshold) and `tests/test_release_readiness.py::test_release_version_is_stable_020` (test expects `0.2.0` while `pyproject.toml` is `0.2.0rc1`); attempted `gh` dispatch and TestPyPI `pip install` smoke-test could not complete in this environment due to missing `gh` CLI and outbound proxy/network restrictions, so actual publishing must be executed from a GitHub-authenticated environment or CI runner that can reach TestPyPI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65664e99c8328b6aab7287aa13588)