### PR TITLE
docs(readme): add run_case() to Key Links and Python API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ pip install -e ".[dev]"
 | | |
 |---|---|
 | [Tutorial](./docs/TUTORIAL.md) | Step-by-step getting-started guide |
-| [Python API reference](#python-api) | `run()` / `PoSelf` / `PoSelfResponse` |
+| [Python API reference](#python-api) | `run()` / `run_case()` / `PoSelf` / `PoSelfResponse` |
+| [run_case API guide](./docs/RUN_CASE.md) | Structured case input → output_schema_v1 output |
 | [REST API](#rest-api) | FastAPI server + curl examples |
 | [Manifesto](./Po_core_Manifesto_When_Pigs_Fly.md) | Philosophy and motivation |
 | [Release state](https://github.com/hiroshitanaka-creator/Po_core/blob/main/docs/status.md) | Current version, evidence gaps, roadmap |
@@ -137,6 +138,8 @@ pip install -e ".[dev]"
 ---
 
 ## Python API
+
+Use `run_case(case: dict)` when you need output_schema_v1-conformant structured decision-support output. Use `run(user_input: str)` when you want the raw philosopher pipeline result.
 
 ### Simple API (Recommended)
 


### PR DESCRIPTION
## Summary

- **Key Links table**: add `run_case()` to the Python API row link text; add new row linking `docs/RUN_CASE.md`
- **Python API section**: add one sentence explaining when to use `run_case(case: dict)` vs `run(user_input: str)`

Docs-only. No runtime changes. Diff: 4 lines added, 1 line modified.

## Test plan

- [ ] Verify Key Links table renders correctly in GitHub markdown preview
- [ ] Verify `docs/RUN_CASE.md` link resolves (file added in #540)

https://claude.ai/code/session_012iE52MAKkTcFceywwEvy5H

---
_Generated by [Claude Code](https://claude.ai/code/session_012iE52MAKkTcFceywwEvy5H)_