### PR TITLE
style: align Black formatting for CI-reported files

### DIFF
--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -100,16 +100,13 @@ class SQLiteTraceStore(TraceStore):
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS trace_sessions (
                     session_id TEXT PRIMARY KEY,
                     updated_at TEXT NOT NULL
                 )
-                """
-            )
-            conn.execute(
-                """
+                """)
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS trace_events (
                     session_id TEXT NOT NULL,
                     event_idx INTEGER NOT NULL,
@@ -119,8 +116,7 @@ class SQLiteTraceStore(TraceStore):
                     payload_json TEXT NOT NULL,
                     PRIMARY KEY (session_id, event_idx)
                 )
-                """
-            )
+                """)
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_trace_events_session ON trace_events(session_id)"
             )
@@ -200,13 +196,11 @@ class SQLiteTraceStore(TraceStore):
     def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
         if max_sessions <= 0:
             return
-        rows = conn.execute(
-            """
+        rows = conn.execute("""
             SELECT session_id
             FROM trace_sessions
             ORDER BY updated_at DESC
-            """
-        ).fetchall()
+            """).fetchall()
         stale_session_ids = [row["session_id"] for row in rows[max_sessions:]]
         if stale_session_ids:
             conn.executemany(

--- a/src/po_core/cli/experiment.py
+++ b/src/po_core/cli/experiment.py
@@ -29,8 +29,7 @@ from po_core.experiments.storage import ExperimentStorage
 
 def _print_help() -> None:
     """ヘルプメッセージを表示"""
-    print(
-        """
+    print("""
 Po_core Experiment CLI
 
 Usage:
@@ -44,8 +43,7 @@ Commands:
     analyze      Analyze experiment results
     promote      Promote winner to main (if recommendation is 'promote')
     rollback     Rollback to previous backup
-"""
-    )
+""")
 
 
 def cmd_list() -> None:


### PR DESCRIPTION
### Motivation
- Resolve CI failure where `black --check src tests` reported two files that would be reformatted by aligning them with the CI Black style.

### Description
- Reformatted `src/po_core/app/rest/store.py` to follow Black's wrapping conventions for triple-quoted SQL strings and chained calls without changing logic.
- Reformatted `src/po_core/cli/experiment.py` to match Black's style for the multi-line help `print` block without changing logic.
- This is a formatting-only change and does not modify any golden/spec files or runtime behavior.

### Testing
- Ran `black --preview --check src/po_core/app/rest/store.py src/po_core/cli/experiment.py`, which passed for the updated files.
- Ran `black --check src tests` with the locally available Black (25.12.0), which still reported reformatting due to formatter-version differences (failure attributable to Black version mismatch).
- Started `pytest -q` to validate the test suite, but the run was long-running and was interrupted in this environment before completion (partial run observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b537d78f488328b5679862fa186f7a)