### PR TITLE
Fix Black formatting issues reported by CI

### DIFF
--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -100,13 +100,16 @@ class SQLiteTraceStore(TraceStore):
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            conn.execute("""
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS trace_sessions (
                     session_id TEXT PRIMARY KEY,
                     updated_at TEXT NOT NULL
                 )
-                """)
-            conn.execute("""
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS trace_events (
                     session_id TEXT NOT NULL,
                     event_idx INTEGER NOT NULL,
@@ -116,7 +119,8 @@ class SQLiteTraceStore(TraceStore):
                     payload_json TEXT NOT NULL,
                     PRIMARY KEY (session_id, event_idx)
                 )
-                """)
+                """
+            )
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_trace_events_session ON trace_events(session_id)"
             )
@@ -196,11 +200,13 @@ class SQLiteTraceStore(TraceStore):
     def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
         if max_sessions <= 0:
             return
-        rows = conn.execute("""
+        rows = conn.execute(
+            """
             SELECT session_id
             FROM trace_sessions
             ORDER BY updated_at DESC
-            """).fetchall()
+            """
+        ).fetchall()
         stale_session_ids = [row["session_id"] for row in rows[max_sessions:]]
         if stale_session_ids:
             conn.executemany(

--- a/src/po_core/cli/experiment.py
+++ b/src/po_core/cli/experiment.py
@@ -29,7 +29,8 @@ from po_core.experiments.storage import ExperimentStorage
 
 def _print_help() -> None:
     """ヘルプメッセージを表示"""
-    print("""
+    print(
+        """
 Po_core Experiment CLI
 
 Usage:
@@ -43,7 +44,8 @@ Commands:
     analyze      Analyze experiment results
     promote      Promote winner to main (if recommendation is 'promote')
     rollback     Rollback to previous backup
-""")
+"""
+    )
 
 
 def cmd_list() -> None:

--- a/tests/unit/test_llm_dry_run_e2e.py
+++ b/tests/unit/test_llm_dry_run_e2e.py
@@ -295,7 +295,9 @@ def test_rest_stream_sse_dry_run_exposes_llm_routing_observability(
     assert any("llm_provider" in payload for payload in philosopher_payloads)
     assert any("llm_model" in payload for payload in philosopher_payloads)
 
-    result_chunk = next(chunk for chunk in chunks if chunk.get("chunk_type") == "result")
+    result_chunk = next(
+        chunk for chunk in chunks if chunk.get("chunk_type") == "result"
+    )
     philosophers = result_chunk.get("payload", {}).get("philosophers", [])
     assert philosophers
     assert any(p.get("provider") for p in philosophers)
@@ -343,7 +345,9 @@ def test_rest_ws_dry_run_exposes_llm_routing_observability(
     assert any("llm_provider" in payload for payload in philosopher_payloads)
     assert any("llm_model" in payload for payload in philosopher_payloads)
 
-    result_chunk = next(chunk for chunk in chunks if chunk.get("chunk_type") == "result")
+    result_chunk = next(
+        chunk for chunk in chunks if chunk.get("chunk_type") == "result"
+    )
     philosophers = result_chunk.get("payload", {}).get("philosophers", [])
     assert philosophers
     assert any(p.get("provider") for p in philosophers)
@@ -352,8 +356,6 @@ def test_rest_ws_dry_run_exposes_llm_routing_observability(
     recorder_providers = {call["provider"] for call in fake_llm_generate}
     assert "openai" in recorder_providers
     assert "gemini" in recorder_providers
-
-
 
 
 @pytest.mark.unit
@@ -395,13 +397,14 @@ def test_rest_stream_sse_dry_run_exposes_llm_fallback_observability(
         for payload in philosopher_payloads
     )
 
-    result_chunk = next(chunk for chunk in chunks if chunk.get("chunk_type") == "result")
+    result_chunk = next(
+        chunk for chunk in chunks if chunk.get("chunk_type") == "result"
+    )
     philosophers = result_chunk.get("payload", {}).get("philosophers", [])
     assert philosophers
     assert any(p.get("llm_fallback") is True for p in philosophers)
     assert any(
-        p.get("llm_fallback") is True
-        and p.get("fallback_reason") == "llm_unavailable"
+        p.get("llm_fallback") is True and p.get("fallback_reason") == "llm_unavailable"
         for p in philosophers
     )
 
@@ -448,13 +451,14 @@ def test_rest_ws_dry_run_exposes_llm_fallback_observability(
         for payload in philosopher_payloads
     )
 
-    result_chunk = next(chunk for chunk in chunks if chunk.get("chunk_type") == "result")
+    result_chunk = next(
+        chunk for chunk in chunks if chunk.get("chunk_type") == "result"
+    )
     philosophers = result_chunk.get("payload", {}).get("philosophers", [])
     assert philosophers
     assert any(p.get("llm_fallback") is True for p in philosophers)
     assert any(
-        p.get("llm_fallback") is True
-        and p.get("fallback_reason") == "llm_unavailable"
+        p.get("llm_fallback") is True and p.get("fallback_reason") == "llm_unavailable"
         for p in philosophers
     )
 
@@ -491,12 +495,12 @@ def test_rest_stream_sse_dry_run_uses_shared_fallback_on_malformed_map(
     ]
     assert philosopher_events
 
-    result_chunk = next(chunk for chunk in chunks if chunk.get("chunk_type") == "result")
+    result_chunk = next(
+        chunk for chunk in chunks if chunk.get("chunk_type") == "result"
+    )
     philosophers = result_chunk.get("payload", {}).get("philosophers", [])
     assert philosophers
-    assert {p.get("provider") for p in philosophers if p.get("provider")} == {
-        "gemini"
-    }
+    assert {p.get("provider") for p in philosophers if p.get("provider")} == {"gemini"}
 
     recorder_providers = {call["provider"] for call in fake_llm_generate}
     assert recorder_providers == {"gemini"}


### PR DESCRIPTION
### Motivation
- CI was failing `black --check` due to formatting violations and needs a formatting-only fix to restore the style gate.
- Keep changes strictly formatting-only to avoid behavioural regressions and preserve frozen golden files and determinism contracts.

### Description
- Reformatted `tests/unit/test_llm_dry_run_e2e.py` to satisfy Black line-wrapping and blank-line rules around long `next(...)` and assertion expressions without changing test logic.
- Reformatted `src/po_core/app/rest/store.py` to normalize multi-line SQL string callsites and method call wrapping to Black style without altering SQL content or behavior.
- Reformatted `src/po_core/cli/experiment.py` to adjust the multi-line `print` help block to Black style and made no semantic changes.
- No golden files or schema files were modified and no runtime logic was changed.

### Testing
- Ran `black --check src tests`, which now passes.
- Ran the full test suite with `pytest -q`, which produced `1 failed, 3711 passed, 4 skipped` and the single failing test is unrelated to formatting: `tests/acceptance/test_m3_acceptance.py::TestTwoTrackPlan::test_action_plan_has_track_labels`.
- No additional automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4d4d5ddd08328b1a0240306692147)