### PR TITLE
Fix Black CI formatting issues in reason router and ensemble

### DIFF
--- a/src/po_core/app/rest/routers/reason.py
+++ b/src/po_core/app/rest/routers/reason.py
@@ -110,12 +110,16 @@ def _extract_philosophers(result: dict) -> list[PhilosopherContribution]:
             continue
 
         name: str = str(p.get("philosopher_id") or p.get("name") or "unknown")
-        weight_raw = p.get("weight") if p.get("weight") is not None else p.get("score", 0.0)
+        weight_raw = (
+            p.get("weight") if p.get("weight") is not None else p.get("score", 0.0)
+        )
 
         normalized = p.get("normalized_response")
         normalized_dict = normalized if isinstance(normalized, dict) else {}
         normalized_meta = normalized_dict.get("metadata")
-        normalized_meta_dict = normalized_meta if isinstance(normalized_meta, dict) else {}
+        normalized_meta_dict = (
+            normalized_meta if isinstance(normalized_meta, dict) else {}
+        )
 
         proposal_meta = p.get("metadata")
         proposal_meta_dict = proposal_meta if isinstance(proposal_meta, dict) else {}
@@ -156,9 +160,7 @@ def _extract_philosophers(result: dict) -> list[PhilosopherContribution]:
                     bool(llm_fallback_val) if llm_fallback_val is not None else None
                 ),
                 fallback_reason=(
-                    str(fallback_reason)
-                    if fallback_reason not in (None, "")
-                    else None
+                    str(fallback_reason) if fallback_reason not in (None, "") else None
                 ),
             )
         )

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -459,7 +459,8 @@ def _run_phase_post(
                 p
                 for p in raw_proposals
                 if isinstance(p, DomainProposal)
-                and str((p.extra or {}).get("philosopher") or "") == result.philosopher_id
+                and str((p.extra or {}).get("philosopher") or "")
+                == result.philosopher_id
             ),
             None,
         )


### PR DESCRIPTION
### Motivation
- CI reported `black --check` failures for two files which caused the main workflow to fail. 

### Description
- Applied `black` formatting to `src/po_core/app/rest/routers/reason.py` and `src/po_core/ensemble.py` and adjusted line-wrapping/parentheses to satisfy the formatter. 
- No functional or behavioral logic changes were introduced; only whitespace and wrapping were modified.

### Testing
- Ran `black --check src/po_core/app/rest/routers/reason.py src/po_core/ensemble.py` and it passed. 
- Ran `python -m py_compile src/po_core/app/rest/routers/reason.py src/po_core/ensemble.py` and it passed. 
- Ran `black --check src tests` which still reports additional unrelated formatting diffs in other files (`src/po_core/app/rest/store.py`, `src/po_core/cli/experiment.py`), so repository-wide formatting remains outstanding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4bd829ebc832890c2e1a1b2381c4a)