### PR TITLE
fix(pocore): make TIME_PRESSURE_DAYS dynamic for policy_lab and planning coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(pocore): make `TIME_PRESSURE_DAYS` references dynamic for policy_lab override compatibility and align execution coverage planning-rule expectations with policy snapshots.
 - fixed(tools): correct `avg_novelty` aggregation in eval_emergence to signals-weighted mean and lock behavior with regression tests.
 
 ### Documentation

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,6 +20,7 @@
 
 ## Meta (Docs Governance)
 - **Phase9-PR-1**: pytest設定の単一真実化（pytest.ini）を完了。
+- **Phase9-PR-2**: policy_lab/coverageの定数参照を動的化し、テストを安定化。
 - **Phase8-PR-1**: publish playbook（`docs/operations/publish_playbook.md`）を追加し、publish.yml の TestPyPI→PyPI 手順と失敗時ロールバックを再現可能な運用手順として固定した。
 - **Phase6-PR-2**: acceptance must-pass（`pytest tests/acceptance/ -v -m acceptance`）のgreen実行証跡をrepo内に固定した（acceptance proof: `docs/release/acceptance_proof_v0.3.0.md`）。
 - **Phase6-PR-4**: OpenAPIライセンス表記をAGPL+Commercialに修正し、OpenAPI description にライセンスリンクを追加した。

--- a/src/pocore/engines/generator_stub.py
+++ b/src/pocore/engines/generator_stub.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from ..policy_v1 import TIME_PRESSURE_DAYS
+from .. import policy_v1
 
 PROFILE_CASE_001 = "job_change_transition_v1"
 PROFILE_CASE_009 = "values_clarification_v1"
@@ -60,7 +60,7 @@ def _needs_two_track_plan(features: Dict[str, Any]) -> bool:
     return (
         int(features.get("unknowns_count", 0) or 0) > 0
         and isinstance(days_to_deadline, int)
-        and days_to_deadline <= TIME_PRESSURE_DAYS
+        and days_to_deadline <= policy_v1.TIME_PRESSURE_DAYS
     )
 
 

--- a/tests/test_execution_coverage.py
+++ b/tests/test_execution_coverage.py
@@ -17,8 +17,7 @@ MUST_COVER_ETHICS_RULE_IDS = {
     "ETH_NO_OVERCLAIM_UNKNOWN",
     "ETH_STAKEHOLDER_CONSENT",
 }
-MUST_COVER_PLANNING_RULE_IDS = {
-    "PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN",
+BASE_PLANNING_RULE_IDS = {
     "PLAN_VALUES_CLARIFICATION_PACK_V1",
 }
 
@@ -75,9 +74,23 @@ def test_execution_covers_minimum_arbitration_codes_and_ethics_rules() -> None:
     ):
         required_arbitration.add("TIME_PRESSURE_LOW_CONF")
 
+    required_planning_rules = set(BASE_PLANNING_RULE_IDS)
+    if (
+        run_case_file(
+            SCENARIOS / "case_005.yaml", seed=0, deterministic=True, now=FIXED_NOW
+        )
+        .get("trace", {})
+        .get("steps", [{}])[-1]
+        .get("metrics", {})
+        .get("policy_snapshot", {})
+        .get("TIME_PRESSURE_DAYS", 0)
+        >= 0
+    ):
+        required_planning_rules.add("PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN")
+
     missing_arbitration = required_arbitration - arbitration_codes
     missing_rules = MUST_COVER_ETHICS_RULE_IDS - ethics_rule_ids
-    missing_planning_rules = MUST_COVER_PLANNING_RULE_IDS - planning_rule_ids
+    missing_planning_rules = required_planning_rules - planning_rule_ids
 
     assert not missing_arbitration, (
         "Missing required arbitration_code coverage from scenarios/*.yaml execution: "


### PR DESCRIPTION
### Motivation
- `scripts/policy_lab.py` temporarily overrides `policy_v1.TIME_PRESSURE_DAYS` at runtime but `generator_stub` imported the value by name, preventing overrides from taking effect.  
- `tests/test_execution_coverage.py` unconditionally required `PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN`, which can fail when `TIME_PRESSURE_DAYS` is negative; the test should follow the same policy-snapshot conditional logic used for arbitration.  
- Update documentation metadata and changelog to record the stabilization change.  

### Description
- Changed `src/pocore/engines/generator_stub.py` to import the module (`from .. import policy_v1`) and use `policy_v1.TIME_PRESSURE_DAYS` in `_needs_two_track_plan` so runtime overrides by `policy_lab` are honored.  
- Modified `tests/test_execution_coverage.py` to use `BASE_PLANNING_RULE_IDS` and build `required_planning_rules` conditionally, adding `PLAN_TWO_TRACK_TIME_PRESSURE_UNKNOWN` only when the `policy_snapshot["TIME_PRESSURE_DAYS"] >= 0`.  
- Updated `docs/status.md` to add `Phase9-PR-2` meta entry and added a one-line Unreleased fix note to `CHANGELOG.md`.  
- Kept frozen golden files untouched and preserved existing arbitration/ethics coverage logic.  

### Testing
- Ran `pytest -q tests/test_policy_lab.py::test_policy_lab_compare_baseline_generates_impacted_requirements` and it passed (`1 passed`).  
- Ran `pytest -q tests/test_execution_coverage.py::test_execution_covers_minimum_arbitration_codes_and_ethics_rules` and it passed (`1 passed`).  
- No other tests were modified; change is limited to dynamic constant lookup and the planning-rule coverage condition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abcaa612908328955ae331106c37d1)