### PR TITLE
Harden REST auth defaults: startup fail-fast + opt-in WS query-key fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,14 @@ PO_RELOAD=false
 
 # ---- Authentication ----
 # Set a strong random key for production.
-# Leave empty or set PO_SKIP_AUTH=true for local development.
+# Development recommendation: PO_SKIP_AUTH=true.
+# Production recommendation: PO_SKIP_AUTH=false + non-empty PO_API_KEY.
+# If PO_SKIP_AUTH=false and PO_API_KEY is blank/whitespace, startup fails fast by design.
 PO_API_KEY=
 PO_SKIP_AUTH=true
+# WebSocket query-param auth fallback (?api_key=...) is disabled by default.
+# Enable only for browser compatibility when custom headers are unavailable.
+PO_WS_ALLOW_QUERY_API_KEY=false
 
 # ---- Security: CORS ----
 # Comma-separated list of allowed origins.

--- a/README.md
+++ b/README.md
@@ -458,6 +458,11 @@ curl http://localhost:8000/v1/philosophers
 curl http://localhost:8000/v1/health
 ```
 
+Auth defaults:
+- Development: `PO_SKIP_AUTH=true`
+- Production: `PO_SKIP_AUTH=false` and set non-empty `PO_API_KEY` (startup fails fast when misconfigured)
+- WebSocket query-string fallback (`?api_key=...`) is disabled by default; enable only when needed via `PO_WS_ALLOW_QUERY_API_KEY=true`
+
 ### Docker
 
 ```bash
