### PR TITLE
docs(release): document blocker for TestPyPI evidence promotion v0.3.0

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -20,6 +20,7 @@
 
 ## Meta (Docs Governance)
 - **Phase11-prep-1**: TestPyPI `0.3.0` の evidence 本体は未作成（template only / evidence pending: outbound access `HTTP 403`）。`docs/release/templates/testpypi_publish_log_template_v0.3.0.md` を追加した。
+- **Phase11-prep-2**: 2026-03-08 に TestPyPI evidence 昇格可否を再検証したが、`python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple po-core-flyingpig==0.3.0` は `ProxyError: Tunnel connection failed: 403 Forbidden` で失敗し、GitHub Actions workflow URL 取得（`curl -I -L https://github.com/hiroshitanaka-creator/Po_core/actions/workflows/publish.yml`）も `CONNECT tunnel failed, response 403` のため、evidence 本体は未作成のまま。
 - **Phase10-PR-1**: CHANGELOGのUnreleased項目を `0.3.0` release sectionへ切り出し、Unreleasedを空（No unreleased changes）に戻した。
 - **Phase9-PR-3**: deliberation scaling benchmark（`tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`）のしきい値を、実測（複数回計測で rounds=3 p50 が概ね 0.84–0.87s）に基づく根拠付き定数 `max(r1 * 4.0, 0.95)` へ見直し。scheduler/CI jitter によるフレークを抑えつつ、退行検知感度を維持。
 - **Phase9-PR-1**: pytest設定の単一真実化（pytest.ini）を完了。


### PR DESCRIPTION
### Motivation
- Re-validate whether the TestPyPI template for `v0.3.0` can be promoted to a fixed evidence file while strictly avoiding fabrication of remote artifacts when those artifacts cannot be observed.

### Description
- Added a `Phase11-prep-2` blocker entry to `docs/status.md` that records the failed remote attempts and states that `docs/release/testpypi_publish_log_v0.3.0.md` was not created, leaving the original template in place.

### Testing
- Ran `pytest -q` which completed successfully (`3549 passed, 134 skipped`); attempts to obtain remote evidence via `python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple po-core-flyingpig==0.3.0` failed with `ProxyError: Tunnel connection failed: 403 Forbidden` and `curl -I -L https://github.com/.../actions/workflows/publish.yml` failed with `CONNECT tunnel failed, response 403`, therefore remote evidence could not be obtained and was not recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4f5d4e288328baddb51db7cfe358)