### PR TITLE
fix(rest): disable trace history endpoint by default

### DIFF
--- a/src/po_core/app/rest/config.py
+++ b/src/po_core/app/rest/config.py
@@ -78,6 +78,7 @@ class APISettings(BaseSettings):
     max_trace_sessions: int = 1000
     trace_store_backend: str = "sqlite"  # sqlite | memory
     trace_db_path: str = ".po_core/trace_store.sqlite3"
+    enable_trace_history: bool = False
 
     class Config:
         env_prefix = "PO_"

--- a/src/po_core/app/rest/routers/trace.py
+++ b/src/po_core/app/rest/routers/trace.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from po_core.app.rest.auth import require_api_key
+from po_core.app.rest.config import APISettings, get_api_settings
 from po_core.app.rest.models import (
     TraceEventOut,
     TraceHistoryItem,
@@ -27,9 +28,16 @@ router = APIRouter(tags=["trace"])
 async def get_trace_history(
     limit: int = Query(default=50, ge=1, le=500),
     _: None = Depends(require_api_key),
+    settings: APISettings = Depends(get_api_settings),
     store: TraceStore = Depends(get_trace_store),
 ) -> TraceHistoryResponse:
     """Return recent trace session summaries in descending recency order."""
+    if not settings.enable_trace_history:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Trace history endpoint is disabled",
+        )
+
     summaries: list[TraceHistorySummary] = store.history(limit=limit)
     items = [
         TraceHistoryItem(

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -52,6 +52,7 @@ def client_no_auth(tmp_path):
             api_key="",
             trace_store_backend="sqlite",
             trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+            enable_trace_history=True,
         )
     )
     from po_core.app.rest import auth
@@ -70,6 +71,7 @@ def client_with_auth(tmp_path):
             api_key="test-secret-key",
             trace_store_backend="sqlite",
             trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+            enable_trace_history=True,
         )
     )
     return TestClient(app, raise_server_exceptions=True)
@@ -480,6 +482,26 @@ def test_trace_history_lists_sessions(client_no_auth):
         "history-1",
     ]
 
+@pytest.mark.unit
+@pytest.mark.phase5
+def test_trace_history_disabled_by_default(tmp_path):
+    """Trace history endpoint is disabled unless explicitly enabled."""
+    app = create_app(
+        APISettings(
+            skip_auth=True,
+            api_key="",
+            trace_store_backend="sqlite",
+            trace_db_path=str(tmp_path / "trace_store.sqlite3"),
+        )
+    )
+    from po_core.app.rest import auth
+
+    app.dependency_overrides[auth.require_api_key] = lambda: None
+    client = TestClient(app, raise_server_exceptions=True)
+
+    resp = client.get("/v1/trace/history?limit=10")
+    assert resp.status_code == 404
+
 
 @pytest.mark.unit
 @pytest.mark.phase5
@@ -493,6 +515,7 @@ def test_trace_persists_across_store_reinitialization(tmp_path):
             api_key="",
             trace_store_backend="sqlite",
             trace_db_path=str(db_path),
+            enable_trace_history=True,
         )
     )
     from po_core.app.rest import auth
@@ -515,6 +538,7 @@ def test_trace_persists_across_store_reinitialization(tmp_path):
             api_key="",
             trace_store_backend="sqlite",
             trace_db_path=str(db_path),
+            enable_trace_history=True,
         )
     )
     app2.dependency_overrides[auth.require_api_key] = lambda: None


### PR DESCRIPTION
### Motivation
- The `GET /v1/trace/history` endpoint exposed all stored `session_id` values and metadata to any holder of the global API key, enabling trivial cross-session enumeration and information disclosure in multi-tenant or shared-key deployments.
- Make the secure choice by default (deny-list) so history enumeration is opt-in for operators who understand the risks.

### Description
- Add a new API setting `enable_trace_history: bool = False` to `APISettings` to require explicit opt-in for history exposure (`src/po_core/app/rest/config.py`).
- Gate `GET /v1/trace/history` behind the new setting and return `404` when it is not enabled (`src/po_core/app/rest/routers/trace.py`).
- Preserve `GET /v1/trace/{session_id}` behavior so existing per-session retrieval still functions with the same auth model.
- Update unit-test fixtures to opt in to history where tests rely on it and add `test_trace_history_disabled_by_default` to assert the secure default (`tests/unit/test_rest_api.py`).

### Testing
- Ran `pytest -q tests/unit/test_rest_api.py` and the suite passed: `39 passed`.
- Ran `pytest -q tests/unit/test_rest_api.py -k 'trace_history'` and the related tests passed: `2 passed`.
- Ran a full test run (`pytest -q --maxfail=1`) which stopped on an existing benchmark performance assertion unrelated to this change (`tests/benchmarks/test_pipeline_perf.py::test_bench_critical_p50`), indicating the change did not break unit tests covering the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56a3d6c208328868ba6724169da69)