@@ -473,7 +478,9 @@ Key environment variables (see `.env.example`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PO_API_KEY` | `""` | API key for `X-API-Key` auth (empty = no auth) |
+| `PO_API_KEY` | `""` | API key for `X-API-Key` auth (`PO_SKIP_AUTH=false` requires non-empty value; blank causes startup failure) |
+| `PO_SKIP_AUTH` | `false` | `true` only for local development (disables auth checks) |
+| `PO_WS_ALLOW_QUERY_API_KEY` | `false` | Opt-in WebSocket `?api_key=` fallback for browser compatibility (less secure than headers) |
 | `PO_CORS_ORIGINS` | `"*"` | Comma-separated allowed CORS origins |
 | `PO_RATE_LIMIT_PER_MINUTE` | `60` | Per-IP rate limit |
 | `PO_PORT` | `8000` | Server port |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.9"
 # =============================================================================
 #
 # Quick start:
-#   cp .env.example .env          # edit PO_API_KEY
+#   cp .env.example .env          # set PO_SKIP_AUTH/PO_API_KEY for your env
 #   docker compose up             # starts API server on :8000
 #
 # With optional tracing DB:
@@ -36,6 +36,7 @@ services:
       - PO_LOG_LEVEL=${PO_LOG_LEVEL:-info}
       - PO_API_KEY=${PO_API_KEY:-}
       - PO_SKIP_AUTH=${PO_SKIP_AUTH:-false}
+      - PO_WS_ALLOW_QUERY_API_KEY=${PO_WS_ALLOW_QUERY_API_KEY:-false}
       - PO_CORS_ORIGINS=${PO_CORS_ORIGINS:-*}
       - PO_RATE_LIMIT_PER_MINUTE=${PO_RATE_LIMIT_PER_MINUTE:-60}
       - PO_ENABLE_SOLARWILL=${PO_ENABLE_SOLARWILL:-true}

--- a/src/po_core/app/rest/config.py
+++ b/src/po_core/app/rest/config.py
@@ -41,6 +41,7 @@ class APISettings(BaseSettings):
     api_key: str = ""
     api_key_header: str = "X-API-Key"
     skip_auth: bool = False  # Set True for local dev / testing
+    ws_allow_query_api_key: bool = False
 
     # CORS — comma-separated list of allowed origins.
     # Use "*" (default) to allow all origins in development.

--- a/src/po_core/app/rest/routers/reason.py
+++ b/src/po_core/app/rest/routers/reason.py
@@ -57,13 +57,22 @@ def _reason_limit() -> str:
     return f"{rpm}/minute"
 
 
-def _resolve_ws_auth_key(websocket: WebSocket) -> str | None:
+def _resolve_ws_auth_key(websocket: WebSocket, *, allow_query_api_key: bool) -> str | None:
     """Resolve API key for WebSocket handshake.
 
-    WebSocket browser clients cannot set arbitrary headers in many environments,
-    so we support the ``api_key`` query parameter as a compatibility fallback.
+    By default, only the ``X-API-Key`` header is accepted because query-string
+    secrets are easier to leak via logs/history/referers.
+
+    If ``allow_query_api_key`` is explicitly enabled, ``?api_key=...`` is accepted
+    as a browser-compatibility fallback for environments that cannot set custom
+    WebSocket headers.
     """
-    return websocket.headers.get("x-api-key") or websocket.query_params.get("api_key")
+    header_key = websocket.headers.get("x-api-key")
+    if header_key:
+        return header_key
+    if allow_query_api_key:
+        return websocket.query_params.get("api_key")
+    return None
 
 
 def _is_ws_rate_limited(websocket: WebSocket, rpm: int) -> bool:
@@ -466,7 +475,9 @@ async def reason_ws(websocket: WebSocket) -> None:
     auth_decision = evaluate_auth_policy(
         skip_auth=api_settings.skip_auth,
         configured_api_key=api_settings.api_key,
-        presented_api_key=_resolve_ws_auth_key(websocket),
+        presented_api_key=_resolve_ws_auth_key(
+            websocket, allow_query_api_key=api_settings.ws_allow_query_api_key
+        ),
     )
     if not auth_decision.allowed:
         await websocket.close(code=1008, reason=auth_decision.message)

--- a/src/po_core/app/rest/server.py
+++ b/src/po_core/app/rest/server.py
@@ -62,6 +62,23 @@ def _parse_cors_origins(cors_origins: str) -> list[str]:
     return [o.strip() for o in cors_origins.split(",") if o.strip()]
 
 
+def _validate_startup_auth_configuration(settings: APISettings) -> None:
+    """Fail fast on startup when production auth is misconfigured."""
+    auth_state = evaluate_auth_policy(
+        skip_auth=settings.skip_auth,
+        configured_api_key=settings.api_key,
+        presented_api_key=settings.api_key,
+    )
+    if auth_state.allowed:
+        return
+    if auth_state.is_misconfigured:
+        raise RuntimeError(
+            "Startup aborted: authentication is enabled (PO_SKIP_AUTH=false) "
+            "but PO_API_KEY is unset or blank. "
+            "Set PO_API_KEY to a non-empty value, or set PO_SKIP_AUTH=true for development only."
+        )
+
+
 def create_app(settings: APISettings | None = None) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -93,6 +110,7 @@ to generate ethically responsible responses.
 ### Authentication
 Include your API key in the `X-API-Key` header for all requests.
 Set `PO_API_KEY` and keep `PO_SKIP_AUTH=false` to enforce authentication.
+If `PO_SKIP_AUTH=false` and `PO_API_KEY` is empty/blank, startup fails fast by design.
 Set `PO_SKIP_AUTH=true` only for development mode.
 
 ### Pipeline
@@ -186,13 +204,7 @@ MemoryRead → TensorCompute → SolarWill → IntentionGate → PhilosopherSele
             },
         )
 
-        auth_state = evaluate_auth_policy(
-            skip_auth=settings.skip_auth,
-            configured_api_key=settings.api_key,
-            presented_api_key=settings.api_key,
-        )
-        if not auth_state.allowed and auth_state.is_misconfigured:
-            logger.error(auth_state.message)
+        _validate_startup_auth_configuration(settings)
 
     return application
 

--- a/tests/benchmarks/test_rest_perf.py
+++ b/tests/benchmarks/test_rest_perf.py
@@ -98,20 +98,19 @@ def bench_client():
     Auth and rate limiting are disabled so repeated calls don't hit
     the 60 req/min cap and each request isn't penalised by key lookup.
     """
-    from po_core.app.rest import auth, config
-
-    def _settings() -> APISettings:
-        return APISettings(
+    app = create_app(
+        APISettings(
             skip_auth=True,
             api_key="",
             rate_limit_per_minute=10_000,
         )
-
-    app = create_app()
-    app.dependency_overrides[config.get_api_settings] = _settings
-    app.dependency_overrides[auth.require_api_key] = lambda: None
+    )
 
     with TestClient(app, raise_server_exceptions=True) as client:
+        # Warm-up once to avoid cold-start initialization cost (e.g. embeddings)
+        # skewing the benchmark smoke threshold.
+        warmup = client.post("/v1/reason", json={"input": _BENCH_PROMPT})
+        assert warmup.status_code == 200
         yield client
 
     _store.clear()

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -309,6 +309,60 @@ def test_protected_http_returns_503_when_auth_misconfigured(tmp_path):
 
 @pytest.mark.unit
 @pytest.mark.phase5
+def test_startup_fails_fast_when_auth_enabled_without_api_key(tmp_path):
+    """startup should fail fast when PO_SKIP_AUTH=false and API key is blank."""
+    app = create_app(
+        APISettings(
+            skip_auth=False,
+            api_key="   ",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Startup aborted"):
+        with TestClient(app, raise_server_exceptions=True):
+            pass
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_startup_allows_dev_mode_without_api_key(tmp_path):
+    """startup should succeed when PO_SKIP_AUTH=true even if API key is blank."""
+    app = create_app(
+        APISettings(
+            skip_auth=True,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        resp = client.get("/v1/health")
+    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_startup_allows_auth_enabled_with_api_key(tmp_path):
+    """startup should succeed when PO_SKIP_AUTH=false and API key is configured."""
+    app = create_app(
+        APISettings(
+            skip_auth=False,
+            api_key="secret",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        resp = client.get("/v1/health")
+    assert resp.status_code == 200
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
 def test_reason_passes_llm_settings_when_enabled(client_no_auth):
     """Reason endpoint forwards LLM settings from API settings to core settings."""
     from po_core.runtime.settings import Settings
@@ -758,40 +812,40 @@ def test_reason_ws_rejects_wrong_api_key(client_with_auth):
 
 @pytest.mark.unit
 @pytest.mark.phase5
-def test_reason_ws_accepts_valid_api_key_query_param(client_with_auth):
-    """WebSocket reason endpoint accepts query-param API key for browser compatibility."""
+def test_reason_ws_rejects_query_param_api_key_by_default(client_with_auth):
+    """WebSocket query-param API key is rejected unless explicitly enabled."""
+    with pytest.raises(Exception):
+        with client_with_auth.websocket_connect(
+            "/v1/ws/reason?api_key=test-secret-key"
+        ):
+            pass
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_reason_ws_accepts_query_param_api_key_when_opted_in(tmp_path):
+    """WebSocket query-param API key works only with explicit opt-in."""
+    app = create_app(
+        APISettings(
+            skip_auth=False,
+            api_key="test-secret-key",
+            ws_allow_query_api_key=True,
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
 
     async def _fake_async_run(*, user_input, settings, tracer):
         tracer.emit(TraceEvent.now("pipeline_step", "req-ws-query-auth", {"step": "start"}))
         return _MOCK_RESULT
 
     with patch("po_core.app.rest.routers.reason.po_async_run", new=_fake_async_run):
-        with client_with_auth.websocket_connect(
-            "/v1/ws/reason?api_key=test-secret-key"
-        ) as ws:
-            ws.send_json({"input": "Is fairness objective?"})
-            first = ws.receive_json()
+        with TestClient(app, raise_server_exceptions=True) as client:
+            with client.websocket_connect("/v1/ws/reason?api_key=test-secret-key") as ws:
+                ws.send_json({"input": "Is fairness objective?"})
+                first = ws.receive_json()
 
     assert first["chunk_type"] == "started"
-
-
-@pytest.mark.unit
-@pytest.mark.phase5
-def test_reason_ws_misconfigured_auth_is_rejected_pre_accept(tmp_path):
-    """WebSocket rejects before accept when auth is enabled but PO_API_KEY is unset."""
-    app = create_app(
-        APISettings(
-            skip_auth=False,
-            api_key="",
-            trace_store_backend="sqlite",
-            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
-        )
-    )
-    client = TestClient(app, raise_server_exceptions=True)
-
-    with pytest.raises(Exception):
-        with client.websocket_connect("/v1/ws/reason"):
-            pass
 
 
 


### PR DESCRIPTION
### Motivation
- Ensure production-safe defaults for API-key authentication so misconfiguration fails early instead of allowing a partially-unprotected server to start. 
- Remove always-on WebSocket query-parameter fallback (a leakage risk) and make it an explicit opt-in for browser-compatibility cases. 
- Keep shared `evaluate_auth_policy()` design and make minimal, testable changes with docs and examples aligned.

### Description
- Added `ws_allow_query_api_key: bool = False` to `APISettings` (env `PO_WS_ALLOW_QUERY_API_KEY`) and wired it into the WS auth resolver so `?api_key=` is accepted only when explicitly enabled. 
- Implemented startup validation `_validate_startup_auth_configuration()` called from `create_app()` that raises a `RuntimeError` when `PO_SKIP_AUTH=false` and `PO_API_KEY` is empty/blank (dev mode with `PO_SKIP_AUTH=true` remains allowed). 
- Hardened WebSocket handling by changing `_resolve_ws_auth_key()` to prefer header auth and only use query param when `ws_allow_query_api_key` is true, and preserved the shared `evaluate_auth_policy()` path. 
- Updated docs/examples/config (`README.md`, `.env.example`, `docker-compose.yml`) and adjusted benchmark fixture to create the app with explicit settings and a warm-up request to avoid cold-start skew. 
- Added/updated tests in `tests/unit/test_rest_api.py` and `tests/benchmarks/test_rest_perf.py` to cover startup fail-fast, WS query-param opt-in, and benchmark compatibility.

### Testing
- Ran `pytest -q tests/unit/test_rest_api.py` and the file passed (new startup + WS tests included). 
- Ran `pytest -q tests/benchmarks/test_rest_perf.py` after adding warm-up; benchmarks passed. 
- Ran the full test suite `pytest -q` which completed successfully: final run reported `3724 passed, 4 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57e31a164832898a87180201a78af)