### PR TITLE
Make LLM philosopher map path env-configurable and add fallback tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,10 @@ PO_LLM_PROVIDER=gemini
 # モデル指定（空=provider別デフォルト）
 # gemini: gemini-2.0-flash-lite / openai: gpt-4o-mini / claude: claude-haiku-4-5 / grok: grok-3-mini
 PO_LLM_MODEL=
+# 哲学者ごとの LLM provider/model マッピング YAML（空=デフォルト設定ファイルを使用）
+# デフォルト: src/po_core/config/llm_philosopher_map.yaml
+PO_LLM_PHILOSOPHER_MAP_PATH=
+
 # タイムアウト秒数
 PO_LLM_TIMEOUT=10.0
 

--- a/README.md
+++ b/README.md
@@ -477,12 +477,13 @@ Key environment variables (see `.env.example`):
 | `PO_CORS_ORIGINS` | `"*"` | Comma-separated allowed CORS origins |
 | `PO_RATE_LIMIT_PER_MINUTE` | `60` | Per-IP rate limit |
 | `PO_PORT` | `8000` | Server port |
-| `PO_PHILOSOPHERS_MAX_NORMAL` | `39` | NORMAL mode philosopher limit (raise to `42` for full roster) |
+| `PO_PHILOSOPHERS_MAX_NORMAL` | `39` | NORMAL mode philosopher limit (configurable; up to `42` for full roster) |
 | `PO_PHILOSOPHERS_MAX_WARN` | `5` | WARN mode philosopher limit |
 | `PO_PHILOSOPHERS_MAX_CRITICAL` | `1` | CRITICAL mode philosopher limit |
 | `PO_PHILOSOPHER_COST_BUDGET_NORMAL` | `80` | NORMAL mode selection cost budget |
 | `PO_PHILOSOPHER_COST_BUDGET_WARN` | `12` | WARN mode selection cost budget |
 | `PO_PHILOSOPHER_COST_BUDGET_CRITICAL` | `3` | CRITICAL mode selection cost budget |
+| `PO_LLM_PHILOSOPHER_MAP_PATH` | `""` | Optional YAML path overriding `src/po_core/config/llm_philosopher_map.yaml` |
 
 ---
 

--- a/src/po_core/app/rest/routers/reason.py
+++ b/src/po_core/app/rest/routers/reason.py
@@ -192,7 +192,7 @@ def _run_reasoning(
     summary="Synchronous philosophical reasoning",
     description=(
         "Submit a prompt for philosophical deliberation. "
-        "The 39-philosopher ensemble deliberates, passes through the "
+        "A configurable philosopher ensemble (up to 42) deliberates, passes through the "
         "W_Ethics Gate, and returns a synthesised response. "
         "Blocks until the full pipeline completes."
     ),

--- a/src/po_core/philosophers/llm_philosopher.py
+++ b/src/po_core/philosophers/llm_philosopher.py
@@ -21,6 +21,7 @@ LLM Philosopher — LLM API バックエンドを持つ哲学者基底クラス
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -37,11 +38,24 @@ if TYPE_CHECKING:
 _LLM_PHILOSOPHER_MAP_PATH = (
     Path(__file__).resolve().parent.parent / "config" / "llm_philosopher_map.yaml"
 )
+_LLM_PHILOSOPHER_MAP_ENV = "PO_LLM_PHILOSOPHER_MAP_PATH"
+
+
+def _resolve_llm_philosopher_map_path(path: Path | None = None) -> Path:
+    """Resolve map path from explicit arg, env var, or bundled default."""
+    if path is not None:
+        return path
+
+    override = os.getenv(_LLM_PHILOSOPHER_MAP_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+
+    return _LLM_PHILOSOPHER_MAP_PATH
 
 
 def _load_llm_philosopher_map(path: Path | None = None) -> dict[str, dict[str, str]]:
     """Load philosopher-specific LLM provider/model overrides from YAML."""
-    yaml_path = path or _LLM_PHILOSOPHER_MAP_PATH
+    yaml_path = _resolve_llm_philosopher_map_path(path)
     if not yaml_path.exists():
         return {}
 

--- a/tests/unit/test_llm_philosopher_registry.py
+++ b/tests/unit/test_llm_philosopher_registry.py
@@ -88,6 +88,51 @@ def test_load_llm_philosopher_map_returns_empty_for_malformed_yaml(tmp_path) -> 
     assert loaded == {}
 
 
+def test_load_llm_philosopher_map_uses_env_override_path(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mapping_file = tmp_path / "custom_map.yaml"
+    mapping_file.write_text(
+        """
+philosophers:
+  spinoza:
+    provider: openai
+    model: gpt-4o-mini
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", str(mapping_file))
+
+    loaded = _load_llm_philosopher_map()
+
+    assert loaded == {"spinoza": {"provider": "openai", "model": "gpt-4o-mini"}}
+
+
+def test_load_llm_philosopher_map_returns_empty_for_missing_env_override_path(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing = tmp_path / "missing_map.yaml"
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", str(missing))
+
+    loaded = _load_llm_philosopher_map()
+
+    assert loaded == {}
+
+
+def test_load_llm_philosopher_map_returns_empty_for_malformed_env_override_yaml(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mapping_file = tmp_path / "malformed_map.yaml"
+    mapping_file.write_text("philosophers: [invalid", encoding="utf-8")
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", str(mapping_file))
+
+    loaded = _load_llm_philosopher_map()
+
+    assert loaded == {}
+
 def test_build_registry_with_explicit_empty_map_does_not_read_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Enable deterministic, local-only switching of philosopher LLM provider/model mappings so experiments and dry-run checks can be performed without calling paid LLM APIs.
- Close observability/configuration gaps by allowing an environment override for the philosopher map path while preserving the existing safe fallback behavior.

### Description
- Add `PO_LLM_PHILOSOPHER_MAP_PATH` environment variable and resolution order `explicit arg → env override → bundled default` via `_resolve_llm_philosopher_map_path()` in `src/po_core/philosophers/llm_philosopher.py` and use it from `_load_llm_philosopher_map()`.
- Keep existing safe fallbacks so missing files, malformed YAML, or invalid payload shapes return an empty mapping `{}` as before.
- Document the new env var in `.env.example` and add the variable to the README environment table while clarifying the philosopher-count wording to "configurable (up to 42)" in the `/v1/reason` OpenAPI description in `src/po_core/app/rest/routers/reason.py`.
- Add unit tests in `tests/unit/test_llm_philosopher_registry.py` to verify env-path override, missing-path fallback, and malformed-YAML fallback.

### Testing
- Ran `pytest -q tests/unit/test_llm_philosopher_registry.py` and the tests in that file passed (`8 passed`).
- Ran the full suite with `pytest -q` and observed a successful run (`3702 passed, 4 skipped`), where the skipped tests are the live LLM integration tests skipped due to no API keys set (no paid API calls were made).
- Confirmed existing frozen/golden artifacts were not modified during these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a2bd4c5c8328a2275cfc76ab8276)