### PR TITLE
Add deterministic paper experiment & benchmark artifacts with seed and digest (Phase31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,8 @@ visualization_outputs*/
 
 # Temporary experiment results (keep important ones in experiments/results/)
 # results/
+# Paper evidence artifacts (Phase31)
+!docs/paper/experiments/results_latest.json
+!docs/paper/benchmarks/results/comparative_results.json
+!docs/paper/benchmarks/results/comparative_table.csv
+

--- a/docs/paper/benchmarks/results/comparative_results.json
+++ b/docs/paper/benchmarks/results/comparative_results.json
@@ -1,0 +1,73 @@
+{
+  "meta": {
+    "benchmark": "phase_23_comparative_v1",
+    "created_at": "2026-02-22T00:00:00Z",
+    "deterministic": true,
+    "seed": 0,
+    "axes": [
+      "diversity",
+      "explainability",
+      "safety",
+      "emergence"
+    ],
+    "po_core_philosopher_count": 48,
+    "results_digest": "a20f803a029153e840cbccde428b54ac0488cb565edf897c664710a17c479843"
+  },
+  "results": [
+    {
+      "system_id": "po_core",
+      "label": "Po_core",
+      "axis_scores": {
+        "diversity": 100.0,
+        "explainability": 91.0,
+        "safety": 89.0,
+        "emergence": 87.0
+      },
+      "overall": 91.75
+    },
+    {
+      "system_id": "moe_baseline",
+      "label": "Mixture-of-Experts baseline",
+      "axis_scores": {
+        "diversity": 58.0,
+        "explainability": 47.0,
+        "safety": 61.0,
+        "emergence": 73.0
+      },
+      "overall": 59.75
+    },
+    {
+      "system_id": "rlhf_baseline",
+      "label": "RLHF baseline",
+      "axis_scores": {
+        "diversity": 35.0,
+        "explainability": 51.0,
+        "safety": 72.0,
+        "emergence": 46.0
+      },
+      "overall": 51.0
+    },
+    {
+      "system_id": "cot_baseline",
+      "label": "Chain-of-Thought baseline",
+      "axis_scores": {
+        "diversity": 36.0,
+        "explainability": 63.0,
+        "safety": 54.0,
+        "emergence": 44.0
+      },
+      "overall": 49.25
+    },
+    {
+      "system_id": "single_llm",
+      "label": "Single LLM (GPT/Claude)",
+      "axis_scores": {
+        "diversity": 31.0,
+        "explainability": 42.0,
+        "safety": 57.0,
+        "emergence": 48.0
+      },
+      "overall": 44.5
+    }
+  ]
+}

--- a/docs/paper/benchmarks/results/comparative_table.csv
+++ b/docs/paper/benchmarks/results/comparative_table.csv
@@ -1,0 +1,6 @@
+system_id,label,diversity,explainability,safety,emergence,overall
+po_core,Po_core,100.0,91.0,89.0,87.0,91.75
+moe_baseline,Mixture-of-Experts baseline,58.0,47.0,61.0,73.0,59.75
+rlhf_baseline,RLHF baseline,35.0,51.0,72.0,46.0,51.0
+cot_baseline,Chain-of-Thought baseline,36.0,63.0,54.0,44.0,49.25
+single_llm,Single LLM (GPT/Claude),31.0,42.0,57.0,48.0,44.5

--- a/docs/paper/experiments/results_latest.json
+++ b/docs/paper/experiments/results_latest.json
@@ -1,0 +1,14 @@
+{
+  "meta": {
+    "pipeline": "paper_experiments_v1",
+    "created_at": "2026-02-22T00:00:00Z",
+    "deterministic": true,
+    "seed": 0
+  },
+  "stats": {
+    "scenario_count": 15,
+    "golden_count": 11,
+    "scenario_digest": "47da511ef65b1eb5b6b92703fbf4eda0c59326871da2dff57cf26b48be1ca8fe",
+    "snapshot_digest": "e46dd423d59b08b8739a6093cd137f9c8a06d611af557f7063dfabb7f4c6b972"
+  }
+}

--- a/docs/paper/paper.md
+++ b/docs/paper/paper.md
@@ -17,7 +17,28 @@ Recent criticism frames LLM systems as "stochastic parrots" that cannot justify 
 
 ## Experiments
 
-Core experiment outputs are versioned under `docs/paper/experiments/` and benchmark summaries under `docs/paper/benchmarks/results/`. The build pipeline appends the latest deterministic snapshot (`scenario_count`, `golden_count`, and scenario digest) into the compiled manuscript to preserve reproducibility.
+Deterministic evidence is generated into repository-tracked artifacts:
+
+- Experiment snapshot: `docs/paper/experiments/results_latest.json`
+  - created_at: `2026-02-22T00:00:00Z`
+  - seed: `0`
+  - digest keys: `scenario_digest`, `snapshot_digest`
+- Comparative benchmark: `docs/paper/benchmarks/results/comparative_results.json`
+  - created_at: `2026-02-22T00:00:00Z`
+  - seed: `0`
+  - digest key: `results_digest`
+
+### Benchmark table (overall)
+
+| System | Diversity | Explainability | Safety | Emergence | Overall |
+|---|---:|---:|---:|---:|---:|
+| Po_core | 100.00 | 91.00 | 89.00 | 87.00 | 91.75 |
+| Mixture-of-Experts baseline | 58.00 | 47.00 | 61.00 | 73.00 | 59.75 |
+| RLHF baseline | 35.00 | 51.00 | 72.00 | 46.00 | 51.00 |
+| Chain-of-Thought baseline | 36.00 | 63.00 | 54.00 | 44.00 | 49.25 |
+| Single LLM (GPT/Claude) | 31.00 | 42.00 | 57.00 | 48.00 | 44.50 |
+
+The benchmark chart is emitted as `docs/paper/benchmarks/results/comparative_overall.svg`, and the CSV/Markdown tables are co-generated for reproducible paper assembly.
 
 ## Limitations
 

--- a/scripts/paper/generate_experiment_snapshot.py
+++ b/scripts/paper/generate_experiment_snapshot.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 
 DEFAULT_TIMESTAMP = "2026-02-22T00:00:00Z"
+DEFAULT_SEED = 0
 
 
 def _scenario_digest(paths: list[Path]) -> str:
@@ -17,16 +18,22 @@ def _scenario_digest(paths: list[Path]) -> str:
     return hasher.hexdigest()
 
 
-def build_snapshot(repo_root: Path, created_at: str) -> dict:
+def _payload_digest(payload: dict) -> str:
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def build_snapshot(repo_root: Path, created_at: str, seed: int) -> dict:
     scenarios_dir = repo_root / "scenarios"
     scenario_files = sorted(scenarios_dir.glob("case_*.yaml"))
     expected_files = sorted(scenarios_dir.glob("case_*_expected.json"))
 
-    return {
+    payload = {
         "meta": {
             "pipeline": "paper_experiments_v1",
             "created_at": created_at,
             "deterministic": True,
+            "seed": seed,
         },
         "stats": {
             "scenario_count": len(scenario_files),
@@ -34,6 +41,8 @@ def build_snapshot(repo_root: Path, created_at: str) -> dict:
             "scenario_digest": _scenario_digest(scenario_files),
         },
     }
+    payload["stats"]["snapshot_digest"] = _payload_digest(payload)
+    return payload
 
 
 def main() -> None:
@@ -41,13 +50,14 @@ def main() -> None:
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--output", default="docs/paper/experiments/results_latest.json")
     parser.add_argument("--created-at", default=DEFAULT_TIMESTAMP)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
     output = (repo_root / args.output).resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
 
-    payload = build_snapshot(repo_root=repo_root, created_at=args.created_at)
+    payload = build_snapshot(repo_root=repo_root, created_at=args.created_at, seed=args.seed)
     output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 

--- a/scripts/paper/run_comparative_benchmark.py
+++ b/scripts/paper/run_comparative_benchmark.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_TIMESTAMP = "2026-02-22T00:00:00Z"
+DEFAULT_SEED = 0
 AXES = ("diversity", "explainability", "safety", "emergence")
 
 
@@ -156,7 +158,12 @@ def _render_svg_chart(rows: list[dict[str, object]]) -> str:
     return "\n".join(svg_lines) + "\n"
 
 
-def run(repo_root: Path, output_dir: Path, created_at: str) -> dict[str, object]:
+def _result_digest(rows: list[dict[str, object]]) -> str:
+    normalized = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def run(repo_root: Path, output_dir: Path, created_at: str, seed: int) -> dict[str, object]:
     profiles = _load_profiles(repo_root)
     rows = _to_result_rows(profiles)
 
@@ -165,8 +172,10 @@ def run(repo_root: Path, output_dir: Path, created_at: str) -> dict[str, object]
             "benchmark": "phase_23_comparative_v1",
             "created_at": created_at,
             "deterministic": True,
+            "seed": seed,
             "axes": list(AXES),
             "po_core_philosopher_count": _count_philosophers(repo_root),
+            "results_digest": _result_digest(rows),
         },
         "results": rows,
     }
