### PR TITLE
Consolidate pytest configuration to pytest.ini and remove duplicate pyproject entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,38 +157,8 @@ skip_gitignore = true
 src_paths = ["src", "tests"]
 
 # ==================
-# Pytest Configuration
+# Pytest configuration source-of-truth is pytest.ini
 # ==================
-[tool.pytest.ini_options]
-minversion = "7.0"
-testpaths = ["tests"]
-pythonpath = ["src"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = [
-    "--strict-markers",
-    "--strict-config",
-    "-ra",
-    "--verbose",
-]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "philosophical: marks tests for philosophical consistency",
-    "unit: marks tests as unit tests",
-    "pipeline: marks tests as pipeline tests (must-pass in CI)",
-    "observability: marks tests for Phase 3 observability features",
-    "redteam: marks tests as adversarial red team tests (Phase 4)",
-    "phase4: marks tests for Phase 4 adversarial hardening",
-    "phase5: marks tests for Phase 5 productization (REST API, Docker, PyPI)",
-    "benchmark: marks performance benchmark tests (run with -m benchmark)",
-]
-filterwarnings = [
-    "error",
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning",
-]
 
 # ==================
 # Coverage Configuration


### PR DESCRIPTION
### Motivation

- Eliminate duplicated pytest settings across `pyproject.toml` and `pytest.ini` to make `pytest.ini` the single source of truth for test configuration. 
- Centralize marker definitions so CI and local runs consistently resolve marks such as `acceptance`, `phase6a`, `phase6b`, `phase6c1`, and `asyncio`.
- Prevent confusing or conflicting pytest behavior when different tools inspect `pyproject.toml` versus `pytest.ini`.

### Description

- Removed the `[tool.pytest.ini_options]` section from `pyproject.toml` and left an explicit comment stating that `pytest.ini` is the pytest configuration source-of-truth. 
- Kept all marker definitions in `pytest.ini`, which already includes `acceptance`, `phase6a`, `phase6b`, `phase6c1`, and `asyncio`. 
- No changes were made to `pytest.ini` or CI job commands; CI continues to invoke `pytest tests/acceptance/ -v -m acceptance` which resolves to `pytest.ini` at runtime. 

### Testing

- Ran `pytest --trace-config tests/acceptance/ -m acceptance --collect-only -q` to confirm `configfile: pytest.ini` is used and test collection resolved correctly. 
- Ran `pytest tests/acceptance/ -v -m acceptance` and observed `43 passed, 9 deselected` for the acceptance suite. 
- Ran `pytest -q` repository-wide and observed three pre-existing unrelated test failures: `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`, `tests/test_execution_coverage.py::test_execution_covers_minimum_arbitration_codes_and_ethics_rules`, and `tests/test_policy_lab.py::test_policy_lab_compare_baseline_generates_impacted_requirements`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb192596c83288ac917128792d45c)