### PR TITLE
chore(test): make pytest.ini the single source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- chore(test): make `pytest.ini` the single source of truth by removing duplicated pytest options from `pyproject.toml`.
 - docs(prd): align `docs/spec/prd.md` status/package/headcount/milestones with SSOT snapshot (`docs/status.md`) and current repository reality (`v0.3.0`, 42 philosophers, M0/M1 complete), and remove PyPI-state ambiguity by documenting `v0.2.0b4` as published history.
 - docs(api): unify public philosopher count references to 42 (OpenAPI summary/description and project metadata).
 - docs(api): fix OpenAPI `license_info` metadata to AGPL-3.0-or-later + Commercial and add explicit license links in API description.

--- a/docs/status.md
+++ b/docs/status.md
@@ -19,6 +19,7 @@
 - **ci-fix-black**: `pyproject.toml` の `black==23.12.1` を `26.1.0` に統一し、CI lint ジョブと `.pre-commit-config.yaml` のバージョンを一致させた（コミット #379 のダウングレードを修正）。
 
 ## Meta (Docs Governance)
+- **Phase9-PR-1**: pytest設定の単一真実化（pytest.ini）を完了。
 - **Phase8-PR-1**: publish playbook（`docs/operations/publish_playbook.md`）を追加し、publish.yml の TestPyPI→PyPI 手順と失敗時ロールバックを再現可能な運用手順として固定した。
 - **Phase6-PR-2**: acceptance must-pass（`pytest tests/acceptance/ -v -m acceptance`）のgreen実行証跡をrepo内に固定した（acceptance proof: `docs/release/acceptance_proof_v0.3.0.md`）。
 - **Phase6-PR-4**: OpenAPIライセンス表記をAGPL+Commercialに修正し、OpenAPI description にライセンスリンクを追加した。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,39 +156,7 @@ ensure_newline_before_comments = true
 skip_gitignore = true
 src_paths = ["src", "tests"]
 
-# ==================
-# Pytest Configuration
-# ==================
-[tool.pytest.ini_options]
-minversion = "7.0"
-testpaths = ["tests"]
-pythonpath = ["src"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = [
-    "--strict-markers",
-    "--strict-config",
-    "-ra",
-    "--verbose",
-]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "philosophical: marks tests for philosophical consistency",
-    "unit: marks tests as unit tests",
-    "pipeline: marks tests as pipeline tests (must-pass in CI)",
-    "observability: marks tests for Phase 3 observability features",
-    "redteam: marks tests as adversarial red team tests (Phase 4)",
-    "phase4: marks tests for Phase 4 adversarial hardening",
-    "phase5: marks tests for Phase 5 productization (REST API, Docker, PyPI)",
-    "benchmark: marks performance benchmark tests (run with -m benchmark)",
-]
-filterwarnings = [
-    "error",
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning",
-]
+# pytest config is defined in pytest.ini
 
 # ==================
 # Coverage Configuration


### PR DESCRIPTION
### Motivation
- Eliminate duplicated pytest configuration split across `pyproject.toml` and `pytest.ini` so `pytest.ini` becomes the single source of truth and avoids configuration drift.
- Record the change in repository governance artifacts so status and changelog reflect the decision. 

### Description
- Removed the `[tool.pytest.ini_options]` section from `pyproject.toml` and left a one-line comment `# pytest config is defined in pytest.ini` in its place. 
- Did not modify `pytest.ini`; all pytest runtime settings remain sourced from `pytest.ini`. 
- Added `- **Phase9-PR-1**: pytest設定の単一真実化（pytest.ini）を完了。` to `docs/status.md`. 
- Appended an Unreleased `chore(test)` entry to `CHANGELOG.md` noting the deduplication. 

### Testing
- Ran `pytest --trace-config -q` to confirm pytest loads `pytest.ini` as the active config file and observed the plugin/config registration output. 
- Ran `pytest -q` (full test suite): `3683` collected, `3545` passed, `134` skipped, and `4` failed; failures appear unrelated to config deduplication and are listed below. 
- Failed tests observed: `tests/benchmarks/test_pipeline_perf.py::test_bench_concurrent_warn_requests`, `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`, `tests/test_execution_coverage.py::test_execution_covers_minimum_arbitration_codes_and_ethics_rules`, and `tests/test_policy_lab.py::test_policy_lab_compare_baseline_generates_impacted_requirements`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc5a948d483288c03f3d5801e54aa)