### PR TITLE
Sync Quickstart and release docs to published v1.0.3 and add release-readiness assertions

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -9,8 +9,8 @@ Po_coreの哲学駆動型AIシステムをすぐに試せるガイドです。
 git clone https://github.com/hiroshitanaka-creator/Po_core.git
 cd Po_core
 
-# 最新の公開済み public version 1.0.2 を install
-pip install "po-core-flyingpig==1.0.2"
+# 公開済み public version 1.0.3 を install
+pip install "po-core-flyingpig==1.0.3"
 ```
 
 ## 🚀 リリース成果物の作成（maintainer向け）
@@ -26,7 +26,7 @@ python -m build
 twine check dist/*
 ```
 
-> Repository target version は `1.0.3` ですが、latest published public version は引き続き `1.0.2` です。現時点で repo 内に固定できている public PyPI evidence は `docs/release/pypi_publication_v1.0.2.md` のみで、`1.0.3` の publication / workflow / clean install/import/smoke は pending です。
+> Repository target version は `1.0.3` で、latest published public version も `1.0.3` です。公開証跡は `docs/release/pypi_publication_v1.0.3.md` / `docs/release/testpypi_publish_log_v1.0.3.md` / `docs/release/smoke_verification_v1.0.3.md` に固定されています。workflow URL と full deps smoke は引き続き pending です。
 
 ## 🔐 REST ランタイム既定値
 
@@ -56,7 +56,7 @@ print(bool(res.text), res.consensus_leader)
 PY
 ```
 
-期待結果: install/import が成功し、最後の行で `True` とリーダー名が出力されること。なおこの install 例は latest published public version `1.0.2` 向けです。`1.0.3` は repository target version ですが、post-publish smoke transcript はまだ `docs/release/smoke_verification_v1.0.3.md` に未固定です。
+期待結果: install/import が成功し、最後の行で `True` とリーダー名が出力されること。install 例は latest published public version `1.0.3` に整合しています。
 
 ## ⚡ 30秒で試す
 
@@ -298,7 +298,7 @@ response = po.generate("この言葉の意味は何か？")
 export PYTHONPATH=/path/to/Po_core/src:$PYTHONPATH
 
 # または開発モードでインストール
-pip install "po-core-flyingpig==1.0.2"
+pip install "po-core-flyingpig==1.0.3"
 ```
 
 ### ImportError: No module named 'click' or 'rich'
@@ -341,7 +341,7 @@ open http://localhost:8000/docs
 ### ローカルで起動する
 
 ```bash
-pip install "po-core-flyingpig==1.0.2"
+pip install "po-core-flyingpig==1.0.3"
 
 # 推奨: 開発でも認証を有効化したまま試す
 export PO_API_KEY=dev-secret-key

--- a/QUICKSTART_EN.md
+++ b/QUICKSTART_EN.md
@@ -6,14 +6,14 @@ A quick guide to get started with Po_core's philosophy-driven AI system.
 
 ```bash
 # Install the published PyPI package
-pip install "po-core-flyingpig==1.0.2"
+pip install "po-core-flyingpig==1.0.3"
 ```
 
 
 
 ## 📦 Published package status
 
-Repository target version is `1.0.3`, while the latest published public version remains `1.0.2`. Today the repo evidences public PyPI publication only for `1.0.2` via `docs/release/pypi_publication_v1.0.2.md`; `1.0.3` publication, workflow-run URLs, and clean post-publish smoke transcripts remain out of bounds until operator-supplied evidence is recorded.
+Repository target version is `1.0.3`, and the latest published public version is also `1.0.3`. Publication evidence is fixed in `docs/release/pypi_publication_v1.0.3.md`, `docs/release/testpypi_publish_log_v1.0.3.md`, and `docs/release/smoke_verification_v1.0.3.md`; workflow-run URL(s) and full-deps smoke transcripts remain pending.
 
 ## 🔐 REST runtime defaults
 
@@ -261,7 +261,7 @@ response = po.generate("What does this word mean?")
 export PYTHONPATH=/path/to/Po_core/src:$PYTHONPATH
 
 # Or install in development mode
-pip install "po-core-flyingpig==1.0.2"
+pip install "po-core-flyingpig==1.0.3"
 ```
 
 ### ImportError: No module named 'click' or 'rich'
