### PR TITLE
ci: add PR governance workflow and lightweight PR-body checker

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,24 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  pr-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate PR governance template requirements
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          python scripts/check_pr_governance.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ci: add pull-request governance workflow to validate SSOT/status/test-report requirements.
 - docs: add PR template checklist to require SSOT acknowledgment, docs/status updates, test reporting, and impact/rollback notes.
 - feat(tools): add standalone Phase4 emergence compare CLI (`scripts/eval_emergence.py`) with baseline/with-deliberation execution, human-readable diff, and optional JSON report output.
 - changed(deliberation): add `avg_novelty` to `DeliberationResult` and include it in `summary()["emergence"]` for trace/summary observability.

--- a/docs/status.md
+++ b/docs/status.md
@@ -14,6 +14,7 @@
 - **F**: ethicsをruleset化し、`rule_id` と `rules_fired` により「どの規則が発火したか」を追跡可能にした。
 
 ## Meta (Docs Governance)
+- **Phase5-PR-2**: PR本文ガバナンスチェックを追加し、SSOT確認・進捗更新・テスト報告・影響範囲記載を pull_request 時に検査するようにした。
 - **Phase5-PR-1**: PRテンプレを追加し、SSOT確認・進捗更新・テスト報告・影響範囲記載を要求するようにした。
 - **Phase4-PR-1**: 創発比較スクリプトを追加し、議論あり/なしの比較計測（avg_novelty 集計修正と回帰テスト固定を含む）を可能にした。
 - **Phase3-PR-2**: SolarWillのWARN/CRITICAL縮退をテストで凍結した。

