### PR TITLE
Fix Black formatting failures in REST, CLI and tests

### DIFF
--- a/src/po_core/app/rest/auth.py
+++ b/src/po_core/app/rest/auth.py
@@ -36,7 +36,9 @@ def evaluate_auth_policy(
       - otherwise allow
     """
     if skip_auth:
-        return AuthDecision(allowed=True, is_misconfigured=False, message="Auth bypassed")
+        return AuthDecision(
+            allowed=True, is_misconfigured=False, message="Auth bypassed"
+        )
 
     expected = configured_api_key.strip()
     if not expected:

--- a/src/po_core/app/rest/routers/reason.py
+++ b/src/po_core/app/rest/routers/reason.py
@@ -57,7 +57,9 @@ def _reason_limit() -> str:
     return f"{rpm}/minute"
 
 
-def _resolve_ws_auth_key(websocket: WebSocket, *, allow_query_api_key: bool) -> str | None:
+def _resolve_ws_auth_key(
+    websocket: WebSocket, *, allow_query_api_key: bool
+) -> str | None:
     """Resolve API key for WebSocket handshake.
 
     By default, only the ``X-API-Key`` header is accepted because query-string

--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -100,13 +100,16 @@ class SQLiteTraceStore(TraceStore):
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            conn.execute("""
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS trace_sessions (
                     session_id TEXT PRIMARY KEY,
                     updated_at TEXT NOT NULL
                 )
-                """)
-            conn.execute("""
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS trace_events (
                     session_id TEXT NOT NULL,
                     event_idx INTEGER NOT NULL,
@@ -116,7 +119,8 @@ class SQLiteTraceStore(TraceStore):
                     payload_json TEXT NOT NULL,
                     PRIMARY KEY (session_id, event_idx)
                 )
-                """)
+                """
+            )
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_trace_events_session ON trace_events(session_id)"
             )
@@ -196,11 +200,13 @@ class SQLiteTraceStore(TraceStore):
     def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
         if max_sessions <= 0:
             return
-        rows = conn.execute("""
+        rows = conn.execute(
+            """
             SELECT session_id
             FROM trace_sessions
             ORDER BY updated_at DESC
-            """).fetchall()
+            """
+        ).fetchall()
         stale_session_ids = [row["session_id"] for row in rows[max_sessions:]]
         if stale_session_ids:
             conn.executemany(

--- a/src/po_core/cli/experiment.py
+++ b/src/po_core/cli/experiment.py
@@ -29,7 +29,8 @@ from po_core.experiments.storage import ExperimentStorage
 
 def _print_help() -> None:
     """ヘルプメッセージを表示"""
-    print("""
+    print(
+        """
 Po_core Experiment CLI
 
 Usage:
@@ -43,7 +44,8 @@ Commands:
     analyze      Analyze experiment results
     promote      Promote winner to main (if recommendation is 'promote')
     rollback     Rollback to previous backup
-""")
+"""
+    )
 
 
 def cmd_list() -> None:

--- a/tests/unit/test_rest_api.py
+++ b/tests/unit/test_rest_api.py
@@ -588,7 +588,9 @@ def test_review_pending_persists_across_app_reinitialization(tmp_path):
         "verdict": {"decision": "escalate"},
     }
     with TestClient(app, raise_server_exceptions=True) as client:
-        with patch("po_core.app.rest.routers.reason.po_run", return_value=escalate_result):
+        with patch(
+            "po_core.app.rest.routers.reason.po_run", return_value=escalate_result
+        ):
             resp = client.post(
                 "/v1/reason",
                 json={"input": "Need review", "session_id": "persist-pending-session"},
@@ -645,7 +647,9 @@ def test_review_decision_persists_across_app_reinitialization(tmp_path):
         "verdict": {"decision": "escalate"},
     }
     with TestClient(app, raise_server_exceptions=True) as client:
-        with patch("po_core.app.rest.routers.reason.po_run", return_value=escalate_result):
+        with patch(
+            "po_core.app.rest.routers.reason.po_run", return_value=escalate_result
+        ):
             create_resp = client.post(
                 "/v1/reason",
                 json={"input": "Need review", "session_id": "persist-decided-session"},
@@ -941,7 +945,10 @@ def test_reason_stream_auth_matrix(client_with_auth):
         json={"input": "test"},
         headers={"X-API-Key": "wrong"},
     )
-    with patch("po_core.app.rest.routers.reason.po_async_run", new=AsyncMock(return_value=_MOCK_RESULT)):
+    with patch(
+        "po_core.app.rest.routers.reason.po_async_run",
+        new=AsyncMock(return_value=_MOCK_RESULT),
+    ):
         ok = client_with_auth.post(
             "/v1/reason/stream",
             json={"input": "test"},
@@ -1010,18 +1017,20 @@ def test_reason_ws_accepts_query_param_api_key_when_opted_in(tmp_path):
     )
 
     async def _fake_async_run(*, user_input, settings, tracer):
-        tracer.emit(TraceEvent.now("pipeline_step", "req-ws-query-auth", {"step": "start"}))
+        tracer.emit(
+            TraceEvent.now("pipeline_step", "req-ws-query-auth", {"step": "start"})
+        )
         return _MOCK_RESULT
 
     with patch("po_core.app.rest.routers.reason.po_async_run", new=_fake_async_run):
         with TestClient(app, raise_server_exceptions=True) as client:
-            with client.websocket_connect("/v1/ws/reason?api_key=test-secret-key") as ws:
+            with client.websocket_connect(
+                "/v1/ws/reason?api_key=test-secret-key"
+            ) as ws:
                 ws.send_json({"input": "Is fairness objective?"})
                 first = ws.receive_json()
 
     assert first["chunk_type"] == "started"
-
-
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- CI was failing due to `black --check` reporting formatting violations in several REST/CLI modules and a unit test, so style-only edits were required to restore the CI gating. 
- These changes are formatting-only to maintain deterministic behavior and avoid any functional changes to business logic.

### Description
- Applied `black` formatting to the REST auth helper at `src/po_core/app/rest/auth.py` to satisfy line-wrapping rules. 
- Reformatted WebSocket helper and router code at `src/po_core/app/rest/routers/reason.py` and persistent trace store SQL blocks at `src/po_core/app/rest/store.py` to align with Black style. 
- Reformatted CLI help printing in `src/po_core/cli/experiment.py` and adjusted long context/patch and WebSocket-connect lines in `tests/unit/test_rest_api.py` to remove style violations. 
- No functional logic was changed and frozen/golden files were not modified.

### Testing
- Ran `black --check src tests` after formatting and the check succeeded with no files reported. 
- Ran `pytest -q` and the test suite passed in this environment with `3728 passed, 4 skipped`.
- Also validated targeted formatting with `black` on the modified files before re-checking the full tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6322331948328b84831a5d989820d)