### PR TITLE
Phase30: arXiv-ready paper structure and reproducible PDF evidence

### DIFF
--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -25,3 +25,15 @@ python scripts/paper/run_comparative_benchmark.py \
 ```
 
 See `docs/paper/benchmarks/README.md` for full reproducibility notes.
+
+
+## arXiv-ready section checklist
+
+`docs/paper/paper.md` maintains the minimum section set required by this roadmap phase:
+
+- Abstract
+- Introduction
+- Method
+- Experiments
+- Limitations
+- References

--- a/docs/paper/paper.md
+++ b/docs/paper/paper.md
@@ -1,20 +1,30 @@
-# Po_core Reproducible Paper Draft
+# Po_core: A Philosophy-Driven AI Deliberation Framework for Ethical Decision Support
 
 ## Abstract
 
-This document is generated through a deterministic local pipeline.
-The pipeline binds experiment outputs and paper rendering in repository-managed scripts.
+Po_core proposes a deterministic, accountable AI deliberation stack that prioritizes ethical reasoning, responsibility attribution, and traceability over unconstrained text generation. This paper package is built reproducibly inside the repository so that claims can be re-checked by rebuilding artifacts from versioned scripts.
+
+## Introduction
+
+Recent criticism frames LLM systems as "stochastic parrots" that cannot justify decisions. Po_core addresses this by enforcing explicit contracts on schema validity, deterministic execution, and trace output. The objective of this paper artifact is to provide an arXiv-ready structure tied directly to executable evidence in the repository.
 
 ## Method
 
-1. Generate experiment snapshot JSON under `docs/paper/experiments/`.
-2. Build a compiled markdown with embedded experiment summary.
-3. Render deterministic PDF.
+1. Generate deterministic experiment snapshots under `docs/paper/experiments/`.
+2. Build comparative benchmark artifacts under `docs/paper/benchmarks/results/`.
+3. Compile `paper.md` with embedded snapshot metadata.
+4. Render a deterministic PDF from the compiled manuscript.
 
-## Results
+## Experiments
 
-Results are embedded from `results_latest.json` at build time.
+Core experiment outputs are versioned under `docs/paper/experiments/` and benchmark summaries under `docs/paper/benchmarks/results/`. The build pipeline appends the latest deterministic snapshot (`scenario_count`, `golden_count`, and scenario digest) into the compiled manuscript to preserve reproducibility.
 
-## Conclusion
+## Limitations
 
-The repository can regenerate experiment output snapshots and an accompanying PDF via fixed commands.
+The current PDF builder intentionally focuses on deterministic single-page rendering to keep infrastructure requirements minimal. Full camera-ready typesetting (multi-page layout, citation styles, figure placement) should be handled in a future release pipeline while preserving deterministic inputs.
+
+## References
+
+1. Po_core repository specs and ADRs (`docs/spec/`, `docs/adr/`).
+2. Acceptance and governance tests (`tests/acceptance/`, `tests/test_traceability.py`).
+3. Deterministic paper pipeline scripts (`scripts/paper/`).

--- a/tests/test_paper_pipeline.py
+++ b/tests/test_paper_pipeline.py
@@ -67,3 +67,17 @@ def test_build_paper_pdf(tmp_path: Path) -> None:
     data = pdf.read_bytes()
     assert data.startswith(b"%PDF-1.4")
     assert b"startxref" in data
+
+
+def test_paper_contains_arxiv_required_sections() -> None:
+    paper = Path("docs/paper/paper.md").read_text(encoding="utf-8")
+    required_headers = [
+        "## Abstract",
+        "## Introduction",
+        "## Method",
+        "## Experiments",
+        "## Limitations",
+        "## References",
+    ]
+    for header in required_headers:
+        assert header in paper


### PR DESCRIPTION
### Motivation
- Provide a minimal, auditable arXiv-ready manuscript layout inside `docs/paper/` so the repository can produce a deterministic PDF that supports the v1.0 roadmap evidence package. 
- Pin the manuscript structure as an executable contract so future changes cannot accidentally remove required scholarly sections while keeping all existing schema/golden contracts untouched.

### Description
- Update `docs/paper/paper.md` to include the required paper sections: `Abstract`, `Introduction`, `Method`, `Experiments`, `Limitations`, and `References`. 
- Add an `arXiv-ready section checklist` to `docs/paper/README.md` to document the Phase30 requirement. 
- Add `test_paper_contains_arxiv_required_sections` to `tests/test_paper_pipeline.py` to lock the section contract as a regression test. 
- No changes were made to output schemas or golden files and no runtime logic was modified.

### Testing
- Ran `pytest -q tests/test_paper_pipeline.py` which passed (3 passed) and verifies snapshot generation, PDF build, and the new section contract. 
- Executed `make paper-build` which runs `scripts/paper/generate_experiment_snapshot.py`, `scripts/paper/run_comparative_benchmark.py`, and `scripts/paper/build_paper_pdf.py` and succeeded. 
- Ran the full test suite with `pytest -q` to check baseline impact and observed unrelated baseline failures (2 failures, 3524 passed, 134 skipped): `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` and `tests/test_release_readiness.py::test_release_version_is_stable_020`, both of which are outside this PR's scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a656c88c5c8328ab1a68a123bd7527)