### PR TITLE
Harden /v1/ws/reason: enforce API key and per-minute WS rate limiting

### DIFF
--- a/src/po_core/app/rest/routers/reason.py
+++ b/src/po_core/app/rest/routers/reason.py
@@ -10,6 +10,7 @@ import functools
 import json
 import time
 import uuid
+from collections import defaultdict, deque
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict
 
@@ -34,6 +35,11 @@ from po_core.trace.in_memory import InMemoryTracer
 
 router = APIRouter(tags=["reason"])
 
+# Best-effort in-memory limiter for WebSocket handshake requests.
+# Uses monotonic timestamps to avoid wall-clock jumps.
+_WS_WINDOW_SECONDS = 60.0
+_ws_rate_log: dict[str, deque[float]] = defaultdict(deque)
+
 
 def _reason_limit() -> str:
     """Return the SlowAPI limit string derived from the current APISettings.
@@ -49,6 +55,29 @@ def _reason_limit() -> str:
 
     rpm: int = get_api_settings().rate_limit_per_minute
     return f"{rpm}/minute"
+
+
+def _is_ws_authorized(websocket: WebSocket, api_key: str, skip_auth: bool) -> bool:
+    """Validate WebSocket API key from header or query parameter."""
+    if skip_auth or not api_key:
+        return True
+    presented = websocket.headers.get("x-api-key") or websocket.query_params.get(
+        "api_key"
+    )
+    return presented == api_key
+
+
+def _is_ws_rate_limited(websocket: WebSocket, rpm: int) -> bool:
+    """Return True when the client exceeded the per-minute WS request budget."""
+    client_ip = websocket.client.host if websocket.client else "unknown"
+    now = time.monotonic()
+    timestamps = _ws_rate_log[client_ip]
+    while timestamps and now - timestamps[0] > _WS_WINDOW_SECONDS:
+        timestamps.popleft()
+    if len(timestamps) >= max(rpm, 1):
+        return True
+    timestamps.append(now)
+    return False
 
 
 # Internal run() returns "ok" on success; map to the published API contract.
@@ -433,6 +462,18 @@ async def reason_ws(websocket: WebSocket) -> None:
     """WebSocket reasoning stream: client sends one ReasonRequest JSON payload."""
     from po_core.app.rest.config import get_api_settings
 
+    api_settings = get_api_settings()
+
+    if not _is_ws_authorized(
+        websocket, api_settings.api_key, skip_auth=api_settings.skip_auth
+    ):
+        await websocket.close(code=1008, reason="Invalid or missing API key")
+        return
+
+    if _is_ws_rate_limited(websocket, api_settings.rate_limit_per_minute):
+        await websocket.close(code=1008, reason="Rate limit exceeded")
+        return
+
     await websocket.accept()
     try:
         raw_body = await websocket.receive_json()
@@ -443,8 +484,6 @@ async def reason_ws(websocket: WebSocket) -> None:
         )
         await websocket.close(code=1003)
         return
-
-    api_settings = get_api_settings()
 
     try:
         async for chunk in _stream_reasoning_chunks(body, api_settings):

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -638,6 +638,34 @@ def test_reason_ws_stream_receives_realtime_events(client_no_auth):
     assert chunks[2]["payload"]["response"] == "Justice is giving each their due."
 
 
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_reason_ws_auth_required(client_with_auth):
+    """WebSocket reason endpoint requires a valid API key when auth is enabled."""
+    with pytest.raises(Exception):
+        with client_with_auth.websocket_connect("/v1/ws/reason"):
+            pass
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_reason_ws_accepts_valid_api_key(client_with_auth):
+    """WebSocket reason endpoint accepts valid API key via header."""
+
+    async def _fake_async_run(*, user_input, settings, tracer):
+        tracer.emit(TraceEvent.now("pipeline_step", "req-ws-auth", {"step": "start"}))
+        return _MOCK_RESULT
+
+    with patch("po_core.app.rest.routers.reason.po_async_run", new=_fake_async_run):
+        with client_with_auth.websocket_connect(
+            "/v1/ws/reason", headers={"X-API-Key": "test-secret-key"}
+        ) as ws:
+            ws.send_json({"input": "Is fairness objective?"})
+            first = ws.receive_json()
+
+    assert first["chunk_type"] == "started"
+
+
 # ---------------------------------------------------------------------------
 # OpenAPI schema
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The WebSocket reasoning handler accepted and processed `ReasonRequest` payloads without invoking `require_api_key` or the SlowAPI limiter, creating an unauthenticated bypass of the reasoning pipeline. 

### Description
- Added `_is_ws_authorized(...)` to validate `X-API-Key` (or `api_key` query param) against configured `APISettings` and to respect `skip_auth`; the check runs before `websocket.accept()`. 
- Added a lightweight in-memory per-IP handshake limiter `_is_ws_rate_limited(...)` using `time.monotonic()` with a 60s sliding window and the configured `rate_limit_per_minute`. 
- Enforced auth and rate-limit checks in `reason_ws` and close the socket with a policy error when checks fail, and introduced `defaultdict`/`deque` support for the in-memory log. 
- Added unit tests `test_reason_ws_auth_required` and `test_reason_ws_accepts_valid_api_key` to cover rejection of unauthenticated WS handshakes and acceptance with a valid API key. 

### Testing
- Ran the focused test subset with `pytest -q tests/unit/test_rest_api.py -k "reason_ws"` and observed `3 passed`. 
- Ran the full test suite with `pytest -q` and observed all tests passing in this environment (`3714 passed, 4 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56dcdc01c8328b2c9bb7ad84d7cde)