### PR TITLE
Unify Black to 23.12.1 and remove redundant Black installs from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-        pip install black==26.1.0
         pip install mypy==1.11.2
 
     - name: Show mypy version

--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -13,9 +13,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black==26.1.0
       - name: Run import graph checks
         run: python tools/import_graph.py --check --print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "pytest-asyncio>=0.21.0",
-    "black==26.1.0",
+    "black==23.12.1",
     "isort==5.13.2",
     "flake8>=6.1.0",
     "mypy>=1.7.0",


### PR DESCRIPTION
### Motivation
- Eliminate conflicting Black pins between `pyproject.toml` and `requirements-dev.txt` and avoid redundant installs in CI workflows.
- Ensure CI uses the same, existing stable Black version that is present in `requirements-dev.txt` to prevent install failures and dependency drift.

### Description
- Changed `[project.optional-dependencies].dev` in `pyproject.toml` to pin `black==23.12.1` to match `requirements-dev.txt`.
- Removed the explicit `pip install black==26.1.0` line from the `lint` job `Install dependencies` step in `.github/workflows/ci.yml` so Black comes from `.[dev]`.
- Removed the Black installation step from `.github/workflows/import-guard.yml` because `tools/import_graph.py` does not require Black.
- Kept all other dev dependency pins unchanged and did not modify any frozen golden files.

### Testing
- Ran `rg -n "black==" pyproject.toml requirements-dev.txt .github/workflows/ci.yml .github/workflows/import-guard.yml` to verify a single canonical `black==23.12.1` reference, which succeeded.
- Executed `python tools/import_graph.py --check --print` to ensure the import-guard workflow can run without Black, which reported no rule violations or cycles and succeeded.
- Attempted a CI-like install with `python -m pip install --upgrade pip && pip install -e ".[dev]" && pip install mypy==1.11.2`, which failed in this environment due to external network/proxy restrictions (403) when contacting PyPI, not due to the repository configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb186e8108328b6bb4c08e9b3a782)