### PR TITLE
docs(api): fix OpenAPI license to AGPL-3.0-or-later + Commercial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- docs(api): fix OpenAPI `license_info` metadata to AGPL-3.0-or-later + Commercial and add explicit license links in API description.
 - chore(release): bump package/runtime metadata to `0.3.0`, update OpenAPI license label, and align acceptance meta contracts while recording acceptance must-pass evidence (acceptance proof: `docs/release/acceptance_proof_v0.3.0.md`).
 - ci: add pull-request governance workflow to validate SSOT/status/test-report requirements.
 - docs: add PR template checklist to require SSOT acknowledgment, docs/status updates, test reporting, and impact/rollback notes.

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,6 +15,7 @@
 
 ## Meta (Docs Governance)
 - **Phase6-PR-2**: acceptance must-pass（`pytest tests/acceptance/ -v -m acceptance`）のgreen実行証跡をPR本文へ追記し、golden更新がversion metadata中心であることを明記した。
+- **Phase6-PR-2**: OpenAPIライセンス表記をAGPL+Commercialに修正した。
 - **Phase6-PR-1**: バージョン表記を0.3.0へ統一し、OpenAPI license表示をAGPL-3.0-or-later + Commercialへ更新した（acceptance proof: `docs/release/acceptance_proof_v0.3.0.md`）。
 - **Phase5-PR-2**: PR本文ガバナンスチェックを追加し、SSOT確認・進捗更新・テスト報告・影響範囲記載を pull_request 時に検査するようにした。
 - **Phase5-PR-1**: PRテンプレを追加し、SSOT確認・進捗更新・テスト報告・影響範囲記載を要求するようにした。

--- a/src/po_core/app/rest/server.py
+++ b/src/po_core/app/rest/server.py
@@ -99,6 +99,10 @@ Leave empty or set `PO_SKIP_AUTH=true` for development mode.
 MemoryRead → TensorCompute → SolarWill → IntentionGate → PhilosopherSelect
 → PartyMachine → ParetoAggregate → ShadowPareto → ActionGate → MemoryWrite
 ```
+
+### License
+- Open source: [AGPL-3.0-or-later](https://github.com/hiroshitanaka-creator/Po_core/blob/main/LICENSE)
+- Commercial: [Commercial License Terms](https://github.com/hiroshitanaka-creator/Po_core/blob/main/COMMERCIAL_LICENSE.md)
         """,
         version="0.3.0",
         contact={
@@ -106,7 +110,10 @@ MemoryRead → TensorCompute → SolarWill → IntentionGate → PhilosopherSele
             "url": "https://github.com/hiroshitanaka-creator/Po_core",
             "email": "flyingpig0229+github@gmail.com",
         },
-        license_info={"name": "AGPL-3.0-or-later + Commercial"},
+        license_info={
+            "name": "AGPL-3.0-or-later + Commercial",
+            "url": "https://github.com/hiroshitanaka-creator/Po_core/blob/main/LICENSE",
+        },
         openapi_tags=[
             {
                 "name": "reason",


### PR DESCRIPTION
### Motivation
- The OpenAPI metadata exposed an ambiguous/incorrect license label and must reflect the project's dual-license status (AGPL + Commercial) to avoid licensing misrepresentation.
- The README/docs references already describe AGPL + Commercial, so the API metadata and status snapshot must be consistent with repository governance. 

### Description
- Updated `src/po_core/app/rest/server.py` to add an explicit `License` section in the OpenAPI `description` and set `license_info` to include `"name": "AGPL-3.0-or-later + Commercial"` and a `url` to the repository `LICENSE` file. 
- Added a link to `COMMERCIAL_LICENSE.md` in the OpenAPI description to make the commercial license location explicit. 
- Appended the Meta line `Phase6-PR-2: OpenAPIライセンス表記をAGPL+Commercialに修正した。` to `docs/status.md` and added a single `Unreleased` changelog line in `CHANGELOG.md` describing the metadata fix. 
- All edits are limited to API metadata and docs (`server.py`, `docs/status.md`, `CHANGELOG.md`) and do not change runtime policy/engine logic. 

### Testing
- Ran repository checks: `git grep -n "license_info"` and `git grep -n "MIT"` to confirm the OpenAPI metadata location and that no stale MIT labeling remained in the API metadata. 
- Executed the full test suite with `pytest -q`; results were `3 failed, 3546 passed, 134 skipped` and the failing tests are `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`, `tests/test_execution_coverage.py::test_execution_covers_minimum_arbitration_codes_and_ethics_rules`, and `tests/test_policy_lab.py::test_policy_lab_compare_baseline_generates_impacted_requirements`. 
- The three failing tests appear in benchmark/coverage/policy areas and the changes in this PR are limited to docs/OpenAPI metadata and thus did not modify the logic these tests exercise.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab70214a1c83288725ab57fc53fcc2)