### PR TITLE
Format files flagged by Black (badge_style & build test)

### DIFF
--- a/src/po_echo/badge_style.py
+++ b/src/po_echo/badge_style.py
@@ -38,7 +38,11 @@ PIG_MESSAGE_BY_LABEL: dict[str, str] = {
 
 def normalize_label(label: str) -> str:
     normalized = (label or "").strip().replace("-", "_").upper()
-    if not normalized.startswith("ECHO_") and normalized in {"BLOCKED", "CHECK", "VERIFIED"}:
+    if not normalized.startswith("ECHO_") and normalized in {
+        "BLOCKED",
+        "CHECK",
+        "VERIFIED",
+    }:
         normalized = f"ECHO_{normalized}"
     if normalized not in LABEL_CONFIG:
         raise ValueError(

--- a/tests/test_build_x_pack.py
+++ b/tests/test_build_x_pack.py
@@ -22,7 +22,9 @@ def _demo_data() -> dict:
             "requires_human_confirm": True,
             "reasons": ["r1", "r2"],
         },
-        "audit": {"verify_command": "po-cosmic verify runs/high_bias_affiliate.badge.json"},
+        "audit": {
+            "verify_command": "po-cosmic verify runs/high_bias_affiliate.badge.json"
+        },
         "content": {
             "headline": "h",
             "hook": "k",
@@ -47,7 +49,9 @@ def test_thread_variant_selection_matches_actual_label(tmp_path: Path) -> None:
         skip_card=True,
         copy_assets=False,
     )
-    assert (out / "thread.md").read_text(encoding="utf-8") == variants["thread.blocked.md"]
+    assert (out / "thread.md").read_text(encoding="utf-8") == variants[
+        "thread.blocked.md"
+    ]
 
 
 def test_meta_json_generation(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Resolve CI failure from `black --check` by applying Black formatting to the files that would be reformatted.

### Description
- Apply `black` formatting to `src/po_echo/badge_style.py` and `tests/test_build_x_pack.py`, adjusting multiline literals and collection formatting to satisfy Black.

### Testing
- Ran `black src/po_core/app/rest/store.py src/po_core/cli/experiment.py src/po_echo/badge_style.py tests/test_build_x_pack.py` and `black --check src tests`, which show no remaining reformat issues for the changed files.
- Running `pytest -q` in this environment raised a collection error (`ModuleNotFoundError: No module named 'tools'`) unrelated to these formatting changes, while `PYTHONPATH=. pytest -q tests/test_build_x_pack.py` passed all 4 tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51f3de8e08328bdd117682bf57ff3)