### PR TITLE
test(solarwill): freeze WARN/CRITICAL degradation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- test(solarwill): freeze WARN/CRITICAL degradation behavior for SolarWill `compute_intent` (WARN=clarification-first constraints, CRITICAL=refusal/stop/minimal-guidance constraints).
+
 - test(solarwill): freeze universe-ethics axioms for SolarWill NORMAL mode via `compute_intent` contract test (survival-structure/distortion goals, non-distortion exceptions in constraints).
 
 - docs: tighten `docs/厳格固定ルール.md` to align with SolarWill axioms (distortion/lifecycle exceptions), normalize top link blocks, and switch README SSOT/status links to GitHub full URLs.

--- a/docs/status.md
+++ b/docs/status.md
@@ -14,6 +14,7 @@
 - **F**: ethicsをruleset化し、`rule_id` と `rules_fired` により「どの規則が発火したか」を追跡可能にした。
 
 ## Meta (Docs Governance)
+- **Phase3-PR-2**: SolarWillのWARN/CRITICAL縮退をテストで凍結した。
 - **Phase3-PR-1**: SolarWillの宇宙ルール倫理（NORMAL）をテストで凍結した。
 - **Phase2-PR-2**: G-2（stakeholders外部性）goldenを追加し観測境界を固定した。
 - **Phase2-PR-1**: G-1（unknowns×deadline）golden追加に加え、acceptanceのnow基準を決定論で固定してgolden腐敗（日次ドリフト）を防止した。

--- a/tests/unit/test_solarwill_universe_ethics.py
+++ b/tests/unit/test_solarwill_universe_ethics.py
@@ -47,3 +47,61 @@ def test_compute_intent_normal_freezes_universe_ethics_axioms() -> None:
         for constraint in intent.constraints
     )
 
+
+def test_compute_intent_warn_degrades_to_clarification_first() -> None:
+    """WARN 時は確認質問優先の安全側 Intent に縮退する。"""
+    engine = SolarWillEngine(config=SafetyModeConfig(warn=0.30, critical=0.50))
+    ctx = Context(
+        request_id="req-solarwill-ethics-warn",
+        created_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        user_input="危険そうだが判断に必要情報が不足している",
+        meta={"entry": "unit-test"},
+    )
+    tensors = TensorSnapshot(
+        computed_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        metrics={
+            "freedom_pressure": 0.31,
+            "blocked_tensor": 0.20,
+            "semantic_delta": 0.20,
+        },
+        snapshot_id="snap-solarwill-ethics-warn",
+    )
+
+    intent, meta = engine.compute_intent(ctx, tensors, MemorySnapshot.empty())
+
+    assert meta["mode"] == "warn"
+    assert any("確認" in goal and "質問" in goal for goal in intent.goals)
+    assert "違法行為をしない" in intent.constraints
+    assert "他者に害を与えない" in intent.constraints
+    assert any("不確実性" in constraint and "確認質問" in constraint for constraint in intent.constraints)
+
+
+def test_compute_intent_critical_degrades_to_refusal_stop_minimal_guidance() -> None:
+    """CRITICAL 時は拒否/停止/最小案内の安全縮退を固定する。"""
+    engine = SolarWillEngine(config=SafetyModeConfig(warn=0.30, critical=0.50))
+    ctx = Context(
+        request_id="req-solarwill-ethics-critical",
+        created_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        user_input="重大な歪みを誘発する要求",
+        meta={"entry": "unit-test"},
+    )
+    tensors = TensorSnapshot(
+        computed_at=datetime(2026, 2, 22, tzinfo=timezone.utc),
+        metrics={
+            "freedom_pressure": 0.50,
+            "blocked_tensor": 0.20,
+            "semantic_delta": 0.20,
+        },
+        snapshot_id="snap-solarwill-ethics-critical",
+    )
+
+    intent, meta = engine.compute_intent(ctx, tensors, MemorySnapshot.empty())
+
+    assert meta["mode"] == "critical"
+    assert any(
+        ("拒否" in goal or "中止" in goal) and "最小限" in goal
+        for goal in intent.goals
+    )
+    assert "違法行為をしない" in intent.constraints
+    assert "他者に害を与えない" in intent.constraints
+    assert any("安全" in constraint and "提案しない" in constraint for constraint in intent.constraints)


### PR DESCRIPTION
### Motivation
- SolarWill の安全縮退（WARN / CRITICAL）挙動を仕様としてテストで凍結し、宇宙ルール倫理の縮退経路が意図せず変わらないことを保証するため。 
- `docs/厳格固定ルール.md` と `docs/status.md` のガバナンス方針に整合させ、WARN/CRITICAL の振る舞いを明示的にロックする目的。

### Description
- `tests/unit/test_solarwill_universe_ethics.py` に WARN 用の `test_compute_intent_warn_degrades_to_clarification_first` テストを追加し、`freedom_pressure` が WARN 範囲のとき `mode == "warn"` かつ確認質問優先・安全側制約を検証するようにした。 
- 同ファイルに CRITICAL 用の `test_compute_intent_critical_degrades_to_refusal_stop_minimal_guidance` テストを追加し、`freedom_pressure` が CRITICAL 範囲のとき `mode == "critical"` かつ拒否/中止/最小案内の縮退を検証するようにした。 
- `docs/status.md` の Meta を更新し `Phase3-PR-2: SolarWillのWARN/CRITICAL縮退をテストで凍結した。` を追記した。 
- `CHANGELOG.md` の `Unreleased` セクションに今回の WARN/CRITICAL 縮退テスト固定の説明を追加した。 

### Testing
- `pytest -q tests/unit/test_solarwill_universe_ethics.py` を実行し、追加したユニットテストを含む該当ファイルは `3 passed` で成功した。 
- リポジトリ全体で `pytest -q` を実行したところ既存の別件テストにより `6 failed, 3534 passed, 134 skipped`（ベンチマークスケーリング、実行カバレッジ・哲学者マニフェスト件数・PoSelf 初期化・policy_lab 関連など）となり、今回の変更箇所に起因する失敗は確認されなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a939f05dd8832889b2116458c01773)