### PR TITLE
Fix Black CI failures in config and test modules

### DIFF
--- a/src/po_core/app/rest/config.py
+++ b/src/po_core/app/rest/config.py
@@ -66,7 +66,6 @@ class APISettings(BaseSettings):
         validation_alias=AliasChoices("PO_LLM_TIMEOUT", "PO_LLM_TIMEOUT_S"),
     )
 
-
     # Philosopher selection tuning (limit + budget per SafetyMode)
     philosopher_cost_budget_normal: int = 80
     philosopher_cost_budget_warn: int = 12

--- a/tests/test_runtime_settings_philosopher_limits.py
+++ b/tests/test_runtime_settings_philosopher_limits.py
@@ -49,8 +49,12 @@ def test_raising_normal_limit_and_budget_increases_selection_count():
 
 
 def test_budget_control_is_effective_under_same_limit():
-    generous_budget = Settings(philosophers_max_normal=42, philosopher_cost_budget_normal=80)
-    tight_budget = Settings(philosophers_max_normal=42, philosopher_cost_budget_normal=20)
+    generous_budget = Settings(
+        philosophers_max_normal=42, philosopher_cost_budget_normal=80
+    )
+    tight_budget = Settings(
+        philosophers_max_normal=42, philosopher_cost_budget_normal=20
+    )
 
     generous_count = _selected_count_from_settings(generous_budget, SafetyMode.NORMAL)
     tight_count = _selected_count_from_settings(tight_budget, SafetyMode.NORMAL)

--- a/tests/unit/test_public_api_env_settings.py
+++ b/tests/unit/test_public_api_env_settings.py
@@ -26,7 +26,9 @@ def _stub_system():
 
 @pytest.mark.unit
 @pytest.mark.phase5
-def test_public_run_uses_settings_from_env_when_settings_is_none(monkeypatch, _stub_system):
+def test_public_run_uses_settings_from_env_when_settings_is_none(
+    monkeypatch, _stub_system
+):
     from po_core.app import api
 
     monkeypatch.setenv("PO_PHILOSOPHERS_MAX_NORMAL", "42")

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -254,7 +254,9 @@ def test_reason_passes_llm_settings_when_enabled(client_no_auth):
     app.dependency_overrides[auth.require_api_key] = lambda: None
     client = TestClient(app, raise_server_exceptions=True)
 
-    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT) as mock_run:
+    with patch(
+        "po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT
+    ) as mock_run:
         resp = client.post("/v1/reason", json={"input": "What is justice?"})
 
     assert resp.status_code == 200
@@ -270,7 +272,9 @@ def test_reason_passes_llm_settings_when_enabled(client_no_auth):
 @pytest.mark.phase5
 def test_reason_keeps_llm_settings_disabled_by_default(client_no_auth):
     """Reason endpoint keeps LLM integration disabled when API settings do not enable it."""
-    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT) as mock_run:
+    with patch(
+        "po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT
+    ) as mock_run:
         resp = client_no_auth.post("/v1/reason", json={"input": "What is justice?"})
 
     assert resp.status_code == 200
@@ -301,7 +305,9 @@ def test_reason_passes_philosopher_limits_and_budgets_from_api_settings(client_n
     app.dependency_overrides[auth.require_api_key] = lambda: None
     client = TestClient(app, raise_server_exceptions=True)
 
-    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT) as mock_run:
+    with patch(
+        "po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT
+    ) as mock_run:
         resp = client.post("/v1/reason", json={"input": "What is justice?"})
 
     assert resp.status_code == 200
@@ -827,7 +833,9 @@ def test_reason_endpoint_reflects_env_based_api_settings(monkeypatch, tmp_path):
     app.dependency_overrides[auth.require_api_key] = lambda: None
     client = TestClient(app, raise_server_exceptions=True)
 
-    with patch("po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT) as mock_run:
+    with patch(
+        "po_core.app.rest.routers.reason.po_run", return_value=_MOCK_RESULT
+    ) as mock_run:
         resp = client.post("/v1/reason", json={"input": "What is justice?"})
 
     assert resp.status_code == 200


### PR DESCRIPTION
### Motivation
- CI `black --check src tests` reported formatting violations in a small set of modules, causing the main pipeline to fail; this PR fixes those formatting issues without changing behavior.

### Description
- Applied `black` formatting to the four files flagged by CI: `src/po_core/app/rest/config.py`, `tests/test_runtime_settings_philosopher_limits.py`, `tests/unit/test_public_api_env_settings.py`, and `tests/unit/test_rest_api.py`, limited to line wrapping and blank-line normalization only.
- Adjusted multi-line call/site formatting (e.g. `with patch(...)` blocks and long `Settings(...)` instantiations) to conform to Black style while preserving semantics.

### Testing
- Ran `black --check src/po_core/app/rest/config.py tests/test_runtime_settings_philosopher_limits.py tests/unit/test_public_api_env_settings.py tests/unit/test_rest_api.py` and it reported no reformatting required after changes (passed).
- Ran `pytest -q tests/test_runtime_settings_philosopher_limits.py tests/unit/test_public_api_env_settings.py tests/unit/test_rest_api.py` and all tests passed (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42f7af8388328919a4d24c27c7aea)