### PR TITLE
Add observability/human-review regression tests and operations runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(rest): add persistent SQLite review queue backend in `src/po_core/app/rest/review_store.py` with restart-safe storage for ESCALATE human-review items (`review_queue` table). Default backend is now sqlite, with optional in-memory backend for local/dev testing.
 - feat(config): add review queue settings `PO_REVIEW_STORE_BACKEND` and `PO_REVIEW_DB_PATH` (`APISettings.review_store_backend`, `APISettings.review_db_path`). When `PO_REVIEW_DB_PATH` is blank, review storage reuses `PO_TRACE_DB_PATH`.
+- docs(ops): add `docs/operations/observability_review_playbook.md` documenting deterministic ESCALATE→review→trace run operations with env examples, startup, verification commands, and expected responses.
 
 ### Tests
 
 - test(rest): add restart-safety tests for review queue pending/decided persistence and regression coverage that `HumanReviewDecided` trace append remains intact after decision flow.
+- test(integration): add `tests/integration/test_observability_review_flow.py` to lock observability/human-review loop regression (ESCALATE enqueue, pending visibility, trace retrieval, decision append, restart persistence for trace/history/review).
+- test(unit): strengthen `tests/unit/test_rest_api.py` with `test_review_decision_increments_trace_event_count` so human decisions are guaranteed to append exactly one `HumanReviewDecided` trace event.
 
 ## [1.0.0] - 2026-03-10
 

--- a/docs/operations/observability_review_playbook.md
+++ b/docs/operations/observability_review_playbook.md
@@ -1,0 +1,131 @@
+# Observability + Human Review Runbook
+
+`/v1/reason` で ESCALATE が発生したケースを、
+「pending review → human decision → trace 記録 → 再起動後の永続化確認」まで再現する運用手順。
+
+## 1. 目的
+
+この runbook は以下 6 点を運用で確認する。
+
+1. `/v1/reason` で ESCALATE が発生する
+2. pending review に積まれる
+3. `/v1/trace/{session_id}` で関連 trace が見える
+4. human decision を送信できる
+5. `HumanReviewDecided` が trace に残る
+6. 再初期化後も trace/history/review 状態が期待通り残る
+
+## 2. 前提環境（例）
+
+```bash
+export PO_SKIP_AUTH=true
+export PO_TRACE_STORE_BACKEND=sqlite
+export PO_TRACE_DB_PATH=.data/po_trace.sqlite3
+export PO_REVIEW_STORE_BACKEND=sqlite
+export PO_REVIEW_DB_PATH=.data/po_trace.sqlite3
+```
+
+- `PO_REVIEW_DB_PATH` を省略した場合は `PO_TRACE_DB_PATH` が再利用される。
+- 永続化確認では、同じ DB パスを再起動後も使うこと。
+
+## 3. 起動
+
+```bash
+python -m po_core.app.rest
+```
+
+ヘルスチェック:
+
+```bash
+curl -s http://127.0.0.1:8000/v1/health
+```
+
+期待: HTTP 200 / `{"status":"ok", ...}`
+
+## 4. フロー確認コマンド
+
+### Step 1: ESCALATE を発生させる
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/v1/reason \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"Need human escalation for safety-sensitive decision","session_id":"ops-review-session-001"}'
+```
+
+期待:
+- HTTP 200
+- `session_id=ops-review-session-001`
+
+### Step 2: pending review に積まれる
+
+```bash
+curl -s http://127.0.0.1:8000/v1/review/pending
+```
+
+期待:
+- `total >= 1`
+- `items[*].session_id` に `ops-review-session-001` が含まれる
+- 対象 item の `id`（review_id）を控える
+
+### Step 3: trace を確認
+
+```bash
+curl -s http://127.0.0.1:8000/v1/trace/ops-review-session-001
+```
+
+期待:
+- `event_count >= 1`
+- `events[*].event_type` に `DecisionEmitted` または ESCALATE 判定由来イベントが含まれる
+
+### Step 4: human decision を送る
+
+`<REVIEW_ID>` は Step 2 で取得した値に置き換える。
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/v1/review/<REVIEW_ID>/decision \
+  -H 'Content-Type: application/json' \
+  -d '{"decision":"approve","reviewer":"ops-oncall","comment":"manual verification complete"}'
+```
+
+期待:
+- HTTP 200
+- `item.status=decided`
+- `item.decision=approve`
+
+### Step 5: `HumanReviewDecided` が trace に残る
+
+```bash
+curl -s http://127.0.0.1:8000/v1/trace/ops-review-session-001
+```
+
+期待:
+- `events[*].event_type` に `HumanReviewDecided` が含まれる
+
+### Step 6: 再起動後の永続化を確認
+
+1. サーバ停止
+2. 同じ環境変数・同じ DB パスで再起動
+3. 以下を確認
+
+```bash
+curl -s http://127.0.0.1:8000/v1/review/pending
+curl -s http://127.0.0.1:8000/v1/trace/ops-review-session-001
+curl -s 'http://127.0.0.1:8000/v1/trace/history?limit=10'
+```
+
+期待:
+- 決定済みであれば pending 件数は 0（対象セッションは pending から消える）
+- `/v1/trace/ops-review-session-001` で `HumanReviewDecided` を再取得できる
+- `/v1/trace/history` に `ops-review-session-001` が残る
+
+## 5. 回帰防止で担保している自動テスト
+
+- `tests/integration/test_observability_review_flow.py`
+  - ESCALATE → pending → trace → decision → HumanReviewDecided → 再初期化後の trace/history/review 永続化を一気通貫で固定。
+- `tests/unit/test_rest_api.py::test_review_decision_increments_trace_event_count`
+  - human decision 時に trace event が 1 件追加されることを固定。
+
+## 6. まだ手動で確認すべき点
+
+- 実運用の入力で ESCALATE が十分に発生するか（ポリシー/モデル設定依存）
+- SSE/WS クライアントでの UI 表示・オペレーター導線（本 runbook は HTTP API 検証中心）
+- 高負荷時の review キュー運用（件数上限・運用アラート・オンコール手順）

