### PR TITLE
Harden API-key check, add incremental trace append API, and make explanation failures observable (with tests)

### DIFF
--- a/reports/forge_root_audit_2026-04-23.md
+++ b/reports/forge_root_audit_2026-04-23.md
@@ -1,0 +1,60 @@
+# ForgeRoot 総合技術評価レポート
+
+## 1. エグゼクティブサマリー
+- 本リポジトリは、2系統の実行基盤を同居させています。
+  - `src/pocore/*` は決定性重視のケース実行パイプライン（`run_case_file`）です。
+  - `src/po_core/*` は REST/CLI/非同期実行を含む本番向けプラットフォームです。
+- 技術スタックは Python 3.10+、FastAPI、Pydantic v2、SlowAPI、SQLAlchemy、Torch、Transformers、Dash/Plotly などです。
+- 総合評価: **84 / 100**
+  - 強み: セキュリティ初期値（fail-closed auth, startup fail-fast）、テスト層の厚み、責務分離。
+  - 懸念: 決定性モデル（`pocore`）と非決定ランタイム（`po_core`）の併存による運用複雑性、広域例外握りつぶし箇所、メモリ/永続ストア一部でスレッド安全性に余地。
+
+## 2. アーキテクチャと設計の評価
+- エントリーポイント
+  - パッケージCLI: `po-core`, `po-self`, `po-trace`, `po-interactive`, `po-experiment` が `pyproject.toml` に定義されています。
+  - REST実行: `python -m po_core.app.rest` は `uvicorn` で `po_core.app.rest.server:app` を起動します。
+- 設計の良い点
+  - `src/pocore/orchestrator.py` は parse→engines→trace→compose の責務が明確。
+  - `src/po_core/app/api.py` は facade として機能し、内部実装依存の直接露出を避けています。
+  - `src/po_core/runtime/settings.py` は設定集中管理で、環境切替を入口で吸収しています。
+- 設計上の負債
+  - `src/pocore/*` と `src/po_core/*` の二重系統が存在し、仕様境界を知らない開発者が誤った実装面を変更しやすい構造です。
+  - Legacy API (`src/po_core/app/api.py` の `app`) を残しつつ新REST系が存在し、認証/運用ポリシーの一貫性を常時検証しないとドリフトしやすいです。
+
+## 3. コード品質と保守性
+### 【Good】
+- スキーマ検証が入出力で明示され、失敗時の詳細メッセージも整備されています。
+- RESTサーバ起動時に auth misconfig / 実行モード / sqlite+multi-worker を fail-fast で拒否する防御設計が入っています。
+- 認証は `skip_auth`・APIキー未設定・不一致を状態分離して扱っており、HTTP 503/401 を明確に返します。
+- ベンチマークテストが性能目標をコード化しており、回帰検知の運用がしやすいです。
+
+### 【Bad/技術的負債】
+- 例外握りつぶし
+  - `src/po_core/ensemble.py` で `ExplanationEmitted` 生成失敗時に `except Exception: pass` があり、監査ログ欠落が静かに発生し得ます。
+- 非決定性の混在
+  - `src/po_core/app/rest/routers/reason.py` と `src/po_core/app/api.py` で `uuid4` や `datetime.now()` を使用。`pocore` の deterministic 契約と思想が異なり、テスト/監査観点で混同リスクがあります。
+- 互換層の複雑化
+  - Legacy surface の維持は移行容易性に寄与する一方、セキュリティ設定の二重管理ポイントとなります。
+
+## 4. セキュリティとパフォーマンスのリスク
+- セキュリティ（評価）
+  - APIキー未設定時 fail-closed（起動拒否・503）を実装しており、公開APIとして良好。
+  - WebSocket は query API key を既定拒否し、明示opt-in時のみ許可するため、漏えいリスクを抑制。
+  - SQL層は SQLAlchemy ORM/SQLite parameter binding を使用しており、文字列連結SQL注入の典型パターンは確認されませんでした。
+- セキュリティ（懸念）
+  - API key 比較は通常比較（定数時間比較ではない）で、理論上タイミング差分攻撃面は残ります（実務上はTLS前提・ネットワークノイズで低リスクだが改善余地）。
+  - 一部 broad exception により、障害の観測性低下→検知遅延のセキュリティ運用リスクがあります。
+- パフォーマンス（評価）
+  - `tests/benchmarks/*` で p50/p90/目標値を定義し、RESTオーバーヘッド評価まで含む点は高評価。
+- パフォーマンス（懸念）
+  - `append_trace_event()` は毎回 `get` + 全件 `save` の再書き込みで、イベント数増大時に O(n^2) 的コストを招く可能性があります。
+  - in-memory WS rate log は prune 実装ありだが、極端なIP分散攻撃時には辞書キー膨張の余地が残ります。
+
+## 5. 改善のためのネクストアクション（優先順位順）
+1. [Highest] **例外握りつぶしの解消と監査イベント保証**
+   - `except Exception: pass` をやめ、構造化ログ＋失敗イベントを emit して可観測性を担保。
+2. [Medium] **認証比較のハードニング**
+   - API key 比較を `hmac.compare_digest` に置換し、ヘッダ解決・認可判定の一貫テストを追加。
+3. [Low] **トレース追記の計算量改善**
+   - `append_trace_event` を差分追記SQLへ変更し、長時間セッションでの再書き込みコストを削減。
+

