### PR TITLE
JSON IPC worker, trace eviction fix, deterministic recommendation, runtime guardrails docs, and replay tests

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -15,6 +15,34 @@ Po_core includes a comprehensive safety system designed to:
 
 ---
 
+## Runtime Deployment Guardrails (P0)
+
+These rules are mandatory for production operations and are based on current
+runtime behavior in the REST layer.
+
+### 1) `PO_TRUST_PROXY_HEADERS` must be enabled only behind a trusted proxy
+
+- Default is `false` and should remain `false` unless your deployment is
+  behind a reverse proxy/load balancer you control.
+- When `true`, rate limiting uses forwarded client IP information. If enabled
+  on a directly exposed service, spoofed headers can weaken per-IP controls.
+- Operational rule:
+  - Public direct exposure: **must be `PO_TRUST_PROXY_HEADERS=false`**
+  - Trusted ingress (Nginx/ALB/Envoy etc.): may be `true` with strict header
+    sanitization at the proxy.
+
+### 2) `PO_WS_ALLOW_QUERY_API_KEY` is forbidden by default
+
+- Default is `false` and should stay `false` in all long-lived environments.
+- Query-string API keys are easier to leak (logs, browser history, referer-like
+  traces, monitoring tools).
+- Operational rule:
+  - Production/staging: **must be `PO_WS_ALLOW_QUERY_API_KEY=false`**
+  - Short-lived local troubleshooting only: temporary `true` is allowed with
+    explicit expiration and key rotation after use.
+
+---
+
 ## Architecture
 
 The safety system consists of three layers:

--- a/src/po_core/app/rest/store.py
+++ b/src/po_core/app/rest/store.py
@@ -251,12 +251,21 @@ class SQLiteTraceStore(TraceStore):
     def _evict_if_needed(self, conn: sqlite3.Connection, max_sessions: int) -> None:
         if max_sessions <= 0:
             return