--- a/docs/status.md
+++ b/docs/status.md
@@ -119,6 +119,9 @@ v1.0.0 リリース定義の全条件が充足された:
   - review queue を SQLite 永続バックエンド対応へ拡張。`PO_REVIEW_STORE_BACKEND=sqlite`（デフォルト）時は `review_queue` テーブルへ保存され、サーバ再起動後も pending/decided 状態を保持。
   - review store は `PO_REVIEW_DB_PATH` 未指定時に `PO_TRACE_DB_PATH` を再利用するため、既存 trace DB と共存可能。
   - `viewer/standalone.html` に ESCALATE Human Review UI を追加。`/v1/review/pending` の一覧表示、item 選択時の `session_id/request_id/reason/source` 表示、`/v1/trace/{session_id}` の最新イベント簡易プレビュー、`approve/reject` 送信（reviewer/comment 入力）と送信後の一覧・詳細更新を実装。
+  - observability/review の回帰検知ラインとして `tests/integration/test_observability_review_flow.py` を追加し、ESCALATE→pending→trace→decision→`HumanReviewDecided`→再初期化後の trace/history/review 永続化を一気通貫で固定。
+  - REST API の補強として `tests/unit/test_rest_api.py` に「human decision で trace event 数が 1 件増加する」検証を追加し、追記漏れを検知できるようにした。
+  - 運用 runbook `docs/operations/observability_review_playbook.md` を追加し、環境変数例・起動手順・確認コマンド・期待レスポンスを明文化した。
 
 - **未完了・制約（main 実装ベース）**
   - WS/SSE の observability はイベント配信機能までで、接続数/配信遅延/切断率など運用メトリクスの集計基盤は未整備。
@@ -127,6 +130,7 @@ v1.0.0 リリース定義の全条件が充足された:
 - **Snapshot sync policy**: `docs/status.md` は main の実態同期を優先し、完了済み項目を Next に残置しない。
 - **Open follow-up（運用上の未解消）**: TestPyPI 側の外部接続制限（HTTP 403）により evidence 本体は未作成のまま。PyPI `0.3.0` 公開証跡・acceptance proof・publish playbook は整備済み。
 - **Stage 3/4 follow-up（実装監査後）**: 未完了は「WS/SSE の運用監視強化」に限定。viewer 側の auth 対応 transport（auto/sse/websocket）と ESCALATE Human Review UI は反映済み。
