### PR TITLE
Phase30: make paper-build produce arXiv draft PDF at docs/paper/po_core_paper.pdf

### DIFF
--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -15,6 +15,10 @@ make paper-build
 
 This command runs the experiment snapshot generation and then builds the PDF from the paper source.
 
+Generated PDF output path:
+
+- `docs/paper/po_core_paper.pdf`
+
 ## Comparative benchmark (Phase 23 / 4-B)
 
 ```bash

--- a/docs/paper/po_core_paper.pdf
+++ b/docs/paper/po_core_paper.pdf
@@ -1,0 +1,93 @@
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Count 1 /Kids [3 0 R] >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 1558 >> stream
+BT
+/F1 11 Tf
+50 780 Td
+14 TL
+(# Po_core: A Philosophy-Driven AI Deliberation Framework for Ethical Decision Support) Tj
+T*
+( ) Tj
+T*
+(## Abstract) Tj
+T*
+( ) Tj
+T*
+(Po_core proposes a deterministic, accountable AI deliberation stack that prioritizes ethical reasoni) Tj
+T*
+( ) Tj
+T*
+(## Introduction) Tj
+T*
+( ) Tj
+T*
+(Recent criticism frames LLM systems as "stochastic parrots" that cannot justify decisions. Po_core a) Tj
+T*
+( ) Tj
+T*
+(## Method) Tj
+T*
+( ) Tj
+T*
+(1. Generate deterministic experiment snapshots under `docs/paper/experiments/`.) Tj
+T*
+(2. Build comparative benchmark artifacts under `docs/paper/benchmarks/results/`.) Tj
+T*
+(3. Compile `paper.md` with embedded snapshot metadata.) Tj
+T*
+(4. Render a deterministic PDF from the compiled manuscript.) Tj
+T*
+( ) Tj
+T*
+(## Experiments) Tj
+T*
+( ) Tj
+T*
+(Core experiment outputs are versioned under `docs/paper/experiments/` and benchmark summaries under ) Tj
+T*
+( ) Tj
+T*
+(## Limitations) Tj
+T*
+( ) Tj
+T*
+(The current PDF builder intentionally focuses on deterministic single-page rendering to keep infrast) Tj
+T*
+( ) Tj
+T*
+(## References) Tj
+T*
+( ) Tj
+T*
+(1. Po_core repository specs and ADRs \(`docs/spec/`, `docs/adr/`\).) Tj
+T*
+(2. Acceptance and governance tests \(`tests/acceptance/`, `tests/test_traceability.py`\).) Tj
+T*
+(3. Deterministic paper pipeline scripts \(`scripts/paper/`\).) Tj
+T*
+( ) Tj
+T*
+(## Embedded Experiment Snapshot) Tj
+T*
+(- scenario_count: 15) Tj
+T*
+(- golden_count: 11) Tj
+T*
+(- scenario_digest: 47da511ef65b1eb5b6b92703fbf4eda0c59326871da2dff57cf26b48be1ca8fe) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+1921
+%%EOF

--- a/scripts/paper/build_paper_pdf.py
+++ b/scripts/paper/build_paper_pdf.py
@@ -76,7 +76,7 @@ def main() -> None:
     parser.add_argument("--paper", default="docs/paper/paper.md")
     parser.add_argument("--experiments", default="docs/paper/experiments/results_latest.json")
     parser.add_argument("--compiled", default="docs/paper/build/paper_compiled.md")
-    parser.add_argument("--pdf", default="docs/paper/build/paper.pdf")
+    parser.add_argument("--pdf", default="docs/paper/po_core_paper.pdf")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()


### PR DESCRIPTION
### Motivation
- Align the deterministic paper pipeline with the v1.0.0 roadmap requirement that `paper.md` be the canonical source and `make paper-build` produce an arXiv-ready PDF at a fixed, documented path.

### Description
- Change the default PDF output path in `scripts/paper/build_paper_pdf.py` to `docs/paper/po_core_paper.pdf` so the build pipeline writes the expected artifact by default.
- Document the canonical generated PDF path in `docs/paper/README.md` and include a deterministic single-page PDF build that embeds the latest experiment snapshot into the compiled manuscript.

### Testing
- Ran `make paper-build` and the build completed and produced `docs/paper/po_core_paper.pdf` successfully.
- Verified the output file with `test -f docs/paper/po_core_paper.pdf` which returned success.
- Ran `pytest -q tests/test_paper_pipeline.py` which passed, and ran `pytest -q` which reported one existing benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` while the rest of the suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69ad0a1f883288f0176b0179fb6e5)