@@ -296,7 +296,7 @@ open http://localhost:8000/docs
 ### Start Locally
 
 ```bash
-pip install "po-core-flyingpig==1.0.2"
+pip install "po-core-flyingpig==1.0.3"
 export PO_API_KEY=dev-secret-key
 
 python -m po_core.app.rest

--- a/REPOSITORY_STRUCTURE.md
+++ b/REPOSITORY_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](./LICENSE)
 
-**Document Status:** release-readiness inventory aligned to repository target version `1.0.3` with latest published public evidence still fixed at `1.0.2`  
+**Document Status:** release-readiness inventory aligned to repository target version `1.0.3` and latest published public evidence fixed at `1.0.3`  
 **Last Updated:** 2026-03-20
 **Scope:** actual repository layout and release-critical files only
 
@@ -86,7 +86,7 @@ The published runtime package lives under `src/po_core/` and currently contains 
 Release-relevant module facts:
 
 - Package version SSOT is `src/po_core/__init__.py`.
-- Release-facing docs must describe `1.0.3` as the repository target version, keep `1.0.2` as the latest published public version until new evidence exists, and may claim only the specific publication facts backed by evidence files under `docs/release/`.
+- Release-facing docs must describe `1.0.3` as the repository target version, sync both repository target and latest published public version to `1.0.3`, and may claim only the specific publication facts backed by evidence files under `docs/release/`.
 - OpenAPI metadata is emitted from `src/po_core/app/rest/server.py`.
 - Installed package data is limited to config YAML, axis specs, JSON schemas, viewer assets, and `py.typed`; unfinished philosopher YAML prompt drafts live under `docs/philosopher_prompt_drafts/` and are not packaged.
 - Experimental Claude-testing modules are **not** under `src/po_core` and therefore are not part of the published runtime surface.

--- a/docs/status.md
+++ b/docs/status.md
@@ -40,9 +40,7 @@
 ## Remaining Evidence Gaps (post-publication)
 
 1. GitHub Actions workflow run URL(s) for `1.0.3` TestPyPI and PyPI runs — not yet fixed in-repo (GitHub API rate-limited 2026-03-22).
-2. Full deps install transcript (`pip install po-core-flyingpig==1.0.3` with all deps) — not completed this session (torch/CUDA deps are large).
-3. Clean-environment import transcript (`python -c "import po_core; print(po_core.__version__)"`) — pending full deps install.
-4. `scripts/release_smoke.py --check-entrypoints` transcript in clean post-publish venv — pending.
+2. Full deps install/import/runtime-smoke transcript in a clean post-publish environment (`pip install po-core-flyingpig==1.0.3` + import + `scripts/release_smoke.py --check-entrypoints`) — not completed this session (torch/CUDA deps are large).
 
 ## Notes
 
@@ -55,7 +53,7 @@
 Post-release follow-up (all publication steps complete):
 
 - Record GitHub Actions workflow run URL(s) for the successful `publish-testpypi` and `publish-pypi` runs once GitHub API rate limit resets or a token is available — update `docs/release/testpypi_publish_log_v1.0.3.md` and `docs/release/pypi_publication_v1.0.3.md`.
-- Complete full deps install (`pip install po-core-flyingpig==1.0.3`) and record clean import + runtime smoke transcript — update `docs/release/smoke_verification_v1.0.3.md` post-publish section.
+- Complete full deps install (`pip install po-core-flyingpig==1.0.3`) and record clean import + runtime smoke transcript (consolidated) — update `docs/release/smoke_verification_v1.0.3.md` post-publish section.
 - Stage 2 planning: v1.1.x feature work, ecosystem expansion (see ROADMAP_FINAL_FORM.md).
 
 ## Completed
@@ -68,4 +66,4 @@ Post-release follow-up (all publication steps complete):
 - 2026-03-21: prompt SSOT を再整合し、draft prompt docs/template から `defer` を除去して runtime action contract と一致させた。
 - 2026-03-21: public truth realignment として、42-philosopher canonical count / dummy helper semantics / `/v1/philosophers` public manifest filtering を docs・metadata・tests・REST router へ同期した.
 - 2026-03-21: runtime safety hardening として、REST server の execution mode default を `process` に変更し、unsafe `thread` mode は `PO_ALLOW_UNSAFE_THREAD_EXECUTION=true` を伴う開発時以外で拒否するようにした。
-- 2026-03-21: `scripts/release_smoke.py --check-entrypoints` が、import 済み checkout とは別物の stale site-packages metadata (`po-core-flyingpig==1.0.2`) を checkout 検証時の version mismatch と誤判定しないよう修正した。これは local/main checkout validation に対する false release blocker 修正である。
+- 2026-03-21: `scripts/release_smoke.py --check-entrypoints` が、import 済み checkout とは別物の stale site-packages metadata を checkout 検証時の version mismatch と誤判定しないよう修正した。これは local/main checkout validation に対する false release blocker 修正である。

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -187,6 +187,10 @@ def test_release_docs_fail_closed_on_stale_wording() -> None:
     assert "PO_CORS_ORIGINS=*" in quickstart_en
     assert "PO_ALLOW_UNSAFE_THREAD_EXECUTION=true" in quickstart_ja
     assert "PO_ALLOW_UNSAFE_THREAD_EXECUTION=true" in quickstart_en
+    assert 'po-core-flyingpig==1.0.2' not in quickstart_ja
+    assert 'po-core-flyingpig==1.0.2' not in quickstart_en
+    assert 'latest published public version remains `1.0.2`' not in quickstart_en
+    assert 'latest published public version は引き続き `1.0.2`' not in quickstart_ja
     assert "43 integrated runtime personas" not in readme
     assert "43 integrated runtime personas" not in quickstart_en
     assert "43の統合済みランタイム・ペルソナ" not in quickstart_ja


### PR DESCRIPTION
### Motivation
- Align user-facing Quickstart docs and repository inventory with the repository SSOT that shows `1.0.3` as the published version to avoid user confusion from lingering `1.0.2` install examples. 
- Keep `docs/status.md` honest by restricting pending evidence to only genuinely unresolved items (workflow URLs and consolidated full-deps install/import/runtime smoke). 
- Prevent accidental regression by adding automated assertions that detect re-introduction of `po-core-flyingpig==1.0.2` or old "latest published public version remains `1.0.2`" wording in the quickstarts.

### Description
- Updated install commands in `QUICKSTART.md` and `QUICKSTART_EN.md` from `pip install "po-core-flyingpig==1.0.2"` to `pip install "po-core-flyingpig==1.0.3"` and adjusted surrounding wording to reference the `1.0.3` evidence files. 
- Replaced wording in `REPOSITORY_STRUCTURE.md` so the document status and release-facing guidance reflect `1.0.3` as both repository target and latest published public evidence. 
- Consolidated the Remaining Evidence Gaps block in `docs/status.md` to list only the actual outstanding items (GitHub Actions workflow run URL(s) and full-deps install/import/runtime-smoke transcript) and removed the stale explicit `1.0.2` phrasing from history lines. 
- Extended `tests/test_release_readiness.py` to assert that `po-core-flyingpig==1.0.2` or the old "latest published public version remains `1.0.2`"/`latest published public version は引き続き \\`1.0.2\\`` wording does not appear in `QUICKSTART.md`/`QUICKSTART_EN.md`, so regressions are caught automatically.

### Testing
- Ran targeted grep checks to verify no remaining `po-core-flyingpig==1.0.2` occurrences in `QUICKSTART.md`, `QUICKSTART_EN.md`, `REPOSITORY_STRUCTURE.md`, and `docs/status.md`, and found none. 
- Ran `pytest tests/test_release_readiness.py -v` and the suite passed with `24 passed` (the modified release-readiness tests succeeded). 
- No full repository test-suite or heavy environment smoke (full-deps install with large optional deps) was run as part of this change because the edits are documentation and test-assertion updates only; those heavy smoke tasks remain in the Next/Follow-up items.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb38cad7548328b62465d9dd617b00)