### PR TITLE
Apply Black formatting to LLM unit tests

### DIFF
--- a/tests/unit/test_llm_dry_run_e2e.py
+++ b/tests/unit/test_llm_dry_run_e2e.py
@@ -75,8 +75,12 @@ def _runtime_settings() -> Settings:
     )
 
 
-def _disable_external_battalion_table(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    monkeypatch.setenv("PO_CORE_BATTALION_TABLE", str(tmp_path / "missing_battalion.yaml"))
+def _disable_external_battalion_table(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv(
+        "PO_CORE_BATTALION_TABLE", str(tmp_path / "missing_battalion.yaml")
+    )
 
 
 @pytest.mark.unit
@@ -114,7 +118,9 @@ async def test_public_async_run_dry_run_e2e_uses_mapped_and_shared_providers(
     _disable_external_battalion_table(monkeypatch, tmp_path)
     monkeypatch.setenv("PO_LLM_PHILOSOPHER_MAP_PATH", _write_map_file(tmp_path))
 
-    result = await api.async_run("dry run public api async", settings=_runtime_settings())
+    result = await api.async_run(
+        "dry run public api async", settings=_runtime_settings()
+    )
 
     providers = {call["provider"] for call in fake_llm_generate}
 

--- a/tests/unit/test_llm_philosopher_registry.py
+++ b/tests/unit/test_llm_philosopher_registry.py
@@ -133,6 +133,7 @@ def test_load_llm_philosopher_map_returns_empty_for_malformed_env_override_yaml(
 
     assert loaded == {}
 
+
 def test_build_registry_with_explicit_empty_map_does_not_read_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- CI `black --check src tests` was failing because two unit test files would be reformatted, so they need to be formatted to satisfy the repository Black policy and restore CI green.

### Description
- Applied Black formatting to `tests/unit/test_llm_dry_run_e2e.py` to normalize multiline argument and function signature line breaks.
- Applied Black formatting to `tests/unit/test_llm_philosopher_registry.py` to remove minor spacing/blank-line issues and align with Black style.
- These are formatting-only changes with no functional logic modifications and no changes to frozen golden files or behavior.

### Testing
- Ran `black --check tests/unit/test_llm_dry_run_e2e.py tests/unit/test_llm_philosopher_registry.py` and it reported the files as formatted (pass).
- Ran `pytest -q tests/unit/test_llm_dry_run_e2e.py tests/unit/test_llm_philosopher_registry.py` and the tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ae2d7c508328a5eda507d26190f2)