### PR TITLE
docs: purge legacy manifesto references and validate links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - docs: tighten `docs/厳格固定ルール.md` to align with SolarWill axioms (distortion/lifecycle exceptions), normalize top link blocks, and switch README SSOT/status links to GitHub full URLs.
 - docs: rename manifesto file to `Po_core_Manifesto_When_Pigs_Fly.md` and update repository references.
+- docs: purge legacy Manifesto filename/URL-encoded references and verify README links target the renamed file.
 
 ## [0.2.0] - 2026-03-03 (Stage2 5-F: stable release)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,6 +16,7 @@
 ## Meta (Docs Governance)
 - **Phase 0 (docs)**: `docs/厳格固定ルール.md` をSolarWill公理（歪み/例外/NORMAL-WARN-CRITICAL）に整合させ、主要文書の導線を統一した。
 - **Phase1-PR-1**: Manifestoファイル名をPo_core_Manifesto_When_Pigs_Fly.mdへ改名し、全参照を更新した。
+- **Phase1-PR-2**: 旧Manifesto参照（URLエンコード含む）を全掃討し、参照0件を保証した。
 
 ## Contracts
 - **最優先ルール**: `docs/厳格固定ルール.md` を参照（これに反する変更は禁止）。


### PR DESCRIPTION
### Motivation
- 完了済みのファイル名変更（`Po_core_Manifesto_When_Pigs_Fly.md`）後に残る旧名・URLエンコード済み参照を機械的に全撤去し、参照0件を保証するためのガバナンス記録を残す。これによりドキュメント導線の単一真実性を保つ。

### Description
- `docs/status.md` の `## Meta (Docs Governance)` に `**Phase1-PR-2**` を追記して旧Manifesto参照（URLエンコード含む）の全掃討と0件保証を記録した。
- `CHANGELOG.md` の Unreleased `### Documentation` に1行追記して今回のドキュメント掃討を明記した。
- README 内の `Manifesto` リンク（“Read our full story …”, `Documentation` リンク群, `Author` の導線）を確認し、すべて `./Po_core_Manifesto_When_Pigs_Fly.md` を指していることを検証した。
- ドキュメントのみの変更で、凍結対象の golden ファイル（`scenarios/case_001_expected.json` / `scenarios/case_009_expected.json`）は一切触れていない。

### Testing
- `git grep -n "# Po_core Manifesto When Pigs Fly.md"` → 0件（合格）。
- `git grep -n "%23%20Po_core%20Manifesto%20When%20Pigs%20Fly.md"` → 0件（合格）。
- `git grep -n "Po_core Manifesto When Pigs Fly.md"` → 0件（合格）。
- `rg -n "Manifesto|full story|Documentation" README.md` により README の該当リンクがすべて `./Po_core_Manifesto_When_Pigs_Fly.md` を指すことを確認した（合格）。
- `pytest tests/acceptance/ -q` を実行したところ、ドキュメント変更とは無関係の既存 acceptance golden ミスマッチにより `7 failed, 41 passed` となった（失敗）。
- 自動テスト結果は PR 本文に添えており、今回の変更は docs-only のためテスト失敗は本 PR に起因しないことを明記する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e4d772148328a7224349c2c87792)