--- a/src/po_core/app/rest/auth.py
+++ b/src/po_core/app/rest/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from dataclasses import dataclass
 from typing import Mapping
 
@@ -49,7 +50,7 @@ def evaluate_auth_policy(
         )
 
     provided = (presented_api_key or "").strip()
-    if provided != expected:
+    if not hmac.compare_digest(provided, expected):
         return AuthDecision(
             allowed=False,
             is_misconfigured=False,

--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -34,6 +34,10 @@ class TraceStore(ABC):
         """Persist trace events for a session."""
 
     @abstractmethod
+    def append(self, session_id: str, event: TraceEvent) -> None:
+        """Append a single trace event for a session."""
+
+    @abstractmethod
     def history(self, limit: int = 50) -> List[TraceHistorySummary]:
         """Return recent session summaries sorted by newest first."""
 
@@ -68,6 +72,11 @@ class InMemoryTraceStore(TraceStore):
         while len(self._sessions) > settings.max_trace_sessions:
             stale_id, _ = self._sessions.popitem(last=False)
             self._store.pop(stale_id, None)
+
+    def append(self, session_id: str, event: TraceEvent) -> None:
+        events = list(self._store.get(session_id, []))
+        events.append(event)
+        self.save(session_id, events)
 
     def history(self, limit: int = 50) -> List[TraceHistorySummary]:
         items = list(self._sessions.items())[-limit:]
@@ -202,6 +211,43 @@ class SQLiteTraceStore(TraceStore):
                 self._evict_if_needed(conn, settings.max_trace_sessions)
                 conn.commit()
 
+    def append(self, session_id: str, event: TraceEvent) -> None:
+        settings = get_api_settings()
+        with self._lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT MAX(event_idx) AS max_event_idx FROM trace_events WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                max_event_idx = (
+                    int(row["max_event_idx"])
+                    if row and row["max_event_idx"] is not None
+                    else -1
+                )
+                next_idx = max_event_idx + 1
+
+                conn.execute(
+                    "INSERT OR REPLACE INTO trace_sessions(session_id, updated_at) VALUES (?, ?)",
+                    (session_id, event.occurred_at.isoformat()),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO trace_events (
+                        session_id, event_idx, event_type, occurred_at, correlation_id, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_id,
+                        next_idx,
+                        event.event_type,
+                        event.occurred_at.isoformat(),
+                        event.correlation_id,
+                        json.dumps(dict(event.payload), ensure_ascii=False, sort_keys=True),
+                    ),
+                )
+                self._evict_if_needed(conn, settings.max_trace_sessions)
+                conn.commit()
+
     def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
         if max_sessions <= 0:
             return
@@ -291,6 +337,4 @@ def save_trace(session_id: str, events: List[TraceEvent]) -> None:
 
 def append_trace_event(session_id: str, event: TraceEvent) -> None:
     """Append a single trace event to an existing session."""
-    store = get_trace_store()
-    existing = store.get(session_id) or []
-    store.save(session_id, existing + [event])
+    get_trace_store().append(session_id, event)

--- a/src/po_core/ensemble.py
+++ b/src/po_core/ensemble.py
@@ -7,6 +7,7 @@ Use ``po_core.app.api.run()`` or ``PoSelf.generate()`` instead.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, Union, cast
@@ -52,6 +53,7 @@ from po_core.trace.pareto_events import emit_pareto_debug_events
 from po_core.trace.synthesis_report_events import emit_synthesis_report_built
 
 DEFAULT_PHILOSOPHERS: List[str] = ["aristotle", "confucius", "wittgenstein"]
+logger = logging.getLogger(__name__)
 
 
 PHILOSOPHER_REGISTRY: Dict[str, type[Philosopher]] = {
@@ -302,8 +304,28 @@ def _run_phase_pre(
                     intent_explanation.to_dict(),
                 )
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.exception(
+                "Failed to emit ExplanationEmitted for intention gate verdict",
+                extra={
+                    "request_id": ctx.request_id,
+                    "stage": "intention",
+                    "decision": v1.decision.value,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            tracer.emit(
+                TraceEvent.now(
+                    "ExplanationEmitFailed",
+                    ctx.request_id,
+                    {
+                        "stage": "intention",
+                        "decision": v1.decision.value,
+                        "error_type": type(exc).__name__,
+                        "error_message": str(exc),
+                    },
+                )
+            )
 
     if v1.decision != Decision.ALLOW:
         fallback = compose_fallback(ctx, v1, stage="intention")

--- a/tests/test_auth_policy.py
+++ b/tests/test_auth_policy.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from po_core.app.rest import auth
+
+
+def test_evaluate_auth_policy_uses_compare_digest(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_compare_digest(provided: str, expected: str) -> bool:
+        calls.append((provided, expected))
+        return False
+
+    monkeypatch.setattr(auth.hmac, "compare_digest", _fake_compare_digest)
+
+    decision = auth.evaluate_auth_policy(
+        skip_auth=False,
+        configured_api_key="secret",
+        presented_api_key="wrong",
+    )
+
+    assert decision.allowed is False
+    assert decision.is_misconfigured is False
+    assert decision.message == "Invalid or missing API key"
+    assert calls == [("wrong", "secret")]
+

--- a/tests/test_run_turn_e2e.py
+++ b/tests/test_run_turn_e2e.py
@@ -253,6 +253,27 @@ class TestSafetyModeTransitions:
         assert mode == "normal"
 
 
+def test_explanation_emit_failure_is_observable(monkeypatch):
+    """Explanation build failure must emit ExplanationEmitFailed (no silent swallow)."""
+    from po_core import ensemble as ensemble_module
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("synthetic explanation failure")
+
+    monkeypatch.setattr(ensemble_module, "build_explanation_from_verdict", _raise)
+
+    deps, tracer, _ = _build_deps(freedom_pressure=0.35)  # triggers non-ALLOW intention
+    run_turn(_make_ctx("Potentially risky input"), deps)
+
+    failed_events = [e for e in tracer.events if e.event_type == "ExplanationEmitFailed"]
+    assert len(failed_events) == 1
+    payload = failed_events[0].payload
+    assert payload["stage"] == "intention"
+    assert payload["decision"] == "revise"
+    assert payload["error_type"] == "RuntimeError"
+    assert "synthetic explanation failure" in payload["error_message"]
+
+
 # ══════════════════════════════════════════════════════════════════════════
 # 3. Degradation Paths
 # ══════════════════════════════════════════════════════════════════════════

--- a/tests/test_storage_worker_guard.py
+++ b/tests/test_storage_worker_guard.py
@@ -8,7 +8,8 @@ from fastapi.testclient import TestClient
 from po_core.app.rest.config import APISettings
 from po_core.app.rest.review_store import SQLiteReviewStore
 from po_core.app.rest.server import create_app
-from po_core.app.rest.store import SQLiteTraceStore
+from po_core.app.rest.store import InMemoryTraceStore, SQLiteTraceStore
+from po_core.domain.trace_event import TraceEvent
 
 EXPECTED_STARTUP_MESSAGE = (
     "Startup aborted: workers > 1 is not supported with sqlite storage backends. "
@@ -70,3 +71,39 @@ def test_review_store_applies_sqlite_pragmas(tmp_path) -> None:
 
     assert journal_mode.lower() == "wal"
     assert busy_timeout == 5000
+
+
+def test_sqlite_trace_store_append_persists_incrementally(tmp_path) -> None:
+    store = SQLiteTraceStore(str(tmp_path / "trace_store.sqlite3"))
+    session_id = "s-append"
+    first = TraceEvent.now("EventA", session_id, {"n": 1})
+    second = TraceEvent.now("EventB", session_id, {"n": 2})
+
+    store.append(session_id, first)
+    store.append(session_id, second)
+
+    events = store.get(session_id)
+    assert events is not None
+    assert [e.event_type for e in events] == ["EventA", "EventB"]
+    assert [e.payload["n"] for e in events] == [1, 2]
+
+    with store._connect() as conn:
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM trace_events WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+    assert cnt == 2
+
+
+def test_inmemory_trace_store_append_keeps_existing_events() -> None:
+    store = InMemoryTraceStore()
+    session_id = "mem-append"
+    first = TraceEvent.now("EventA", session_id, {"n": 1})
+    second = TraceEvent.now("EventB", session_id, {"n": 2})
+
+    store.append(session_id, first)
+    store.append(session_id, second)
+
+    events = store.get(session_id)
+    assert events is not None
+    assert [e.event_type for e in events] == ["EventA", "EventB"]


### PR DESCRIPTION
### Motivation
- Prevent timing attacks by using a constant-time comparison for API keys when evaluating auth. 
- Avoid O(n^2) behaviour and enable safer incremental writes for trace events by adding an append API to trace stores. 
- Stop silently swallowing explanation-generation errors and ensure failures are logged and emitted as observable trace events for auditability.

### Description
- Replace plain equality with `hmac.compare_digest` in `po_core.app.rest.auth.evaluate_auth_policy` and import `hmac` to harden API-key comparison. 
- Introduce `TraceStore.append` abstract method and implement `append` for `InMemoryTraceStore` and `SQLiteTraceStore`, with the SQLite variant performing an incremental `INSERT` and updating `trace_sessions` under a lock. 
- Change `append_trace_event` to call the new `append` method rather than reloading and resaving the full session. 
- Replace a broad `except Exception: pass` in `po_core.ensemble` with structured `logger.exception` logging and emit a `ExplanationEmitFailed` `TraceEvent` containing error details. 
- Add tests: `tests/test_auth_policy.py` to assert `compare_digest` is used, extend `tests/test_run_turn_e2e.py` with `test_explanation_emit_failure_is_observable`, and add `tests/test_storage_worker_guard.py` checks for `SQLiteTraceStore.append` and `InMemoryTraceStore.append`. 
- Add a new audit report at `reports/forge_root_audit_2026-04-23.md` summarizing repo findings.

### Testing
- Ran `pytest tests/test_auth_policy.py` which asserted `evaluate_auth_policy` uses `hmac.compare_digest` and passed. 
- Ran the new `test_explanation_emit_failure_is_observable` in `tests/test_run_turn_e2e.py` which confirmed `ExplanationEmitFailed` is emitted and passed. 
- Ran the new SQLite and in-memory append tests in `tests/test_storage_worker_guard.py` which verified incremental persistence and in-memory append behavior and passed. 
- The modified test subset above passed locally under `pytest` (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c3e17574832892940cfd340704f0)