### PR TITLE
Add dry‑run E2E tests for LLM routing and enable LLM wiring in test system

### DIFF
--- a/src/po_core/runtime/wiring.py
+++ b/src/po_core/runtime/wiring.py
@@ -394,16 +394,33 @@ def build_test_system(settings: Settings | None = None) -> WiredSystem:
             )
 
     # PhilosopherRegistry (SafetyModeに応じた編成制御 + cost budget)
-    registry = PhilosopherRegistry(
-        max_normal=settings.philosophers_max_normal,
-        max_warn=settings.philosophers_max_warn,
-        max_critical=settings.philosophers_max_critical,
-        budget_normal=settings.philosopher_cost_budget_normal,
-        budget_warn=settings.philosopher_cost_budget_warn,
-        budget_critical=settings.philosopher_cost_budget_critical,
-        battalion_plans=battalion_plans,
-        required_roles=selected_roles,
-    )
+    if getattr(settings, "enable_llm_philosophers", False):
+        from po_core.adapters.llm_adapter import LLMAdapter
+        from po_core.philosophers.llm_philosopher import build_llm_philosopher_registry
+
+        llm_adapter = LLMAdapter.from_settings(settings)
+        registry = build_llm_philosopher_registry(
+            adapter=llm_adapter,
+            max_normal=settings.philosophers_max_normal,
+            max_warn=settings.philosophers_max_warn,
+            max_critical=settings.philosophers_max_critical,
+            budget_normal=settings.philosopher_cost_budget_normal,
+            budget_warn=settings.philosopher_cost_budget_warn,
+            budget_critical=settings.philosopher_cost_budget_critical,
+            battalion_plans=battalion_plans,
+            required_roles=selected_roles,
+        )
+    else:
+        registry = PhilosopherRegistry(
+            max_normal=settings.philosophers_max_normal,
+            max_warn=settings.philosophers_max_warn,
+            max_critical=settings.philosophers_max_critical,
+            budget_normal=settings.philosopher_cost_budget_normal,
+            budget_warn=settings.philosopher_cost_budget_warn,
+            budget_critical=settings.philosopher_cost_budget_critical,
+            battalion_plans=battalion_plans,
+            required_roles=selected_roles,
+        )
 
     return WiredSystem(
         memory_read=mem,

--- a/tests/unit/test_llm_dry_run_e2e.py
+++ b/tests/unit/test_llm_dry_run_e2e.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from po_core.adapters.llm_adapter import LLMAdapter
+from po_core.app.rest.config import APISettings
+from po_core.app.rest.server import create_app
+from po_core.runtime.settings import Settings
+
+
+@pytest.fixture
+def fake_llm_generate(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
+    calls: list[dict[str, str]] = []
+
+    def _fake_generate(self: LLMAdapter, system: str, user: str) -> str:
+        provider = self.provider.value
+        model = self.model
+        self.actual_model = model
+        calls.append(
+            {
+                "provider": provider,
+                "model": model,
+                "system": system,
+                "user": user,
+            }
+        )
+        return json.dumps(
+            {
+                "reasoning": f"[DRYRUN provider={provider} model={model}] {user}",
+                "perspective": "dry-run",
+                "confidence": 0.77,
+                "action_type": "answer",
+                "citations": [],
+            }
+        )
+
+    monkeypatch.setattr(LLMAdapter, "generate", _fake_generate)
+    return calls
+
+
+def _write_map_file(tmp_path) -> str:
+    map_file = tmp_path / "llm_map.yaml"
+    map_file.write_text(
+        """
+philosophers:
+  aristotle:
+    provider: openai
+    model: gpt-4o-mini
+  kant:
+    provider: openai
+    model: gpt-4o-mini
+  confucius:
+    provider: openai
+    model: gpt-4o-mini
+""".strip(),
+        encoding="utf-8",
+    )
+    return str(map_file)
+
+
+def _runtime_settings() -> Settings:
+    return Settings(
+        enable_llm_philosophers=True,
+        llm_provider="gemini",
+        philosophers_max_normal=5,
+        philosopher_cost_budget_normal=10,
+        freedom_pressure_warn=1.0,
+        freedom_pressure_critical=2.0,
+        philosopher_timeout_s_normal=30.0,
+        philosopher_workers_normal=1,
+        deliberation_max_rounds=1,
+    )
+
+
+def _disable_external_battalion_table(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("PO_CORE_BATTALION_TABLE", str(tmp_path / "missing_battalion.yaml"))
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_public_run_dry_run_e2e_uses_mapped_and_shared_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    fake_llm_generate: list[dict[str, str]],
+) -> None:
+    from po_core.app import api
+
+    _disable_external_battalion_table(monkeypatch, tmp_path)
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", _write_map_file(tmp_path))
+
+    result = api.run("dry run public api", settings=_runtime_settings())
+
+    providers = {call["provider"] for call in fake_llm_generate}
+
+    assert result["status"] in {"ok", "blocked", "fallback"}
+    assert fake_llm_generate
+    assert "openai" in providers
+    assert "gemini" in providers
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+@pytest.mark.asyncio
+async def test_public_async_run_dry_run_e2e_uses_mapped_and_shared_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    fake_llm_generate: list[dict[str, str]],
+) -> None:
+    from po_core.app import api
+
+    _disable_external_battalion_table(monkeypatch, tmp_path)
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", _write_map_file(tmp_path))
+
+    result = await api.async_run("dry run public api async", settings=_runtime_settings())
+
+    providers = {call["provider"] for call in fake_llm_generate}
+
+    assert result["status"] in {"ok", "blocked", "fallback"}
+    assert fake_llm_generate
+    assert "openai" in providers
+    assert "gemini" in providers
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_rest_reason_dry_run_e2e_records_fake_llm_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    fake_llm_generate: list[dict[str, str]],
+) -> None:
+    _disable_external_battalion_table(monkeypatch, tmp_path)
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", _write_map_file(tmp_path))
+
+    app = create_app(
+        APISettings(
+            skip_auth=True,
+            enable_llm_philosophers=True,
+            llm_provider="gemini",
+            philosophers_max_normal=5,
+            philosopher_cost_budget_normal=10,
+        )
+    )
+    from po_core.app.rest import auth
+
+    app.dependency_overrides[auth.require_api_key] = lambda: None
+    client = TestClient(app, raise_server_exceptions=True)
+
+    response = client.post("/v1/reason", json={"input": "dry run rest"})
+
+    providers = {call["provider"] for call in fake_llm_generate}
+
+    assert response.status_code == 200
+    assert fake_llm_generate
+    assert "openai" in providers
+    assert "gemini" in providers
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_public_run_dry_run_e2e_falls_back_to_shared_provider_on_malformed_map(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    fake_llm_generate: list[dict[str, str]],
+) -> None:
+    from po_core.app import api
+
+    _disable_external_battalion_table(monkeypatch, tmp_path)
+    malformed = tmp_path / "llm_map_malformed.yaml"
+    malformed.write_text("philosophers: [invalid", encoding="utf-8")
+    monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", str(malformed))
+
+    result = api.run("dry run malformed map", settings=_runtime_settings())
+
+    providers = {call["provider"] for call in fake_llm_generate}
+
+    assert result["status"] in {"ok", "blocked", "fallback"}
+    assert fake_llm_generate
+    assert providers == {"gemini"}


