### PR TITLE
docs: sync Stage 3/4 observability/streaming/review status to main

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -127,12 +127,12 @@ PyPI publish pending. Spec/acceptance-test scaffolding in progress (M0).
 - 53 new Phase 3 tests (2477 total, 0 failures)
 - Legacy `test_visualizer_with_po_self_session` skipped (Phase 3 scope)
 
-**Remaining Work:**
+**Remaining Work (main実装同期済み):**
 
-- Trace database (SQLite) for historical query support
 - Interaction heatmap (NxN philosopher tensor visualization)
-- WebSocket streaming for real-time event delivery
-- Human review interface for ESCALATE decisions
+- Human review queue persistence (current `review_store` is in-memory only)
+- ESCALATE UI: pending review list + approve/reject action flow in viewer
+- Streaming observability hardening (WS/SSE connection metrics, lag, disconnect telemetry)
 
 **Exit Criteria:**
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -106,10 +106,24 @@ v1.0.0 リリース定義の全条件が充足された:
 
 - **v1.0.0 残タスク（Stage 2 完了後）**: PyPI v1.0.0 公開（workflow_dispatch）、arXiv 投稿（論文査読後）。
 
+
+## Stage 3/4 実装監査（observability / streaming / review）
+
+- **既にあるもの（main 実装と一致）**
+  - Trace store は backend 切替式で、`memory` に加えて `sqlite` を実装済み。`trace_sessions` / `trace_events` テーブルでセッション履歴・イベント履歴を保持し、`get/history` で再取得できる。
+  - `/v1/reason/stream`（SSE）と `/v1/ws/reason`（WebSocket）の両方でリアルタイム chunk 配信を実装済み。trace event を逐次配信し、終了時に trace 保存まで行う。
+  - ESCALATE 判定時は `/v1/reason` から review queue へ投入され、`/v1/review/pending` と `/v1/review/{review_id}/decision` で human decision を処理できる。決定時は `HumanReviewDecided` が trace に追記される。
+  - viewer `standalone.html` は live mode で `/v1/ws/reason` に接続し、stream chunk（started/event/result/done）を表示できる。
+
+- **未完了・制約（main 実装ベース）**
+  - review queue は `review_store.py` のプロセス内 OrderedDict 実装のみで、再起動耐性がない（SQLite などの永続バックエンド未実装）。
+  - `standalone.html` には ESCALATE の pending 一覧取得・approve/reject 送信UIがなく、human review 操作は API 直叩き前提。
+  - WS/SSE の observability はイベント配信機能までで、接続数/配信遅延/切断率など運用メトリクスの集計基盤は未整備。
+
 ## Next
 - **Snapshot sync policy**: `docs/status.md` は main の実態同期を優先し、完了済み項目を Next に残置しない。
 - **Open follow-up（運用上の未解消）**: TestPyPI 側の外部接続制限（HTTP 403）により evidence 本体は未作成のまま。PyPI `0.3.0` 公開証跡・acceptance proof・publish playbook は整備済み。
-- **Stage 3 次ステップ**: SQLite 永続化・WebSocket ストリーミング・Human-in-the-Loop ESCALATE UI（v1.0.0 リリース後着手）。
+- **Stage 3/4 follow-up（実装監査後）**: 未完了は「review queue の永続化」「ESCALATE 向け専用UI」「WS/SSE の運用監視強化」に限定。SQLite trace 永続化とWS配信そのものは main 実装済み。
 
 ## Deliberation Protocol v1 (PR-4)
 - 新しい内部プロトコル `Propose -> Critique -> Synthesize` を `src/po_core/deliberation/protocol.py` に追加。


### PR DESCRIPTION
### Motivation
- Bring `docs/status.md` and roadmap notes into alignment with the actual `main` implementation for Stage 3/4 (observability, streaming, human review) so the single source of truth reflects implemented behavior and outstanding gaps. 
- Replace a coarse “WebSocket/SQLite/ESCALATE UI” lump with concrete remaining work items to make follow-ups actionable and reviewable. 
- Provide a minimal audit trail that links documented status to the code paths and tests that demonstrate the claims.

### Description
- Updated `docs/status.md` to add a `Stage 3/4 実装監査` section that enumerates what is already implemented (SQLite trace backend, SSE + WebSocket streaming, ESCALATE→review API flow, viewer WS live stream) and what remains (review queue persistence, ESCALATE UI, streaming observability metrics). 
- Updated `NEXT_STEPS.md` to remove items now implemented in `main` and to replace them with concrete residual tasks (`review_store` persistence, ESCALATE UI actions in viewer, streaming ops telemetry). 
- No production code/golden test files were changed; the change is limited to documentation synchronization after auditing the implementation files (`src/po_core/app/rest/routers/reason.py`, `src/po_core/app/rest/store.py`, `src/po_core/app/rest/review_store.py`, `src/po_core/app/rest/routers/review.py`, `src/po_core/viewer/standalone.html`) and relevant unit tests.

### Testing
- Ran the focused test command `pytest -q tests/unit/test_rest_api.py -k "trace_persists_across_store_reinitialization or reason_ws_stream_receives_realtime_events or reason_escalate_enqueues_human_review"`, and all selected tests passed (3 passed). 
- Verified via the test suite that the trace SQLite backend, SSE/WS streaming endpoints, and ESCALATE→review API flow are exercised by tests; no frozen golden files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61f242b4c83288369e662d111d539)