### PR TITLE
session_engine: validate session JSON root and add generic typing for _apply_patch

### DIFF
--- a/src/po_core/app/session_engine.py
+++ b/src/po_core/app/session_engine.py
@@ -17,14 +17,16 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any
+from typing import Any, TypeVar, cast
+
+T = TypeVar("T")
 
 
 class SessionPatchError(ValueError):
     """Raised when a JSON Patch operation fails."""
 
 
-def _apply_patch(obj: Any, operations: list[dict[str, Any]]) -> Any:
+def _apply_patch(obj: T, operations: list[dict[str, Any]]) -> T:
     """Apply RFC6902-compatible JSON Patch operations to a Python object.
 
     Supports: add, remove, replace.
@@ -181,4 +183,9 @@ def load_session_answers(path: str) -> dict[str, Any]:
         Parsed session answers dict.
     """
     with open(path, encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError("Session answers JSON must be an object")
+
+    return cast(dict[str, Any], data)


### PR DESCRIPTION
### Motivation

- Ensure `load_session_answers` fails early when the session answers JSON root is not an object to avoid downstream errors. 
- Preserve and express the input type of objects passed through the JSON Patch engine with stronger typing on `_apply_patch`.

### Description

- Make `_apply_patch` generic by adding a `TypeVar` `T` and changing its signature to `def _apply_patch(obj: T, ...) -> T` so the patched object type is preserved.
- Validate the output of `json.load` in `load_session_answers` to ensure it is a `dict` and raise `ValueError` if not, using `cast(dict[str, Any], data)` for typing.
- Add `TypeVar` and `cast` imports and adjust the `load_session_answers` file-read scope to perform the type check after closing the file.

### Testing

- Ran the session engine unit tests with `pytest -q` including tests covering patch application and session answers loading, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7af7665b8832884daf5bee17a4949)