-        rows = conn.execute("""
+        row = conn.execute("SELECT COUNT(1) AS n FROM trace_sessions").fetchone()
+        session_count = int(row["n"]) if row and row["n"] is not None else 0
+        excess = session_count - max_sessions
+        if excess <= 0:
+            return
+        stale_rows = conn.execute(
+            """
             SELECT session_id
             FROM trace_sessions
-            ORDER BY updated_at DESC
-            """).fetchall()
-        stale_session_ids = [row["session_id"] for row in rows[max_sessions:]]
+            ORDER BY updated_at ASC
+            LIMIT ?
+            """,
+            (excess,),
+        ).fetchall()
+        stale_session_ids = [row["session_id"] for row in stale_rows]
         if stale_session_ids:
             conn.executemany(
                 "DELETE FROM trace_events WHERE session_id = ?",

--- a/src/po_core/philosopher_worker.py
+++ b/src/po_core/philosopher_worker.py
@@ -1,32 +1,46 @@
 """
-philosopher_worker.py — DEPRECATED stdin/stdout pickle IPC worker.
+philosopher_worker.py — stdin/stdout JSON IPC worker.
 
-This module is NOT used by any production code path.  The active process
+This module is NOT used by any production code path. The active process
 execution path is ``po_core.runtime.philosopher_executor._run_one_in_subprocess``
 via ``multiprocessing.Queue``.
 
-SECURITY NOTE (B301):
-  The pickle.loads() call below is intentionally restricted:
-  - It is only reachable when this script is invoked as ``__main__``
-  - The stdin pipe is controlled exclusively by a parent Po_core process
-  - Input is validated to be SerializedJob before use
-
-MIGRATION STATUS: pending replacement with JSON+dataclass round-trip.
-  Blocker: SerializedJob contains philosopher instances (non-JSON-serializable).
-  Approach: reconstruct philosopher from philosopher_id + registry in worker.
-  Tracked in: docs/tech_debt/P3-2-pickle-ipc.md
+Security posture:
+- No pickle deserialization.
+- Input is strict JSON payload with philosopher_id + serializable snapshots.
+- Philosopher instance is reconstructed in-worker from registry metadata.
 """
 from __future__ import annotations
 
-import pickle  # nosec B301 — see module docstring above
+import json
 import struct
 import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
 
 from po_core.philosopher_process import ExecOutcome, SerializedJob, run_one_philosopher
+from po_core.philosophers.registry import PhilosopherRegistry
+
+from .domain.context import Context
+from .domain.intent import Intent
+from .domain.memory_snapshot import MemoryItem, MemorySnapshot
+from .domain.tensor_snapshot import TensorSnapshot
 
 # Length-prefixed framing: 4-byte big-endian uint32 + payload bytes.
 # Prevents partial-read bugs when stdout is flushed in chunks.
 _FRAME_HEADER = "!I"
+
+
+@dataclass(frozen=True)
+class _JsonJob:
+    philosopher_id: str
+    ctx: Context
+    intent: Intent
+    tensors: TensorSnapshot
+    memory: MemorySnapshot
+    limit_per_philosopher: int
+    timeout_s: float
 
 
 def _write_framed(stream: object, data: bytes) -> None:
@@ -36,12 +50,166 @@ def _write_framed(stream: object, data: bytes) -> None:
     stream.flush()
 
 
+def _parse_datetime(value: Any) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("datetime field must be a non-empty ISO-8601 string")
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _parse_context(payload: Mapping[str, Any]) -> Context:
+    request_id = str(payload.get("request_id") or "").strip()
+    user_input = str(payload.get("user_input") or "")
+    if not request_id:
+        raise ValueError("ctx.request_id is required")
+    created_at = _parse_datetime(payload.get("created_at"))
+    raw_meta = payload.get("meta")
+    meta = dict(raw_meta) if isinstance(raw_meta, Mapping) else {}
+    return Context(
+        request_id=request_id,
+        created_at=created_at,
+        user_input=user_input,
+        meta=meta,
+    )
+
+
+def _parse_intent(payload: Mapping[str, Any]) -> Intent:
+    raw_goals = payload.get("goals")
+    raw_constraints = payload.get("constraints")
+    raw_weights = payload.get("weights")
+    goals = [str(x) for x in raw_goals] if isinstance(raw_goals, list) else []
+    constraints = (
+        [str(x) for x in raw_constraints] if isinstance(raw_constraints, list) else []
+    )
+    weights = (
+        {str(k): float(v) for k, v in dict(raw_weights).items()}
+        if isinstance(raw_weights, Mapping)
+        else {}
+    )
+    return Intent(goals=goals, constraints=constraints, weights=weights)
+
+
+def _parse_tensors(payload: Mapping[str, Any]) -> TensorSnapshot:
+    computed_at = _parse_datetime(payload.get("computed_at"))
+    raw_metrics = payload.get("metrics")
+    metrics = (
+        {str(k): float(v) for k, v in dict(raw_metrics).items()}
+        if isinstance(raw_metrics, Mapping)
+        else {}
+    )
+    return TensorSnapshot(
+        computed_at=computed_at,
+        metrics=metrics,
+        version=str(payload.get("version") or "v1"),
+    )
+
+
+def _parse_memory(payload: Mapping[str, Any]) -> MemorySnapshot:
+    raw_items = payload.get("items")
+    items: list[MemoryItem] = []
+    if isinstance(raw_items, list):
+        for item in raw_items:
+            if not isinstance(item, Mapping):
+                continue
+            item_id = str(item.get("item_id") or "").strip()
+            text = str(item.get("text") or "")
+            created_at_raw = item.get("created_at")
+            if not item_id or created_at_raw is None:
+                continue
+            tags_raw = item.get("tags")
+            tags = [str(x) for x in tags_raw] if isinstance(tags_raw, list) else []
+            items.append(
+                MemoryItem(
+                    item_id=item_id,
+                    created_at=_parse_datetime(created_at_raw),
+                    text=text,
+                    tags=tags,
+                )
+            )
+    raw_meta = payload.get("meta")
+    meta = (
+        {str(k): str(v) for k, v in dict(raw_meta).items()}
+        if isinstance(raw_meta, Mapping)
+        else {}
+    )
+    summary = payload.get("summary")
+    return MemorySnapshot(
+        items=items,
+        summary=str(summary) if isinstance(summary, str) else None,
+        meta=meta,
+    )
+
+
+def _decode_json_job(payload: bytes) -> _JsonJob:
+    root = json.loads(payload.decode("utf-8"))
+    if not isinstance(root, Mapping):
+        raise ValueError("IPC payload must be a JSON object")
+    philosopher_id = str(root.get("philosopher_id") or "").strip()
+    if not philosopher_id:
+        raise ValueError("philosopher_id is required")
+    ctx_raw = root.get("ctx")
+    intent_raw = root.get("intent")
+    tensors_raw = root.get("tensors")
+    memory_raw = root.get("memory")
+    if not isinstance(ctx_raw, Mapping):
+        raise ValueError("ctx must be an object")
+    if not isinstance(intent_raw, Mapping):
+        raise ValueError("intent must be an object")
+    if not isinstance(tensors_raw, Mapping):
+        raise ValueError("tensors must be an object")
+    if not isinstance(memory_raw, Mapping):
+        raise ValueError("memory must be an object")
+
+    return _JsonJob(
+        philosopher_id=philosopher_id,
+        ctx=_parse_context(ctx_raw),
+        intent=_parse_intent(intent_raw),
+        tensors=_parse_tensors(tensors_raw),
+        memory=_parse_memory(memory_raw),
+        limit_per_philosopher=int(root.get("limit_per_philosopher", 3)),
+        timeout_s=float(root.get("timeout_s", 5.0)),
+    )
+
+
+def _load_philosopher(philosopher_id: str) -> Any:
+    registry = PhilosopherRegistry(cache_instances=False)
+    philosophers, errors = registry.load([philosopher_id])
+    if errors:
+        err = errors[0]
+        raise ValueError(
+            f"Failed to load philosopher {philosopher_id}: {err.error} ({err.module}:{err.symbol})"
+        )
+    if not philosophers:
+        raise ValueError(f"No philosopher loaded for id: {philosopher_id}")
+    return philosophers[0]
+
+
+def _encode_outcome(outcome: ExecOutcome) -> bytes:
+    payload = {
+        "proposals": [proposal.to_dict() for proposal in outcome.proposals],
+        "n": int(outcome.n),
+        "timed_out": bool(outcome.timed_out),
+        "error": outcome.error,
+        "latency_ms": int(outcome.latency_ms),
+        "philosopher_id": outcome.philosopher_id,
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+
+
 def main() -> int:
     payload = sys.stdin.buffer.read()
     try:
-        job = pickle.loads(payload)  # nosec B301
-    except (pickle.UnpicklingError, TypeError, ValueError) as exc:
-        # Pickle deserialization failure: return an error outcome instead of crashing
+        json_job = _decode_json_job(payload)
+        philosopher = _load_philosopher(json_job.philosopher_id)
+        job = SerializedJob(
+            philosopher=philosopher,
+            ctx=json_job.ctx,
+            intent=json_job.intent,
+            tensors=json_job.tensors,
+            memory=json_job.memory,
+            limit_per_philosopher=json_job.limit_per_philosopher,
+            timeout_s=json_job.timeout_s,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
         error_outcome = ExecOutcome(
             proposals=[],
             n=0,
@@ -50,17 +218,11 @@ def main() -> int:
             latency_ms=0,
             philosopher_id="<unknown>",
         )
-        _write_framed(sys.stdout.buffer, pickle.dumps(error_outcome))  # nosec B301
+        _write_framed(sys.stdout.buffer, _encode_outcome(error_outcome))
         return 1
 
-    if not isinstance(job, SerializedJob):
-        raise TypeError(f"Expected SerializedJob, got {type(job).__name__}")
-
     outcome = run_one_philosopher(job)
-    _write_framed(
-        sys.stdout.buffer,
-        pickle.dumps(outcome),  # nosec B301
-    )
+    _write_framed(sys.stdout.buffer, _encode_outcome(outcome))
     return 0
 
 

--- a/src/pocore/engines/recommendation_v1.py
+++ b/src/pocore/engines/recommendation_v1.py
@@ -17,6 +17,19 @@ def _has_profile(features: Optional[Dict[str, Any]], profile: str) -> bool:
     return isinstance(features, dict) and features.get("scenario_profile") == profile
 
 
+def _resolve_recommended_option_id(options: List[Dict[str, Any]]) -> str:
+    option_ids = [
+        str(opt.get("option_id"))
+        for opt in options
+        if isinstance(opt, dict) and isinstance(opt.get("option_id"), str)
+    ]
+    if "opt_1" in option_ids:
+        return "opt_1"
+    if option_ids:
+        return option_ids[0]
+    return "opt_1"
+
+
 def arbitrate_recommendation(
     case: Dict[str, Any],
     *,
@@ -24,13 +37,20 @@ def arbitrate_recommendation(
     features: Optional[Dict[str, Any]],
     options: List[Dict[str, Any]],
 ) -> Tuple[Dict[str, Any], str]:
-    """Produce recommendation payload with deterministic arbitration code."""
+    """Produce recommendation payload with deterministic arbitration code.
+
+    Contract:
+    - Recommendation arbitration is primarily feature-driven.
+    - When status is ``recommended``, ``recommended_option_id`` is resolved
+      from the provided ``options`` set deterministically.
+    """
+    recommended_option_id = _resolve_recommended_option_id(options)
 
     if _has_profile(features, PROFILE_CASE_001):
         return (
             {
                 "status": "recommended",
-                "recommended_option_id": "opt_1",
+                "recommended_option_id": recommended_option_id,
                 "reason": (
                     "重要不明点が残ったまま転職を断言するより、"
                     "期限付きで情報収集し基準で決断する方が誠実で後悔を減らしやすい。"
@@ -83,7 +103,7 @@ def arbitrate_recommendation(
         return (
             {
                 "status": "recommended",
-                "recommended_option_id": "opt_1",
+                "recommended_option_id": recommended_option_id,
                 "reason": (
                     "制約が矛盾している状態では、どの案も破綻しやすい。"
                     "まず制約を再設計してから進めるべき。"
@@ -116,7 +136,7 @@ def arbitrate_recommendation(
         return (
             {
                 "status": "recommended",
-                "recommended_option_id": "opt_1",
+                "recommended_option_id": recommended_option_id,
                 "reason": "期限が近いため、低リスクな案で前進しつつ不明点を並行して潰す。",
                 "counter": "不明点が残るため、見積もりや期待値にズレが出る。",
                 "alternatives": [
@@ -133,7 +153,7 @@ def arbitrate_recommendation(
     return (
         {
             "status": "recommended",
-            "recommended_option_id": "opt_1",
+            "recommended_option_id": recommended_option_id,
             "reason": "害を抑えつつ前進できるため。",
             "counter": "遅いと感じる可能性がある。",
             "alternatives": [

--- a/tests/test_session_replay_unit.py
+++ b/tests/test_session_replay_unit.py
@@ -5,6 +5,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+import yaml
+
+from pocore.runner import run_session_replay
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "session_replay.py"
 CASE_PATH = ROOT / "scenarios" / "case_002.yaml"
@@ -56,3 +61,56 @@ def test_session_replay_is_deterministic(tmp_path: Path) -> None:
     second = _run_replay(tmp_path, "run2")
 
     assert first == second
+
+
+def _write_case_and_answers(
+    tmp_path: Path, *, patch_ops: list[dict[str, object]]
+) -> tuple[Path, Path]:
+    case = {
+        "case_id": "case_replay_001",
+        "title": "session replay invalid patch",
+        "problem": "test",
+        "constraints": [],
+        "values": ["stability"],
+    }
+    answers = {"case_ref": "case_replay_001", "patch": patch_ops}
+    answers.update(
+        {
+            "version": "1.0",
+            "answers": [
+                {
+                    "question_id": "q1",
+                    "answer_text": "stub",
+                    "applied_patch_paths": [str(patch_ops[0]["path"])],
+                }
+            ],
+        }
+    )
+
+    case_path = tmp_path / "case.yaml"
+    answers_path = tmp_path / "answers.yaml"
+    case_path.write_text(yaml.safe_dump(case, allow_unicode=True), encoding="utf-8")
+    answers_path.write_text(
+        yaml.safe_dump(answers, allow_unicode=True), encoding="utf-8"
+    )
+    return case_path, answers_path
+
+
+def test_run_session_replay_rejects_unknown_patch_operation(tmp_path: Path) -> None:
+    case_path, answers_path = _write_case_and_answers(
+        tmp_path,
+        patch_ops=[{"op": "copy", "path": "/values/0", "value": "x"}],
+    )
+
+    with pytest.raises(ValueError, match="Unsupported patch operation"):
+        run_session_replay(case_path, answers_path)
+
+
+def test_run_session_replay_rejects_out_of_range_list_index(tmp_path: Path) -> None:
+    case_path, answers_path = _write_case_and_answers(
+        tmp_path,
+        patch_ops=[{"op": "replace", "path": "/values/9", "value": "x"}],
+    )
+
+    with pytest.raises(ValueError, match="List replace index out of range"):
+        run_session_replay(case_path, answers_path)


### PR DESCRIPTION
### Motivation

- Replace insecure pickle-based IPC with a safer, JSON-based worker to eliminate deserialization risks and enable clearer validation.
- Fix incorrect SQLite trace eviction logic so the store reliably removes the oldest sessions when exceeding `max_trace_sessions`.
- Make recommendation arbitration deterministic with a stable resolution of `recommended_option_id` from provided `options`.
- Document mandatory runtime deployment guardrails for proxy and websocket API-key behavior and add unit tests to validate session replay patch handling.

### Description

- Rewrote `philosopher_worker.py` to accept length-prefixed JSON IPC payloads, added strict parsing/validation helpers, reconstructs philosopher instances via `PhilosopherRegistry`, and emits JSON-encoded `ExecOutcome` results instead of `pickle` payloads.
- Fixed `SQLiteTraceStore._evict_if_needed` to compute session count via `SELECT COUNT(1)`, calculate `excess`, select the oldest sessions by `ORDER BY updated_at ASC LIMIT ?`, and delete only those stale sessions.
- Added `_resolve_recommended_option_id` and switched `arbitrate_recommendation` to derive `recommended_option_id` deterministically from the given `options` instead of hardcoding `opt_1`.
- Extended `docs/SAFETY.md` with a new "Runtime Deployment Guardrails (P0)" section describing required settings for `PO_TRUST_PROXY_HEADERS` and `PO_WS_ALLOW_QUERY_API_KEY`.
- Updated `tests/test_session_replay_unit.py` to use `pytest` and `yaml`, kept the determinism test, and added tests that assert `run_session_replay` rejects unsupported patch operations and out-of-range list indices, plus helper functions to write temporary case/answers files.

### Testing

- Ran `pytest tests/test_session_replay_unit.py` which executed the deterministic replay test and the two new negative tests for patch validation, and all tests passed.
- Confirmed the modified SQLite eviction logic through the unit test environment reproducing eviction scenarios (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cd5e1058832880919d907998fc08)