### PR TITLE
ci: pin mypy version for stable lint type-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
         pip install black==26.1.0
+        pip install mypy==1.11.2
+
+    - name: Show mypy version
+      run: |
+        mypy --version
 
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
### Motivation
- Prevent CI/runner drift in the `Type check with mypy` job by fixing the mypy version so local and CI type-checking behavior is reproducible.

### Description
- Add `pip install mypy==1.11.2` to the lint job and a `Show mypy version` step in `.github/workflows/ci.yml` so the analyzer version is visible in CI logs.

### Testing
- Ran `mypy src/po_core/domain/ src/po_core/experiments/ src/po_core/app/ src/po_core/ports/` locally which returned `Success: no issues found in 53 source files`, and ran `pytest -q` which produced 14 unrelated test failures (acceptance golden diffs, benchmark scaling, and philosopher/manifest count mismatches) while 3519 tests passed and 134 were skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b2b9bc0483289949211f36da9091)