### PR TITLE
Add X Runway pack generator, badge SVGs, templates, and Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -438,3 +438,9 @@ visualization_outputs*/
 !docs/paper/benchmarks/results/comparative_results.json
 !docs/paper/benchmarks/results/comparative_table.csv
 
+
+# X runway local generated binaries
+assets/*.gif
+assets/*.png
+assets/*.jpg
+assets/*.jpeg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: paper-experiments paper-benchmark paper-pdf paper-build
+.PHONY: paper-experiments paper-benchmark paper-pdf paper-build x-assets x-pack x-pack-all x-metrics-init
 
 paper-experiments:
 	python scripts/paper/generate_experiment_snapshot.py
@@ -10,3 +10,26 @@ paper-pdf:
 	python scripts/paper/build_paper_pdf.py
 
 paper-build: paper-experiments paper-benchmark paper-pdf
+
+x-assets:
+	python tools/demo_shopping.py
+	python tools/generate_badge.py runs/high_bias_affiliate.badge.json --out runs/high_bias_affiliate.badge.svg
+	python tools/generate_badge.py runs/mixed_contaminated.badge.json --out runs/mixed_contaminated.badge.svg
+	python tools/generate_badge.py runs/clean_multi_merchant.badge.json --out runs/clean_multi_merchant.badge.svg
+	python assets/flying_pig_anim.py
+
+x-pack:
+	@if [ -z "$(CASE)" ]; then echo "CASE is required. e.g. make x-pack CASE=high_bias_affiliate"; exit 1; fi
+	python tools/build_x_pack.py --case $(CASE) --repo-url https://github.com/hiroshitanaka-creator/project-echo --out-dir dist/x
+
+x-pack-all:
+	python tools/build_x_pack.py --all --repo-url https://github.com/hiroshitanaka-creator/project-echo --out-dir dist/x
+
+x-metrics-init:
+	@mkdir -p ops
+	@if [ ! -f ops/x_metrics.csv ]; then \
+		echo "date,case,angle,post_url,impressions,engagements,bookmarks,profile_visits,link_clicks,github_stars_before,github_stars_after" > ops/x_metrics.csv; \
+		echo "initialized ops/x_metrics.csv"; \
+	else \
+		echo "ops/x_metrics.csv already exists"; \
+	fi

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ pip install po-core-flyingpig
 - その結果を golden（期待JSON）へ固定し、CI（`pytest -q`）で契約を検証する。
 - 凍結golden `scenarios/case_001_expected.json` / `scenarios/case_009_expected.json` は変更禁止。
 
+
+## X Runway (manual distribution pack)
+
+X Runway は、X API や自動投稿を使わずに、手動投稿の効果検証を行うためのローカル配信パック生成機能です。
+`demo-shopping` 由来の audit/badge データを元に、thread 文面・checklist・meta・画像カードをケースごとに出力します。
+
+```bash
+make x-assets
+make x-pack CASE=high_bias_affiliate
+make x-pack-all
+make x-metrics-init
+```
+
+生成例: `dist/x/high_bias_affiliate/thread.md`, `dist/x/high_bias_affiliate/meta.json`, `dist/x/high_bias_affiliate/checklist.md`
+
 ## Contribution Tracks
 
 ### <a id="ai-track"></a> AI Track

--- a/assets/flying_pig_anim.py
+++ b/assets/flying_pig_anim.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    out = Path(__file__).with_name("pig_flying.gif")
+    try:
+        from PIL import Image, ImageDraw
+
+        frames = []
+        for i in range(4):
+            frame = Image.new("RGB", (220, 120), (20, 30, 60))
+            draw = ImageDraw.Draw(frame)
+            draw.text((20 + i * 8, 40), "🐷=>", fill=(255, 220, 220))
+            frames.append(frame)
+        frames[0].save(
+            out,
+            save_all=True,
+            append_images=frames[1:],
+            duration=160,
+            loop=0,
+            format="GIF",
+        )
+    except Exception:
+        # 1x1 transparent GIF fallback
+        out.write_bytes(
+            b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+        )
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/content/templates/x_checklist.md.tmpl
+++ b/content/templates/x_checklist.md.tmpl
@@ -1,0 +1,7 @@
+# X投稿チェックリスト（{{case}}）
+
+- [ ] card.png を確認した
+- [ ] thread.md を確認した
+- [ ] repo_url ({{repo_url}}) を確認した
+- [ ] `{{verify_command}}` を確認した
+- [ ] 投稿後に URL を ops/x_metrics.csv に記録した

--- a/content/templates/x_thread_blocked.md.tmpl
+++ b/content/templates/x_thread_blocked.md.tmpl
@@ -1,0 +1,24 @@
+## Post 1
+{{headline}}
+
+{{hook}}
+
+Case: {{case}} / Label: {{label}} {{pig_state}}
+
+## Post 2
+Bias: {{bias_original}} -> {{bias_final}}
+Execution: {{execution_allowed}}
+Human confirm: {{requires_human_confirm}}
+
+Reasons:
+{{reasons}}
+
+## Post 3
+停止判断の根拠は audit + badge で再現できます。
+
+Verify: `{{verify_command}}`
+Repo: {{repo_url}}
+
+## Post 4
+{{cta}}
+{{tags}}

--- a/content/templates/x_thread_check.md.tmpl
+++ b/content/templates/x_thread_check.md.tmpl
@@ -1,0 +1,26 @@
+## Post 1
+{{headline}}
+
+{{hook}}
+
+Case: {{case}} / Label: {{label}} {{pig_state}}
+
+## Post 2
+CHECKは「自動実行せず、人間確認へ退避する」ための状態です。
+Bias: {{bias_original}} -> {{bias_final}}
+Execution: {{execution_allowed}}
+Human confirm: {{requires_human_confirm}}
+
+## Post 3
+責任境界を明示:
+- 自動系: 候補整理まで
+- 人間: 最終判断
+
+Reasons:
+{{reasons}}
+
+## Post 4
+Verify: `{{verify_command}}`
+Repo: {{repo_url}}
+{{cta}}
+{{tags}}

--- a/content/templates/x_thread_verified.md.tmpl
+++ b/content/templates/x_thread_verified.md.tmpl
@@ -1,0 +1,24 @@
+## Post 1
+{{headline}}
+
+{{hook}}
+
+Case: {{case}} / Label: {{label}} {{pig_state}}
+
+## Post 2
+VERIFIEDは「候補セットの健全性が高い」状態です。
+ただし正解を断定する推薦ではありません。
+
+Bias: {{bias_original}} -> {{bias_final}}
+Execution: {{execution_allowed}}
+
+## Post 3
+証拠と責任境界:
+{{reasons}}
+
+Verify: `{{verify_command}}`
+Repo: {{repo_url}}
+
+## Post 4
+{{cta}}
+{{tags}}

--- a/docs/X_RUNWAY.md
+++ b/docs/X_RUNWAY.md
@@ -1,0 +1,37 @@
+# X Runway
+
+X Runway の目的は「自動拡散」ではなく、手動投稿で仮説検証するための配信パックをローカル生成することです。
+X API / ブラウザ拡張 / 外部SaaS 連携は扱いません。
+
+## 使い方
+
+```bash
+make x-assets
+make x-pack CASE=high_bias_affiliate
+make x-pack-all
+make x-metrics-init
+```
+
+## 2週間の手動投稿プロトコル
+
+1. `dist/x/<case>/thread.md` を手動で投稿（3〜4ポスト）。
+2. 投稿URLと指標を `ops/x_metrics.csv` に追記。
+3. 2週間で 3ケース × 3角度（BLOCKED/CHECK/VERIFIED）を回す。
+4. 毎日同じ時間帯で比較し、文面以外の変数をなるべく固定する。
+
+## 観測指標
+
+- impressions
+- engagement rate
+- bookmarks
+- profile visits
+- link clicks
+- GitHub stars 増分
+
+## 暫定 Go / No-Go 基準
+
+- median impressions >= 2000
+- engagement rate >= 3%
+- link_clicks / impressions >= 1%
+- GitHub star conversion >= 5%
+- 「使ってみたい」等の明確反応が 5件以上

--- a/src/po_echo/__init__.py
+++ b/src/po_echo/__init__.py
@@ -1,0 +1,1 @@
+"""Project Echo helper modules."""

--- a/src/po_echo/badge_style.py
+++ b/src/po_echo/badge_style.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+LABEL_CONFIG: dict[str, dict[str, str]] = {
+    "ECHO_BLOCKED": {
+        "display": "ECHO BLOCKED",
+        "bg": "#3A1111",
+        "fg": "#FFD9D9",
+        "accent": "#FF5A5A",
+    },
+    "ECHO_CHECK": {
+        "display": "ECHO CHECK",
+        "bg": "#2F2910",
+        "fg": "#FFF5CC",
+        "accent": "#F6C343",
+    },
+    "ECHO_VERIFIED": {
+        "display": "ECHO VERIFIED",
+        "bg": "#102C1E",
+        "fg": "#D8FFE9",
+        "accent": "#45D483",
+    },
+}
+
+PIG_STATE_BY_LABEL: dict[str, str] = {
+    "ECHO_BLOCKED": "🐷💥",
+    "ECHO_CHECK": "🐷⚠️",
+    "ECHO_VERIFIED": "🐷🌈",
+}
+
+PIG_MESSAGE_BY_LABEL: dict[str, str] = {
+    "ECHO_BLOCKED": "Risk signal detected. Stop execution.",
+    "ECHO_CHECK": "Need human confirmation before acting.",
+    "ECHO_VERIFIED": "Candidate set is ready with clear boundaries.",
+}
+
+
+def normalize_label(label: str) -> str:
+    normalized = (label or "").strip().replace("-", "_").upper()
+    if not normalized.startswith("ECHO_") and normalized in {"BLOCKED", "CHECK", "VERIFIED"}:
+        normalized = f"ECHO_{normalized}"
+    if normalized not in LABEL_CONFIG:
+        raise ValueError(
+            f"Unsupported label '{label}'. Expected one of: {', '.join(LABEL_CONFIG)}"
+        )
+    return normalized
+
+
+def get_label_config(label: str) -> dict[str, Any]:
+    key = normalize_label(label)
+    return {
+        "label": key,
+        **LABEL_CONFIG[key],
+        "pig_state": PIG_STATE_BY_LABEL[key],
+        "pig_message": PIG_MESSAGE_BY_LABEL[key],
+    }

--- a/src/po_echo/badge_svg.py
+++ b/src/po_echo/badge_svg.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from po_echo.badge_style import get_label_config
+
+
+def generate_svg(badge: dict) -> str:
+    config = get_label_config(str(badge.get("label", "")))
+    case = str(badge.get("case", "unknown_case"))
+    bias_original = float(badge.get("bias_original", 0.0))
+    bias_final = float(badge.get("bias_final", 0.0))
+    execution = "allowed" if badge.get("execution_allowed", False) else "blocked"
+    reasons = badge.get("reasons", [])[:3]
+    reason_lines = "".join(
+        f'<text x="48" y="{340 + i * 36}" fill="{config["fg"]}" font-size="24">- {reason}</text>'
+        for i, reason in enumerate(reasons)
+    )
+
+    return f"""<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1200\" height=\"630\" viewBox=\"0 0 1200 630\">
+  <rect width=\"1200\" height=\"630\" fill=\"{config['bg']}\"/>
+  <rect x=\"38\" y=\"38\" width=\"1124\" height=\"554\" rx=\"24\" fill=\"none\" stroke=\"{config['accent']}\" stroke-width=\"4\"/>
+  <text x=\"48\" y=\"96\" fill=\"{config['fg']}\" font-size=\"40\" font-family=\"Arial, sans-serif\">Project Echo</text>
+  <text x=\"48\" y=\"150\" fill=\"{config['accent']}\" font-size=\"56\" font-weight=\"700\" font-family=\"Arial, sans-serif\">{config['display']}</text>
+  <text x=\"48\" y=\"200\" fill=\"{config['fg']}\" font-size=\"30\" font-family=\"Arial, sans-serif\">{config['pig_state']}  case: {case}</text>
+  <text x=\"48\" y=\"250\" fill=\"{config['fg']}\" font-size=\"28\" font-family=\"Arial, sans-serif\">Bias: {bias_original:.2f} -&gt; {bias_final:.2f}</text>
+  <text x=\"48\" y=\"290\" fill=\"{config['fg']}\" font-size=\"28\" font-family=\"Arial, sans-serif\">Execution: {execution}</text>
+  {reason_lines}
+</svg>
+"""
+
+
+def write_svg(badge: dict, out_path: Path) -> Path:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(generate_svg(badge), encoding="utf-8")
+    return out_path

--- a/tests/test_badge_style.py
+++ b/tests/test_badge_style.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from po_echo.badge_style import get_label_config, normalize_label
+
+
+def test_normalize_label_aliases() -> None:
+    assert normalize_label("blocked") == "ECHO_BLOCKED"
+    assert normalize_label("echo_check") == "ECHO_CHECK"
+
+
+def test_get_label_config_contains_required_fields() -> None:
+    config = get_label_config("ECHO_VERIFIED")
+    assert config["display"] == "ECHO VERIFIED"
+    assert config["pig_state"] == "🐷🌈"
+
+
+def test_normalize_label_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        normalize_label("something_else")

--- a/tests/test_build_x_pack.py
+++ b/tests/test_build_x_pack.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.build_x_pack import (
+    render_thread_variants,
+    summarize_case,
+    write_pack,
+)
+from po_echo.badge_svg import write_svg
+
+
+def _demo_data() -> dict:
+    return {
+        "badge": {
+            "case": "high_bias_affiliate",
+            "label": "ECHO_BLOCKED",
+            "bias_original": 0.9,
+            "bias_final": 0.3,
+            "execution_allowed": False,
+            "requires_human_confirm": True,
+            "reasons": ["r1", "r2"],
+        },
+        "audit": {"verify_command": "po-cosmic verify runs/high_bias_affiliate.badge.json"},
+        "content": {
+            "headline": "h",
+            "hook": "k",
+            "cta": "c",
+            "tags": ["#AI"],
+        },
+    }
+
+
+def test_thread_variant_selection_matches_actual_label(tmp_path: Path) -> None:
+    data = _demo_data()
+    summary = summarize_case("high_bias_affiliate", data, "https://example.com/repo")
+    variants = render_thread_variants(summary, data["content"])
+    out = write_pack(
+        "high_bias_affiliate",
+        summary,
+        data["badge"],
+        variants,
+        "checklist",
+        tmp_path,
+        font_path=None,
+        skip_card=True,
+        copy_assets=False,
+    )
+    assert (out / "thread.md").read_text(encoding="utf-8") == variants["thread.blocked.md"]
+
+
+def test_meta_json_generation(tmp_path: Path) -> None:
+    data = _demo_data()
+    summary = summarize_case("high_bias_affiliate", data, "https://example.com/repo")
+    variants = render_thread_variants(summary, data["content"])
+    out = write_pack(
+        "high_bias_affiliate",
+        summary,
+        data["badge"],
+        variants,
+        "checklist",
+        tmp_path,
+        font_path=None,
+        skip_card=True,
+        copy_assets=False,
+    )
+    meta = json.loads((out / "meta.json").read_text(encoding="utf-8"))
+    assert meta["actual_label"] == "ECHO_BLOCKED"
+    assert meta["verify_command"].startswith("po-cosmic verify")
+
+
+def test_skip_card_pack_generation(tmp_path: Path) -> None:
+    data = _demo_data()
+    summary = summarize_case("high_bias_affiliate", data, "https://example.com/repo")
+    variants = render_thread_variants(summary, data["content"])
+    out = write_pack(
+        "high_bias_affiliate",
+        summary,
+        data["badge"],
+        variants,
+        "checklist",
+        tmp_path,
+        font_path=None,
+        skip_card=True,
+        copy_assets=False,
+    )
+    assert (out / "thread.check.md").exists()
+    assert not (out / "card.png").exists()
+
+
+def test_badge_svg_generation_from_badge_json(tmp_path: Path) -> None:
+    badge = _demo_data()["badge"]
+    out = tmp_path / "badge.svg"
+    write_svg(badge, out)
+    text = out.read_text(encoding="utf-8")
+    assert "ECHO BLOCKED" in text

--- a/tools/build_x_pack.py
+++ b/tools/build_x_pack.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+CASES = ["high_bias_affiliate", "mixed_contaminated", "clean_multi_merchant"]
+THREAD_BY_LABEL = {
+    "ECHO_BLOCKED": "thread.blocked.md",
+    "ECHO_CHECK": "thread.check.md",
+    "ECHO_VERIFIED": "thread.verified.md",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build X runway distribution pack")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--case", choices=CASES)
+    g.add_argument("--all", action="store_true")
+    p.add_argument("--repo-url", required=True)
+    p.add_argument("--out-dir", type=Path, default=Path("dist/x"))
+    p.add_argument("--font-path", type=Path, default=None)
+    p.add_argument("--skip-card", action="store_true")
+    p.add_argument("--copy-assets", dest="copy_assets", action="store_true", default=True)
+    p.add_argument("--no-copy-assets", dest="copy_assets", action="store_false")
+    return p.parse_args()
+
+
+def load_case_inputs(case: str) -> dict[str, Any]:
+    badge_path = ROOT / "runs" / f"{case}.badge.json"
+    audit_path = ROOT / "runs" / f"{case}.audit.json"
+    content_path = ROOT / "content" / "x_cases" / f"{case}.json"
+    missing = [str(p) for p in [badge_path, audit_path, content_path] if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "Missing required inputs: " + ", ".join(missing) + ". Try `make x-assets` first."
+        )
+    return {
+        "badge": json.loads(badge_path.read_text(encoding="utf-8")),
+        "audit": json.loads(audit_path.read_text(encoding="utf-8")),
+        "content": json.loads(content_path.read_text(encoding="utf-8")),
+    }
+
+
+def summarize_case(case: str, data: dict[str, Any], repo_url: str) -> dict[str, Any]:
+    badge = data["badge"]
+    from po_echo.badge_style import PIG_STATE_BY_LABEL, normalize_label
+
+    label = normalize_label(str(badge.get("label", "")))
+    verify_command = data["audit"].get(
+        "verify_command", f"po-cosmic verify runs/{case}.badge.json"
+    )
+    return {
+        "case": case,
+        "actual_label": label,
+        "available_thread_variants": [
+            "thread.blocked.md",
+            "thread.check.md",
+            "thread.verified.md",
+        ],
+        "pig_state": PIG_STATE_BY_LABEL[label],
+        "bias_original": float(badge.get("bias_original", 0.0)),
+        "bias_final": float(badge.get("bias_final", 0.0)),
+        "execution_allowed": bool(badge.get("execution_allowed", False)),
+        "requires_human_confirm": bool(badge.get("requires_human_confirm", False)),
+        "reasons": list(badge.get("reasons", [])),
+        "repo_url": repo_url,
+        "verify_command": str(verify_command),
+    }
+
+
+def _render_template(template_path: Path, context: dict[str, str]) -> str:
+    text = template_path.read_text(encoding="utf-8")
+    for key, value in context.items():
+        text = text.replace(f"{{{{{key}}}}}", value)
+    return text
+
+
+def render_thread_variants(summary: dict[str, Any], content: dict[str, Any]) -> dict[str, str]:
+    reasons = "\n".join(f"- {item}" for item in summary["reasons"])
+    context = {
+        "case": summary["case"],
+        "headline": content["headline"],
+        "hook": content["hook"],
+        "cta": content["cta"],
+        "label": summary["actual_label"],
+        "pig_state": summary["pig_state"],
+        "bias_original": f"{summary['bias_original']:.2f}",
+        "bias_final": f"{summary['bias_final']:.2f}",
+        "execution_allowed": "allowed" if summary["execution_allowed"] else "blocked",
+        "requires_human_confirm": "yes" if summary["requires_human_confirm"] else "no",
+        "reasons": reasons,
+        "repo_url": summary["repo_url"],
+        "verify_command": summary["verify_command"],
+        "tags": " ".join(content.get("tags", [])),
+    }
+    templates = {
+        "thread.blocked.md": ROOT / "content" / "templates" / "x_thread_blocked.md.tmpl",
+        "thread.check.md": ROOT / "content" / "templates" / "x_thread_check.md.tmpl",
+        "thread.verified.md": ROOT / "content" / "templates" / "x_thread_verified.md.tmpl",
+    }
+    return {name: _render_template(path, context) for name, path in templates.items()}
+
+
+def render_checklist(summary: dict[str, Any]) -> str:
+    return _render_template(
+        ROOT / "content" / "templates" / "x_checklist.md.tmpl",
+        {
+            "case": summary["case"],
+            "repo_url": summary["repo_url"],
+            "verify_command": summary["verify_command"],
+        },
+    )
+
+
+def render_card_png(summary: dict[str, Any], out_path: Path, font_path: Path | None = None) -> None:
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except Exception as exc:
+        raise RuntimeError(
+            "Pillow is required for card generation. Use --skip-card to continue without image output."
+        ) from exc
+
+    from po_echo.badge_style import get_label_config
+
+    cfg = get_label_config(summary["actual_label"])
+    img = Image.new("RGB", (1600, 900), cfg["bg"])
+    draw = ImageDraw.Draw(img)
+
+    def _font(size: int):
+        if font_path:
+            try:
+                return ImageFont.truetype(str(font_path), size)
+            except Exception:
+                pass
+        return ImageFont.load_default()
+
+    draw.text((60, 60), "Project Echo", fill=cfg["fg"], font=_font(60))
+    draw.text((60, 130), cfg["display"], fill=cfg["accent"], font=_font(76))
+    draw.text((60, 220), summary["pig_state"], fill=cfg["fg"], font=_font(64))
+    draw.text(
+        (60, 300),
+        f"Bias: {summary['bias_original']:.2f} -> {summary['bias_final']:.2f}",
+        fill=cfg["fg"],
+        font=_font(44),
+    )
+    exec_label = "allowed" if summary["execution_allowed"] else "blocked"
+    draw.text((60, 360), f"Execution: {exec_label}", fill=cfg["fg"], font=_font(44))
+    for i, reason in enumerate(summary["reasons"][:3]):
+        draw.text((60, 430 + i * 54), f"- {reason}", fill=cfg["fg"], font=_font(34))
+    draw.text((60, 800), "GitHub: project-echo", fill=cfg["fg"], font=_font(30))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path)
+
+
+def _prepare_badge_svg(case: str, badge: dict[str, Any], out_path: Path) -> None:
+    from po_echo.badge_svg import write_svg
+
+    src = ROOT / "runs" / f"{case}.badge.svg"
+    if src.exists():
+        shutil.copy2(src, out_path)
+    else:
+        write_svg(badge, out_path)
+
+
+def write_pack(
+    case: str,
+    summary: dict[str, Any],
+    badge: dict[str, Any],
+    thread_variants: dict[str, str],
+    checklist: str,
+    out_dir: Path,
+    font_path: Path | None,
+    skip_card: bool,
+    copy_assets: bool,
+) -> Path:
+    case_dir = out_dir / case
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename, text in thread_variants.items():
+        (case_dir / filename).write_text(text, encoding="utf-8")
+    active = THREAD_BY_LABEL[summary["actual_label"]]
+    (case_dir / "thread.md").write_text(thread_variants[active], encoding="utf-8")
+    (case_dir / "checklist.md").write_text(checklist, encoding="utf-8")
+    (case_dir / "meta.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+    if not skip_card:
+        render_card_png(summary, case_dir / "card.png", font_path=font_path)
+
+    if copy_assets:
+        _prepare_badge_svg(case, badge, case_dir / "badge.svg")
+        gif = ROOT / "assets" / "pig_flying.gif"
+        if gif.exists():
+            shutil.copy2(gif, case_dir / "pig_flying.gif")
+    return case_dir
+
+
+def main() -> int:
+    args = parse_args()
+    targets = CASES if args.all else [args.case]
+    for case in targets:
+        data = load_case_inputs(case)
+        summary = summarize_case(case, data, args.repo_url)
+        threads = render_thread_variants(summary, data["content"])
+        checklist = render_checklist(summary)
+        path = write_pack(
+            case,
+            summary,
+            data["badge"],
+            threads,
+            checklist,
+            args.out_dir,
+            args.font_path,
+            args.skip_card,
+            args.copy_assets,
+        )
+        print(f"generated: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/demo_shopping.py
+++ b/tools/demo_shopping.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+CASES = {
+    "high_bias_affiliate": {
+        "label": "ECHO_BLOCKED",
+        "bias_original": 0.91,
+        "bias_final": 0.27,
+        "execution_allowed": False,
+        "requires_human_confirm": True,
+        "reasons": [
+            "single affiliate source dominates evidence",
+            "ad-like phrasing detected in candidate summaries",
+            "insufficient independent merchant signals",
+        ],
+    },
+    "mixed_contaminated": {
+        "label": "ECHO_CHECK",
+        "bias_original": 0.62,
+        "bias_final": 0.41,
+        "execution_allowed": False,
+        "requires_human_confirm": True,
+        "reasons": [
+            "some contamination removed but uncertainty remains",
+            "merchant metadata has partial gaps",
+            "human confirmation required for accountability",
+        ],
+    },
+    "clean_multi_merchant": {
+        "label": "ECHO_VERIFIED",
+        "bias_original": 0.33,
+        "bias_final": 0.12,
+        "execution_allowed": True,
+        "requires_human_confirm": False,
+        "reasons": [
+            "multiple merchants corroborate core claims",
+            "risk signals under policy threshold",
+            "responsibility boundaries are explicit",
+        ],
+    },
+}
+
+
+def main() -> int:
+    runs = Path("runs")
+    runs.mkdir(parents=True, exist_ok=True)
+    for case, payload in CASES.items():
+        audit = {
+            "case": case,
+            "summary": payload,
+            "verify_command": f"po-cosmic verify runs/{case}.badge.json",
+        }
+        badge = {"case": case, **payload}
+        (runs / f"{case}.audit.json").write_text(
+            json.dumps(audit, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        (runs / f"{case}.badge.json").write_text(
+            json.dumps(badge, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+    print("generated demo-shopping runs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_badge.py
+++ b/tools/generate_badge.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate Project Echo badge SVG")
+    parser.add_argument("badge_json", type=Path, help="Path to badge JSON")
+    parser.add_argument("--out", type=Path, default=None, help="Output SVG path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    badge = json.loads(args.badge_json.read_text(encoding="utf-8"))
+    out = args.out or args.badge_json.with_suffix(".svg")
+    from po_echo.badge_svg import write_svg
+
+    write_svg(badge, out)
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a local “X Runway” workflow to generate manual-posting distribution packs for hypothesis testing without using X APIs or external automation.
- Produce reproducible per-case artifacts (thread text, checklist, meta, badge image, optional card) to support manual A/B testing and metrics collection.
- Make it easy to generate demo inputs and badges for quick experiments and auditability.

### Description

- Add a pack builder `tools/build_x_pack.py` that summarizes badge/audit/content inputs and renders thread variants, checklist, card PNG, and badge SVG into `dist/x/<case>` directories. 
- Introduce helper modules `src/po_echo/badge_style.py` and `src/po_echo/badge_svg.py` to normalize labels and render badge SVGs; add `src/po_echo/__init__.py`.
- Add CLI utilities `tools/demo_shopping.py` and `tools/generate_badge.py` plus an `assets/flying_pig_anim.py` fallback GIF generator and new content templates under `content/templates/` for blocked/check/verified threads and a checklist.
- Add docs `docs/X_RUNWAY.md`, README additions describing usage, Makefile targets `x-assets`, `x-pack`, `x-pack-all`, and `x-metrics-init`, and update `.gitignore` to allow generated asset files.

### Testing

- Added unit tests `tests/test_badge_style.py` and `tests/test_build_x_pack.py` which validate label normalization, config fields, SVG output, and pack writing behavior.
- Ran `pytest -q` against the modified codebase and the new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b515f4a5e88328adc9292c74ed454f)