### PR TITLE
chore: format 4 test files with Black (line-length=88, py311)

### DIFF
--- a/tests/acceptance/test_acceptance_suite.py
+++ b/tests/acceptance/test_acceptance_suite.py
@@ -420,5 +420,6 @@ def test_at_meta_seeded_default_now_is_fixed(case_001):
 
     assert out["meta"]["created_at"] == "2026-03-03T00:00:00Z"
 
+
 # Need to import StubComposer at module level for the parametrize test
 from po_core.app.composer import StubComposer  # noqa: E402

--- a/tests/unit/test_eval_emergence_aggregate.py
+++ b/tests/unit/test_eval_emergence_aggregate.py
@@ -10,7 +10,9 @@ import pytest
 def _load_eval_emergence_module():
     repo_root = Path(__file__).resolve().parents[2]
     module_path = repo_root / "scripts" / "eval_emergence.py"
-    spec = importlib.util.spec_from_file_location("eval_emergence_for_tests", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "eval_emergence_for_tests", module_path
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/tests/unit/test_phase6b_emergence.py
+++ b/tests/unit/test_phase6b_emergence.py
@@ -407,7 +407,9 @@ class TestDeliberationResultNewFields:
             EmergenceSignal(0.88, "Nietzsche", ("Nietzsche", "Hegel"), 2),
             EmergenceSignal(0.65, "Hume", ("Hume", "Locke"), 3),
         ]
-        assert self._make_result(sigs, {}).avg_novelty == pytest.approx((0.72 + 0.88 + 0.65) / 3)
+        assert self._make_result(sigs, {}).avg_novelty == pytest.approx(
+            (0.72 + 0.88 + 0.65) / 3
+        )
 
     def test_summary_includes_emergence_section(self):
         sig = EmergenceSignal(0.75, "Sartre", ("Sartre", "Kant"), 2)

--- a/tests/unit/test_solarwill_universe_ethics.py
+++ b/tests/unit/test_solarwill_universe_ethics.py
@@ -73,7 +73,10 @@ def test_compute_intent_warn_degrades_to_clarification_first() -> None:
     assert any("確認" in goal and "質問" in goal for goal in intent.goals)
     assert "違法行為をしない" in intent.constraints
     assert "他者に害を与えない" in intent.constraints
-    assert any("不確実性" in constraint and "確認質問" in constraint for constraint in intent.constraints)
+    assert any(
+        "不確実性" in constraint and "確認質問" in constraint
+        for constraint in intent.constraints
+    )
 
 
 def test_compute_intent_critical_degrades_to_refusal_stop_minimal_guidance() -> None:
@@ -99,9 +102,11 @@ def test_compute_intent_critical_degrades_to_refusal_stop_minimal_guidance() -> 
 
     assert meta["mode"] == "critical"
     assert any(
-        ("拒否" in goal or "中止" in goal) and "最小限" in goal
-        for goal in intent.goals
+        ("拒否" in goal or "中止" in goal) and "最小限" in goal for goal in intent.goals
     )
     assert "違法行為をしない" in intent.constraints
     assert "他者に害を与えない" in intent.constraints
-    assert any("安全" in constraint and "提案しない" in constraint for constraint in intent.constraints)
+    assert any(
+        "安全" in constraint and "提案しない" in constraint
+        for constraint in intent.constraints
+    )


### PR DESCRIPTION
### Motivation
- CI was failing because Black reported formatting diffs for four test files, so the repository needs those files formatted to satisfy the CI Black check.

### Description
- Applied Black formatting (settings: `--line-length 88`, `--target-version py311`) to exactly these files: `tests/acceptance/test_acceptance_suite.py`, `tests/unit/test_eval_emergence_aggregate.py`, `tests/unit/test_phase6b_emergence.py`, and `tests/unit/test_solarwill_universe_ethics.py`.
- Changes are formatting-only (line wraps, blank-line adjustments); there are no logic or behavioral modifications to tests.
- Commit was created with the message `fix: black formatting on 4 test files`.

### Testing
- Ran `black --line-length 88 --target-version py311` on the four files and Black reformatted the four files successfully (output: "4 files reformatted").
- Verified with `black --check --line-length 88 --target-version py311` that the files are now compliant and would be left unchanged.
- Changes were staged and committed (commit message: `fix: black formatting on 4 test files`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5c3883e48328911b508b76544dda)