+- **Observability/review follow-up**: 現状の自動回帰は HTTP API（reason/review/trace/history）の整合性まで。運用メトリクス（接続数・遅延・失敗率）と UI 操作導線の保証は手動確認を継続。
 
 ## Deliberation Protocol v1 (PR-4)
 - 新しい内部プロトコル `Propose -> Critique -> Synthesize` を `src/po_core/deliberation/protocol.py` に追加。

--- a/tests/integration/test_observability_review_flow.py
+++ b/tests/integration/test_observability_review_flow.py
@@ -1,0 +1,130 @@
+"""Integration test for observability/human-review regression line.
+
+Flow under test (deterministic, no external dependency):
+1. POST /v1/reason triggers ESCALATE
+2. item is queued in /v1/review/pending
+3. related trace is retrievable via /v1/trace/{session_id}
+4. human decision is submitted
+5. HumanReviewDecided appears in trace
+6. after app/store reinitialization, trace/history/review state is preserved
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from po_core.app.rest.config import APISettings
+from po_core.app.rest.review_store import get_review_store, reset_review_store
+from po_core.app.rest.server import create_app
+from po_core.app.rest.store import reset_trace_store
+from po_core.domain.trace_event import TraceEvent
+
+
+@pytest.mark.integration
+@pytest.mark.observability
+def test_observability_review_flow_persists_across_reinitialization(tmp_path):
+    """ESCALATE -> review -> trace append -> restart persistence stays observable."""
+    db_path = tmp_path / "observability_review.sqlite3"
+    session_id = "obs-review-session"
+    request_id = "req-obs-review-001"
+
+    settings = APISettings(
+        skip_auth=True,
+        api_key="",
+        trace_store_backend="sqlite",
+        trace_db_path=str(db_path),
+        review_store_backend="sqlite",
+        review_db_path=str(db_path),
+    )
+
+    def _build_client() -> TestClient:
+        app = create_app(settings)
+        from po_core.app.rest import auth
+
+        app.dependency_overrides[auth.require_api_key] = lambda: None
+        return TestClient(app, raise_server_exceptions=True)
+
+    def _mock_escalate_run(*, user_input, settings, tracer):  # noqa: ARG001
+        tracer.emit(
+            TraceEvent.now(
+                "DecisionEmitted",
+                correlation_id=request_id,
+                payload={"gate": {"decision": "escalate"}},
+            )
+        )
+        return {
+            "status": "ok",
+            "request_id": request_id,
+            "verdict": {"decision": "escalate"},
+            "proposal": {"content": "Escalated to human review."},
+            "proposals": [],
+            "tensors": {},
+            "safety_mode": "WARN",
+        }
+
+    with _build_client() as client:
+        with patch(
+            "po_core.app.rest.routers.reason.po_run",
+            side_effect=_mock_escalate_run,
+        ):
+            reason_resp = client.post(
+                "/v1/reason",
+                json={"input": "Need operator decision", "session_id": session_id},
+            )
+        assert reason_resp.status_code == 200
+
+        pending_resp = client.get("/v1/review/pending")
+        assert pending_resp.status_code == 200
+        pending_items = pending_resp.json()["items"]
+        assert len(pending_items) == 1
+        assert pending_items[0]["session_id"] == session_id
+        review_id = pending_items[0]["id"]
+
+        trace_before = client.get(f"/v1/trace/{session_id}")
+        assert trace_before.status_code == 200
+        before_events = trace_before.json()["events"]
+        assert any(e["event_type"] == "DecisionEmitted" for e in before_events)
+
+        decision_resp = client.post(
+            f"/v1/review/{review_id}/decision",
+            json={"decision": "approve", "reviewer": "ops", "comment": "verified"},
+        )
+        assert decision_resp.status_code == 200
+
+        trace_after = client.get(f"/v1/trace/{session_id}")
+        assert trace_after.status_code == 200
+        after_events = trace_after.json()["events"]
+        assert any(e["event_type"] == "HumanReviewDecided" for e in after_events)
+
+    reset_trace_store()
+    reset_review_store()
+
+    with _build_client() as client2:
+        pending_after_restart = client2.get("/v1/review/pending")
+        assert pending_after_restart.status_code == 200
+        assert pending_after_restart.json()["total"] == 0
+
+        trace_after_restart = client2.get(f"/v1/trace/{session_id}")
+        assert trace_after_restart.status_code == 200
+        restarted_events = trace_after_restart.json()["events"]
+        event_types = [event["event_type"] for event in restarted_events]
+        assert "DecisionEmitted" in event_types
+        assert "HumanReviewDecided" in event_types
+
+        history_resp = client2.get("/v1/trace/history?limit=10")
+        assert history_resp.status_code == 200
+        assert any(
+            item["session_id"] == session_id for item in history_resp.json()["items"]
+        )
+
+        decided = get_review_store().apply_decision(
+            review_id,
+            decision="approve",
+            reviewer="ops-restart-check",
+            comment="persisted",
+        )
+        assert decided is not None
+        assert decided["status"] == "decided"

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -524,6 +524,46 @@ def test_review_decision_updates_item_and_appends_trace(client_no_auth):
 
 @pytest.mark.unit
 @pytest.mark.phase5
+def test_review_decision_increments_trace_event_count(client_no_auth):
+    """Human review decision must append exactly one trace event."""
+
+    def _mock_run(*, user_input, settings, tracer):  # noqa: ARG001
+        tracer.emit(
+            TraceEvent.now(
+                "DecisionEmitted",
+                correlation_id="req-escalate-trace-count",
+                payload={"gate": {"decision": "escalate"}},
+            )
+        )
+        return {
+            **_MOCK_RESULT,
+            "request_id": "req-escalate-trace-count",
+            "verdict": {"decision": "escalate"},
+        }
+
+    with patch("po_core.app.rest.routers.reason.po_run", side_effect=_mock_run):
+        client_no_auth.post(
+            "/v1/reason",
+            json={"input": "Need review", "session_id": "escalate-session-trace-count"},
+        )
+
+    trace_before = client_no_auth.get("/v1/trace/escalate-session-trace-count").json()
+    count_before = trace_before["event_count"]
+
+    review_id = client_no_auth.get("/v1/review/pending").json()["items"][0]["id"]
+    decision = client_no_auth.post(
+        f"/v1/review/{review_id}/decision",
+        json={"decision": "approve", "reviewer": "alice", "comment": "safe"},
+    )
+    assert decision.status_code == 200
+
+    trace_after = client_no_auth.get("/v1/trace/escalate-session-trace-count").json()
+    assert trace_after["event_count"] == count_before + 1
+    assert trace_after["events"][-1]["event_type"] == "HumanReviewDecided"
+
+
+@pytest.mark.unit
+@pytest.mark.phase5
 def test_review_pending_persists_across_app_reinitialization(tmp_path):
     """SQLite review store keeps pending items across app recreation."""
     db_path = tmp_path / "trace_store.sqlite3"


### PR DESCRIPTION
### Motivation
- Make the observability → human-review loop regression-detectable by adding deterministic automated coverage for the full flow from ESCALATE to persisted trace and review state across restarts.
- Provide an operational, reproducible runbook so operators can exercise and validate the ESCALATE → review → trace lifecycle in production-like environments.
- Harden the REST API contract around review decisions so omissions (e.g., missing trace append) are detected by unit tests.

### Description
- Add an end-to-end integration test `tests/integration/test_observability_review_flow.py` that deterministically exercises: POST `/v1/reason` producing ESCALATE, `/v1/review/pending` visibility, `/v1/trace/{session_id}` retrieval, submitting a human decision, verifying `HumanReviewDecided` in the trace, and validating persistence after trace/review store reinitialization using SQLite.
- Strengthen unit coverage in `tests/unit/test_rest_api.py` with `test_review_decision_increments_trace_event_count` to assert that a human decision appends exactly one `HumanReviewDecided` trace event and increments `event_count` by one.
- Add an operations runbook `docs/operations/observability_review_playbook.md` documenting environment variable examples, startup instructions, verification commands for each step, and expected responses, and update `docs/status.md` and `CHANGELOG.md` to record the new regression lines and runbook.

### Testing
- Ran `pytest -q tests/integration/test_observability_review_flow.py` and it passed (1 passed).
- Ran `pytest -q tests/unit/test_rest_api.py` and it passed (53 passed).
- Ran the combined invocation `pytest -q tests/integration/test_observability_review_flow.py tests/unit/test_rest_api.py` and all tests passed (54 passed in the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62c15f2e08328ace34067e0968429)