### PR DESCRIPTION
### Motivation
- Provide true end-to-end dry-run coverage for LLM routing / philosopher map override / shared fallback without calling paid APIs.  
- The existing public API env tests stubbed `build_test_system` and `run_turn`, so they did not exercise the real wiring for LLM routing.  
- Tests must be deterministic and non-networking while verifying that mapped providers and the shared fallback are actually invoked.  

### Description
- Added `tests/unit/test_llm_dry_run_e2e.py` which monkeypatches `LLMAdapter.generate` with a deterministic fake that records `provider/model/system/user` calls and returns a stable JSON payload for all dry‑run paths.  
- The new tests cover synchronous `po_core.app.api.run()`, asynchronous `po_core.app.api.async_run()`, and the REST `POST /v1/reason` endpoint, plus a malformed/missing map fallback case.  
- Minor production change in `src/po_core/runtime/wiring.py`: `build_test_system()` now mirrors `build_system()` when `settings.enable_llm_philosophers` is true by constructing an LLM adapter and using `build_llm_philosopher_registry`, so the public API paths use the same LLM wiring in test mode.  
- No golden/expected files were modified and no external API keys are used; the test-only fake prevents network/costly calls.  

### Testing
- Ran `pytest -q tests/unit/test_llm_dry_run_e2e.py` and observed `4 passed`.  
- Ran `pytest -q tests/unit/test_public_api_env_settings.py tests/unit/test_rest_api.py::test_reason_passes_llm_settings_when_enabled tests/unit/test_llm_philosopher_registry.py` and observed all selected checks passed (`11 passed`).  
- Tests validate only that at least one mapped provider call and at least one shared fallback call occur (call-recorder centric assertions) to avoid brittle exact-count expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a91c49d48328821d5c691b84e733)