### PR TITLE
fix(rest): fail-closed when API key is not configured

### DIFF
--- a/src/po_core/app/rest/auth.py
+++ b/src/po_core/app/rest/auth.py
@@ -12,7 +12,7 @@ Usage:
     ):
         ...
 
-When PO_SKIP_AUTH=true or PO_API_KEY is empty the check is bypassed
+When PO_SKIP_AUTH=true the check is bypassed
 (useful for local development and unit tests).
 """
 
@@ -34,10 +34,16 @@ async def require_api_key(
     FastAPI dependency that validates the X-API-Key header.
 
     Raises 401 when the key is missing or incorrect.
-    Bypassed when skip_auth=True or api_key is empty (dev mode).
+    Raises 503 when API key auth is enabled but PO_API_KEY is not configured.
+    Bypassed only when skip_auth=True (dev mode).
     """
-    if settings.skip_auth or not settings.api_key:
+    if settings.skip_auth:
         return
+    if not settings.api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="API key authentication is enabled but PO_API_KEY is not configured",
+        )
     if api_key != settings.api_key:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -272,6 +272,28 @@ def test_reason_auth_valid_key(client_with_auth):
 
 @pytest.mark.unit
 @pytest.mark.phase5
+def test_reason_auth_returns_503_when_key_not_configured(tmp_path):
+    """Reason endpoint fails closed when auth is enabled without PO_API_KEY."""
+    app = create_app(
+        APISettings(
+            skip_auth=False,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+    client = TestClient(app, raise_server_exceptions=True)
+
+    resp = client.post(
+        "/v1/reason",
+        json={"input": "test"},
+        headers={"X-API-Key": "wrong"},
+    )
+    assert resp.status_code == 503
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
 def test_reason_passes_llm_settings_when_enabled(client_no_auth):
     """Reason endpoint forwards LLM settings from API settings to core settings."""
     from po_core.runtime.settings import Settings


### PR DESCRIPTION
### Motivation
- The API guard previously skipped authentication when `PO_API_KEY` was empty, which left network-exposed endpoints unauthenticated by default.
- The change enforces a fail-closed behavior so a misconfigured deployment cannot be used without explicit operator action.

### Description
- Change `require_api_key` in `src/po_core/app/rest/auth.py` to only bypass when `skip_auth=True` and to raise `503 Service Unavailable` when auth is enabled but `api_key` is empty instead of allowing access.
- Preserve the existing `401 Unauthorized` response for invalid or missing client keys when an API key is configured.
- Add a regression unit test `test_reason_auth_returns_503_when_key_not_configured` to `tests/unit/test_rest_api.py` that verifies protected endpoints return `503` when `skip_auth=False` and `api_key` is unset.

### Testing
- Ran `pytest -q tests/unit/test_rest_api.py -k "auth"` and the selected REST authentication tests passed (`5 passed`).
- Ran the full test suite with `pytest -q`; the run completed but two benchmark timing tests failed in this environment: `tests/benchmarks/test_pipeline_perf.py::test_bench_concurrent_warn_requests` and `tests/benchmarks/test_pipeline_perf.py::test_bench_deliberation_scaling`, which are unrelated timing-sensitive benchmarks and do not affect the auth regression fix.
- The added unit test ensures the auth bypass cannot be reintroduced silently in future changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56fa877bc8328b9e55f43f6b7e3d0)