--- a/scripts/check_pr_governance.py
+++ b/scripts/check_pr_governance.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Lightweight PR governance checks for pull_request events."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+REQUIRED_HEADINGS = [
+    "必須チェック（SSOT / 進捗 / テスト報告）",
+    "Status Update",
+    "Test Report",
+    "Impact / Rollback",
+]
+
+REQUIRED_CHECKBOXES = {
+    "SSOT acknowledgment": "SSOT `docs/厳格固定ルール.md` を読んだ",
+    "docs/status.md update": "`docs/status.md` を更新した（どこを動かしたかを記載）",
+    "test report": "実行したテストコマンドと結果を下記に記載した",
+    "impact/rollback": "影響範囲とロールバック手順を下記に記載した",
+}
+
+SUBSTANTIVE_PREFIXES = (
+    "src/",
+    "tests/",
+    "scripts/",
+    "scenarios/",
+    ".github/workflows/",
+    "docs/spec/",
+)
+SUBSTANTIVE_FILES = {"pyproject.toml"}
+
+# Explicit exemptions for docs/governance-only PRs where status updates may be relaxed.
+STATUS_UPDATE_EXEMPT_FILES = {
+    ".github/pull_request_template.md",
+    "CHANGELOG.md",
+    "docs/status.md",
+}
+
+PLACEHOLDER_VALUES = {"", "-", "tbd", "n/a", "未記入"}
+
+
+def extract_section(body: str, heading: str) -> str:
+    pattern = rf"(?ms)^##\s+{re.escape(heading)}\s*\n(.*?)(?=^##\s+|\Z)"
+    match = re.search(pattern, body)
+    return match.group(1).strip() if match else ""
+
+
+def is_placeholder(text: str) -> bool:
+    normalized = text.strip()
+    if normalized.lower() in PLACEHOLDER_VALUES:
+        return True
+    return normalized == ""
+
+
+def has_checked_box(body: str, label_fragment: str) -> bool:
+    pattern = rf"(?im)^-\s*\[[xX]\]\s*.*{re.escape(label_fragment)}"
+    return re.search(pattern, body) is not None
+
+
+def requires_status_update(changed_files: list[str]) -> bool:
+    if not changed_files:
+        return False
+
+    def _is_exempt(path: str) -> bool:
+        return path in STATUS_UPDATE_EXEMPT_FILES or path.startswith("docs/")
+
+    if all(_is_exempt(path) for path in changed_files):
+        return False
+
+    return any(
+        path.startswith(SUBSTANTIVE_PREFIXES)
+        or path in SUBSTANTIVE_FILES
+        or re.match(r"^requirements[^/]*\.txt$", path)
+        for path in changed_files
+    )
+
+
+def _extract_field(section: str, field_name: str) -> str:
+    for line in section.splitlines():
+        if field_name in line:
+            _, _, value = line.partition(":")
+            return value.strip()
+    return ""
+
+
+def _has_non_placeholder_line(text: str) -> bool:
+    for line in text.splitlines():
+        candidate = line.strip()
+        if candidate.startswith("- ["):
+            continue
+        if not is_placeholder(candidate):
+            return True
+    return False
+
+
+def validate_body(body: str, changed_files: list[str]) -> list[str]:
+    failures: list[str] = []
+
+    for heading in REQUIRED_HEADINGS:
+        if f"## {heading}" not in body:
+            failures.append(f"Missing section heading: {heading}")
+
+    for label, fragment in REQUIRED_CHECKBOXES.items():
+        if not has_checked_box(body, fragment):
+            failures.append(f"Missing checked box: {label}")
+
+    status_section = extract_section(body, "Status Update")
+    if not status_section:
+        failures.append("Missing section content: Status Update")
+    else:
+        updated_area = _extract_field(status_section, "更新箇所")
+        updated_content = _extract_field(status_section, "更新内容")
+        if is_placeholder(updated_area):
+            failures.append("Missing section content: Status Update / 更新箇所")
+        if is_placeholder(updated_content):
+            failures.append("Missing section content: Status Update / 更新内容")
+
+    test_section = extract_section(body, "Test Report")
+    if not test_section:
+        failures.append("Missing section content: Test Report")
+    else:
+        marker = "実行ログ（コマンドと結果）:"
+        log_text = test_section.split(marker, 1)[1] if marker in test_section else ""
+        if not _has_non_placeholder_line(log_text):
+            failures.append("Missing section content: Test Report / 実行ログ（コマンドと結果）")
+
+    impact_section = extract_section(body, "Impact / Rollback")
+    if not impact_section:
+        failures.append("Missing section content: Impact / Rollback")
+    else:
+        impact_scope = _extract_field(impact_section, "影響範囲")
+        rollback = _extract_field(impact_section, "ロールバック手順")
+        if is_placeholder(impact_scope):
+            failures.append("Missing section content: Impact / Rollback / 影響範囲")
+        if is_placeholder(rollback):
+            failures.append("Missing section content: Impact / Rollback / ロールバック手順")
+
+    if requires_status_update(changed_files) and "docs/status.md" not in changed_files:
+        failures.append("docs/status.md must be updated for code-affecting changes")
+
+    return failures
+
+
+def _changed_files(base_sha: str, head_sha: str) -> list[str]:
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_sha}..{head_sha}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return []
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _load_event(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("GITHUB_EVENT_PATH is not set; skipping PR governance check.")
+        return 0
+
+    event_file = Path(event_path)
+    if not event_file.exists():
+        print(f"Event payload not found: {event_file}; skipping.")
+        return 0
+
+    payload = _load_event(event_file)
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        print("No pull_request payload; skipping PR governance check.")
+        return 0
+
+    body = str(pull_request.get("body") or "")
+    base_sha = str((pull_request.get("base") or {}).get("sha") or "")
+    head_sha = str((pull_request.get("head") or {}).get("sha") or "")
+    changed_files = _changed_files(base_sha, head_sha) if base_sha and head_sha else []
+
+    failures = validate_body(body=body, changed_files=changed_files)
+    if failures:
+        print("PR governance check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PR governance check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_pr_governance_check.py
+++ b/tests/unit/test_pr_governance_check.py
@@ -1,0 +1,63 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[2] / "scripts" / "check_pr_governance.py"
+spec = spec_from_file_location("check_pr_governance", module_path)
+assert spec and spec.loader
+module = module_from_spec(spec)
+spec.loader.exec_module(module)
+
+extract_section = module.extract_section
+has_checked_box = module.has_checked_box
+is_placeholder = module.is_placeholder
+requires_status_update = module.requires_status_update
+
+
+def test_has_checked_box_detects_checked_variants() -> None:
+    body = """
+- [x] SSOT `docs/厳格固定ルール.md` を読んだ
+- [X] 実行したテストコマンドと結果を下記に記載した
+- [ ] 影響範囲とロールバック手順を下記に記載した
+"""
+    assert has_checked_box(body, "SSOT `docs/厳格固定ルール.md` を読んだ")
+    assert has_checked_box(body, "実行したテストコマンドと結果を下記に記載した")
+    assert not has_checked_box(body, "影響範囲とロールバック手順を下記に記載した")
+
+
+def test_is_placeholder_detects_template_values() -> None:
+    assert is_placeholder("")
+    assert is_placeholder("-")
+    assert is_placeholder("TBD")
+    assert is_placeholder("n/a")
+    assert is_placeholder("未記入")
+    assert not is_placeholder("更新済み")
+
+
+def test_requires_status_update_for_substantive_change() -> None:
+    changed_files = ["src/pocore/runner.py", "CHANGELOG.md"]
+    assert requires_status_update(changed_files)
+
+
+def test_requires_status_update_relaxed_for_docs_or_template_only() -> None:
+    changed_files = [
+        ".github/pull_request_template.md",
+        "CHANGELOG.md",
+        "docs/status.md",
+    ]
+    assert not requires_status_update(changed_files)
+
+
+def test_extract_section_returns_expected_block() -> None:
+    body = """
+## Status Update
+- 更新箇所（Completed / Meta / Next など）: Meta
+- 更新内容: governance workflow added
+
+## Test Report
+実行ログ（コマンドと結果）:
+- pytest -q
+"""
+    section = extract_section(body, "Status Update")
+    assert "更新箇所" in section
+    assert "governance workflow added" in section
+    assert "## Test Report" not in section


### PR DESCRIPTION
### Motivation
- Enforce PR template requirements (SSOT acknowledgement, status update, test report, impact/rollback) at pull_request time with a lightweight check to improve governance while avoiding mixing into the heavy CI test job.
- Require `docs/status.md` to be updated for substantive code changes while allowing docs-only or template-only PRs to be exempt.

### Description
- Add `scripts/check_pr_governance.py` which reads the GitHub `pull_request` payload from `GITHUB_EVENT_PATH`, extracts the PR body, computes changed files via `git diff --name-only base..head`, verifies required headings and checked boxes, detects placeholder content, enforces `docs/status.md` update for substantive changes, and prints an enumerated failure list on error.
- Add a standalone GitHub Actions workflow `.github/workflows/pr-governance.yml` that runs on `pull_request` events, checks out with `fetch-depth: 0`, sets up Python, and executes `python scripts/check_pr_governance.py` (keeps this governance check separate from the heavy `ci.yml` jobs).
- Add unit tests `tests/unit/test_pr_governance_check.py` exercising `extract_section`, `has_checked_box`, `is_placeholder`, and `requires_status_update` logic using the script as a module-loaded test target.
- Update `docs/status.md` Meta with a Phase5-PR-2 note describing that PR-body governance checks now run at pull_request time, and add one line to `CHANGELOG.md` under `Unreleased / Changed` describing the new workflow.

### Testing
- Ran `pytest -q tests/unit/test_pr_governance_check.py` and it passed (all unit assertions for the checker logic succeeded).
- Ran `python scripts/check_pr_governance.py` with no `GITHUB_EVENT_PATH` and it exited cleanly with the expected skip message; ran with a sample `GITHUB_EVENT_PATH=/tmp/pr_event.json` payload and it returned success for the sample PR body.
- Ran a full test run `pytest -q` which exhibited unrelated existing test failures in the repository (6 failing tests listed below) that are outside the scope of this change: `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`, `tests/test_execution_coverage.py::test_execution_covers_minimum_arbitration_codes_and_ethics_rules`, `tests/test_philosophers_pipeline.py::{test_manifest_has_44_specs,test_43_non_dummy_philosophers}`, `tests/test_po_self_v2.py::TestPoSelfInitialization::test_default_has_44_philosophers`, and `tests/test_policy_lab.py::test_policy_lab_compare_baseline_generates_impacted_requirements`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa44776f3483289bdbd51ba07deee6)