@@ -209,11 +218,12 @@ def main() -> None:
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--output-dir", default="docs/paper/benchmarks/results")
     parser.add_argument("--created-at", default=DEFAULT_TIMESTAMP)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
     output_dir = (repo_root / args.output_dir).resolve()
-    run(repo_root=repo_root, output_dir=output_dir, created_at=args.created_at)
+    run(repo_root=repo_root, output_dir=output_dir, created_at=args.created_at, seed=args.seed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Provide repository-tracked, deterministic evidence artifacts for the paper pipeline so claims can be reproduced from the repo (Phase31 requirement). 
- Include compact cryptographic digests and fixed `seed` metadata so re-runs can be mechanically verified for identical outputs.

### Description

- Extend `scripts/paper/generate_experiment_snapshot.py` to accept a `--seed`, include `meta.seed`, and add a computed `snapshot_digest` to `stats` using SHA256 of a normalized payload. 
- Extend `scripts/paper/run_comparative_benchmark.py` to accept a `--seed`, include `meta.seed`, and add a computed `results_digest` using SHA256 of the normalized rows. 
- Update `docs/paper/paper.md` to document the generated artifacts, their `created_at`/`seed` fields, and the digest keys; include the benchmark table used in the manuscript. 
- Add deterministic evidence files under `docs/paper/experiments/results_latest.json` and `docs/paper/benchmarks/results/*` and update `.gitignore` to allow tracking these Phase31 artifacts.

### Testing

- `make paper-build` ran successfully and produced compiled markdown and a deterministic single-page PDF. 
- Re-running `make paper-build` produced identical SHA256 hashes for the generated artifacts, verifying determinism. 
- Focused tests `pytest -q tests/test_paper_pipeline.py tests/test_comparative_benchmark.py` passed. 
- Full test run `pytest -q` produced one unrelated benchmark failure in `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling` due to runtime performance thresholds in this environment while the functional changes and deterministic outputs remain validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69aeba15c83289f2747d3534cfc2a)