### PR TITLE
fix(ci): align TypeScript SDK package version with Python 1.0.0

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@po-core/sdk",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "TypeScript client SDK for the Po_core philosophical reasoning API",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
### Motivation
- Fix CI/release inconsistencies caused by version drift where Python package `pyproject.toml` declares `1.0.0` while the TypeScript SDK `clients/typescript/package.json` remained `0.3.0`, which can break release/readiness and packaging checks.

### Description
- Synchronized only `clients/typescript/package.json` by updating the `version` field from `0.3.0` to `1.0.0`, without changing tests, golden files, schemas, or other workflow definitions.

### Testing
- Ran `pytest -q tests/test_release_readiness.py` which passed, regenerated OpenAPI (`PYTHONPATH=src python scripts/export_openapi.py`) and TS types (`python scripts/generate_ts_openapi_types.py`) which succeeded, built and tested the SDK (`cd clients/typescript && npm run build && npm run test`) which succeeded, and performed `cd clients/typescript && npm pack` which succeeded; `pip install -e .` failed in this environment due to proxy/build-dependency fetch restrictions but is unrelated to the version sync.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e8978c588328add6599759a4cdac)