### PR TITLE
release: prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-30
+
+### Added
+- feat(api): export `run_case(case: dict)` and `async_run_case()` from the top-level `po_core` package; returns `output_schema_v1`-conformant result (RT-GAP-004).
+- feat(ensemble): `CaseSignals` + `_SCENARIO_ROUTING` for scenario-aware philosopher selection — routes `values_clarification` and `conflicting_constraints` to dedicated `(preferred_tags, limit_override)` pairs (RT-GAP-001/002/003).
+- feat(trace): `SafetyModeInferred` event emitted immediately after `infer_safety_mode()` — 7-field payload covering mode, thresholds, source_metric, and reason (MODE-TR-1/2).
+- feat(trace): `CaseSignalsApplied` event emitted when `_apply_case_signals()` mutates the result dict — records `action_type_before/after` and `applied_changes` list (TR-1).
+- feat(trace): `PhilosophersSelected` payload extended with 7 selection-rationale fields: `scenario_type`, `preferred_tags`, `limit_override`, `limit`, `require_tags`, `max_risk`, `cost_budget` (SEL-TR-1).
+- feat(trace): `ParetoWinnerSelected` payload gains top-level `weights` dict and `winner.weighted_score` (6 sig. fig., recomputable within 1e-4) (AGG-TR-1/2).
+- feat(domain): `ParetoWeights.emergence` field — NORMAL=0.10, WARN=0.05, CRITICAL=0.00; all six objectives now appear in every Pareto scores dict (AGG-TR-3).
+- feat(tensors): `TensorComputed` payload gains `metric_status` — per-metric provenance dict covering all 4 expected metrics with `"computed"`/`"missing"` status and source (TENSOR-TR-1/2).
+- feat(tensors): `TensorEngine.compute()` populates `TensorSnapshot.values` with `TensorValue(source=module_name)` for each metric function (TENSOR-TR-2).
+- docs: `docs/ENGINE_TRACE_CONTRACT.md` — full field-level spec for all trace events (normal-path + override-path sequences, `weighted_score` recomputation formula, known non-goals).
+- docs: `docs/viewer/README.md` — normal path, override path, conditional events, key field changes, `weighted_score` verification arithmetic.
+- docs: `docs/viewer/sample_trace.json` updated — aligned to contract: metrics dict, metric_status, SafetyModeInferred, PhilosophersSelected rationale, ParetoFrontComputed emergence, ParetoWinnerSelected weights+weighted_score (TRACE-VIEW-1).
+
+### Tests
+- test(acceptance): 45 new acceptance tests in `tests/acceptance/test_runtime_acceptance.py` (TestRunCaseSchemaConformance, TestCaseSignalsTraceVisibility, TestParetoWinnerTraceContract, TestParetoWinnerScoreExplainability, TestParetoSafetyModeWeights, TestActionGateTraceContract, TestSafetyModeInferredTrace, TestPhilosopherSelectionRationale, TestTensorComputedTrace, TestTensorComputedStatusTrace).
+- test(unit): `tests/unit/test_safety_mode_inferred_branches.py` — 7 tests covering all 4 branches and 3 boundary/config cases (pure function, 0.08s).
+- test(unit): `tests/unit/test_sample_trace_contract.py` — 8 tests asserting sample_trace.json alignment with ENGINE_TRACE_CONTRACT (pure JSON parse, 0.06s).
+- Completion matrix: **164 pass / 0 fail / 0 not-yet** (was 110 at v1.0.3 close).
+
 ## [1.0.3] - 2026-03-22
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -26,7 +26,7 @@ python -m build
 twine check dist/*
 ```
 
-> Repository target version は `1.0.3` で、latest published public version も `1.0.3` です。公開証跡は `docs/release/pypi_publication_v1.0.3.md` / `docs/release/testpypi_publish_log_v1.0.3.md` / `docs/release/smoke_verification_v1.0.3.md` に固定されています。workflow URL と full deps smoke は引き続き pending です。
+> Repository target version は `1.1.0` で、latest published public version は `1.0.3` です。公開証跡は `docs/release/pypi_publication_v1.0.3.md` / `docs/release/testpypi_publish_log_v1.0.3.md` / `docs/release/smoke_verification_v1.0.3.md` に固定されています。`1.1.0` の publish は pending です。
 
 ## 🔐 REST ランタイム既定値
 

--- a/QUICKSTART_EN.md
+++ b/QUICKSTART_EN.md
@@ -13,7 +13,7 @@ pip install "po-core-flyingpig==1.0.3"
 
 ## 📦 Published package status
 
-Repository target version is `1.0.3`, and the latest published public version is also `1.0.3`. Publication evidence is fixed in `docs/release/pypi_publication_v1.0.3.md`, `docs/release/testpypi_publish_log_v1.0.3.md`, and `docs/release/smoke_verification_v1.0.3.md`; workflow-run URL(s) and full-deps smoke transcripts remain pending.
+Repository target version is `1.1.0`; the latest published public version is `1.0.3`. Publication evidence for `1.0.3` is fixed in `docs/release/pypi_publication_v1.0.3.md`, `docs/release/testpypi_publish_log_v1.0.3.md`, and `docs/release/smoke_verification_v1.0.3.md`. `1.1.0` publish is pending.
 
 ## 🔐 REST runtime defaults
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For full source layout and component detail → [Architecture docs](./02_archite
 
 ## Release State
 
-Version `1.0.3` is published on PyPI. Package classifiers declare `Development Status :: 4 - Beta`.
+Repository target version is `1.1.0`; `1.0.3` is the latest published on PyPI. Package classifiers declare `Development Status :: 4 - Beta`.
 
 For the complete evidence record, evidence gaps, and roadmap: **[docs/status.md](https://github.com/hiroshitanaka-creator/Po_core/blob/main/docs/status.md)**
 

--- a/REPOSITORY_STRUCTURE.md
+++ b/REPOSITORY_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](./LICENSE)
 
-**Document Status:** release-readiness inventory aligned to repository target version `1.0.3` and latest published public evidence fixed at `1.0.3`  
+**Document Status:** release-readiness inventory aligned to repository target version `1.1.0`; latest published public evidence fixed at `1.0.3`  
 **Last Updated:** 2026-03-20
 **Scope:** actual repository layout and release-critical files only
 
@@ -86,7 +86,7 @@ The published runtime package lives under `src/po_core/` and currently contains 
 Release-relevant module facts:
 
 - Package version SSOT is `src/po_core/__init__.py`.
-- Release-facing docs must describe `1.0.3` as the repository target version, sync both repository target and latest published public version to `1.0.3`, and may claim only the specific publication facts backed by evidence files under `docs/release/`.
+- Release-facing docs must describe `1.1.0` as the repository target version and `1.0.3` as the latest published public version; they may claim only the specific publication facts backed by evidence files under `docs/release/`.
 - OpenAPI metadata is emitted from `src/po_core/app/rest/server.py`.
 - Installed package data is limited to config YAML, axis specs, JSON schemas, viewer assets, and `py.typed`; unfinished philosopher YAML prompt drafts live under `docs/philosopher_prompt_drafts/` and are not packaged.
 - Experimental Claude-testing modules are **not** under `src/po_core` and therefore are not part of the published runtime surface.

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -2,7 +2,7 @@
 
 Minimal TypeScript client for the official `POST /v1/reason` contract generated from the repository OpenAPI schema.
 
-- Python package release SSOT remains `src/po_core/__init__.py` (`1.0.3` in this repo snapshot).
+- Python package release SSOT remains `src/po_core/__init__.py` (`1.1.0` in this repo snapshot; `1.0.3` is the latest published on PyPI).
 - This SDK README describes the same official REST contract used in `QUICKSTART.md` / `QUICKSTART_EN.md`; it does **not** claim separate npm publication evidence.
 - If the server keeps the recommended default `PO_SKIP_AUTH=false`, pass a non-empty API key so the client sends `x-api-key`.
 

--- a/docs/completion_matrix.md
+++ b/docs/completion_matrix.md
@@ -2,7 +2,7 @@
 
 Audit date: 2026-04-28  
 Last updated: 2026-04-30 (TRACE-VIEW-1: sample_trace.json aligned with ENGINE_TRACE_CONTRACT; viewer README added; 8 unit tests added; unit total 7→15, overall 156→164)  
-Source: `main @ e24cf74`
+Source: `release/v1.1.0-prep @ 7afd043`
 
 Legend: ✅ PASS · ❌ FAIL (gap exposed) · ⚠️ PARTIAL · 🔲 NOT YET
 

--- a/docs/completion_matrix.md
+++ b/docs/completion_matrix.md
@@ -1,8 +1,8 @@
-# Completion Matrix — Po_core v1.0.3
+# Completion Matrix — Po_core v1.1.0
 
 Audit date: 2026-04-28  
 Last updated: 2026-04-30 (TRACE-VIEW-1: sample_trace.json aligned with ENGINE_TRACE_CONTRACT; viewer README added; 8 unit tests added; unit total 7→15, overall 156→164)  
-Source: `main @ 22060ce`
+Source: `main @ e24cf74`
 
 Legend: ✅ PASS · ❌ FAIL (gap exposed) · ⚠️ PARTIAL · 🔲 NOT YET
 

--- a/docs/completion_matrix.md
+++ b/docs/completion_matrix.md
@@ -2,7 +2,7 @@
 
 Audit date: 2026-04-28  
 Last updated: 2026-04-30 (TRACE-VIEW-1: sample_trace.json aligned with ENGINE_TRACE_CONTRACT; viewer README added; 8 unit tests added; unit total 7→15, overall 156→164)  
-Source: `release/v1.1.0-prep @ 7afd043`
+Source: `release/v1.1.0-prep @ 04986bc`
 
 Legend: ✅ PASS · ❌ FAIL (gap exposed) · ⚠️ PARTIAL · 🔲 NOT YET
 

--- a/docs/operations/publish_playbook.md
+++ b/docs/operations/publish_playbook.md
@@ -2,7 +2,7 @@
 
 最優先ルール（単一真実）：[docs/厳格固定ルール.md](/docs/厳格固定ルール.md)
 最新進捗：[docs/status.md](/docs/status.md)
-最終オペレータ引き継ぎ（次回リリース用・簡潔版）：[docs/release/release_candidate_handoff_v1.0.3.md](/docs/release/release_candidate_handoff_v1.0.3.md)
+最終オペレータ引き継ぎ（次回リリース用・簡潔版）：[docs/release/release_candidate_handoff_v1.1.0.md](/docs/release/release_candidate_handoff_v1.1.0.md)
 
 このプレイブックは、`.github/workflows/publish.yml` を**人依存なく再現可能**に運用するための固定手順です。
 
@@ -37,7 +37,7 @@
 4. **タグ運用と provenance の整合**
    - `workflow_dispatch` / release の publish は `refs/heads/main` または `refs/tags/vX.Y.Z` 以外から publish しない。
    - publish guard は `git merge-base --is-ancestor <publish-sha> origin/main` で、公開対象コミットが `origin/main` 到達可能であることを必須条件として検証する。
-   - `vX.Y.Z` タグの `X.Y.Z` は `src/po_core/__init__.py` の `__version__` と一致していなければならない（例: `v1.0.3` ↔ `__version__ = "1.0.3"`）。
+   - `vX.Y.Z` タグの `X.Y.Z` は `src/po_core/__init__.py` の `__version__` と一致していなければならない（例: `v1.1.0` ↔ `__version__ = "1.1.0"`）。
    - 同一版数の再公開はしない（PyPIは同一versionの再upload不可）。
 5. **Trusted Publishing前提**
    - GitHub Environments に `testpypi` / `pypi` が存在する。

--- a/docs/release/release_candidate_handoff_v1.1.0.md
+++ b/docs/release/release_candidate_handoff_v1.1.0.md
@@ -1,0 +1,50 @@
+# Release Candidate Operator Handoff for v1.1.0
+
+Purpose: give the maintainer a compact, maintainer-focused pre-publish handoff bundle for release candidate `1.1.0` without overstating publication status.
+
+## 1. Machine-verified facts already fixed in-repo
+
+- Repository target version is `1.1.0`.
+- Latest public PyPI evidence points to `1.0.3` via `docs/release/pypi_publication_v1.0.3.md` (published 2026-03-22).
+- `pyproject.toml` reads package version dynamically from `src/po_core/__init__.py`.
+- Release readiness guardrails exist in `tests/test_release_readiness.py`.
+- `docs/status.md` explicitly separates pre-publish candidate truth from post-publish evidence truth.
+- `docs/release/smoke_verification_v1.1.0.md` is intentionally a pending placeholder, not publish evidence.
+- Completion matrix: **164 pass / 0 fail / 0 not-yet** (as of 2026-04-30).
+
+## 2. What v1.1.0 adds over v1.0.3
+
+- `po_core.run_case(case)` / `async_run_case(case)` public API (RT-GAP-004)
+- Scenario-aware philosopher selection via `CaseSignals` + `_SCENARIO_ROUTING` (RT-GAP-001/002/003)
+- Full engine trace audit contract: `SafetyModeInferred`, `CaseSignalsApplied`, `PhilosophersSelected` rationale, `ParetoWinnerSelected` weights+weighted_score, `TensorComputed` metric_status (TENSOR-TR-1/2, MODE-TR-1/2, SEL-TR-1, AGG-TR-1/2/3/4, TR-1)
+- `docs/ENGINE_TRACE_CONTRACT.md` — full field-level spec for all trace events
+- `docs/viewer/sample_trace.json` aligned to contract (TRACE-VIEW-1)
+- 53 new tests (completion matrix: 110 → 164)
+- All changes are backward-compatible: existing `po_core.run()` callers unaffected.
+
+## 3. Operator evidence still required before stronger public claims
+
+Do **not** claim any of the following for `1.1.0` until exact operator evidence is recorded in-repo:
+
+- successful GitHub Actions workflow run URL(s)
+- TestPyPI package URL(s) and whether TestPyPI was actually used
+- PyPI version page URL for `1.1.0`
+- clean-environment install transcript for `po-core-flyingpig==1.1.0`
+- clean-environment import transcript showing `po_core.__version__ == "1.1.0"`
+- clean-environment smoke transcript for the minimum supported runtime path
+- final classification of the publication path: `TestPyPI only` or `TestPyPI + PyPI`
+
+## 4. Pre-publish checklist
+
+- [x] `src/po_core/__init__.py` `__version__` = `"1.1.0"`
+- [x] `CHANGELOG.md` `[1.1.0]` section added above `[1.0.3]`
+- [x] `docs/status.md` Repository target version → `1.1.0`
+- [x] All `DOCS_WITH_VERSION` files mention `1.1.0`
+- [x] `tests/test_release_readiness.py` updated to expect `"1.1.0"`
+- [x] `docs/release/release_candidate_handoff_v1.1.0.md` (this file) exists
+- [x] `docs/release/smoke_verification_v1.1.0.md` exists (pending state)
+- [ ] CI green on `main` (`pytest tests/ -v -m "not slow"`)
+- [ ] Golden files regenerated after version bump
+- [ ] TestPyPI publish and smoke
+- [ ] PyPI publish
+- [ ] Post-publish smoke (`scripts/release_smoke.py --check-entrypoints`)

--- a/docs/release/smoke_verification_v1.1.0.md
+++ b/docs/release/smoke_verification_v1.1.0.md
@@ -1,0 +1,24 @@
+# Smoke Verification Evidence for v1.1.0
+
+- Version: `1.1.0`
+- Evidence status: **pre-publish placeholder** — pending actual publish
+- Pre-publish local smoke: pending
+- Post-publish state: pending — not yet published
+
+## Post-publish Evidence Summary
+
+| Evidence | Status |
+|----------|--------|
+| PyPI `1.1.0` public page | pending |
+| TestPyPI `1.1.0` public page | pending |
+| `pip install --no-deps` wheel install in clean venv | pending |
+| Workflow run URL | pending |
+| Full deps install + import + runtime smoke | pending |
+
+This file will be updated to confirmed evidence state after:
+1. `po-core-flyingpig==1.1.0` is uploaded to TestPyPI and PyPI.
+2. A clean-environment install/import/smoke transcript is recorded.
+3. GitHub Actions workflow run URL(s) are retrieved and noted here.
+
+See `docs/release/pypi_publication_v1.0.3.md` for the reference pattern of a completed evidence file.
+See `docs/release/release_candidate_handoff_v1.1.0.md` for the pre-publish operator checklist.

--- a/docs/release/smoke_verification_v1.1.0.md
+++ b/docs/release/smoke_verification_v1.1.0.md
@@ -1,4 +1,6 @@
-# Smoke Verification Evidence for v1.1.0
+# Smoke Verification Placeholder for v1.1.0
+
+> ⚠️ **PRE-PUBLISH PLACEHOLDER — this is not evidence.** All fields are pending actual publication.
 
 - Version: `1.1.0`
 - Evidence status: **pre-publish placeholder** — pending actual publish

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,7 +17,7 @@
 - v1.1.0 candidate handoff: `docs/release/release_candidate_handoff_v1.1.0.md`
 - v1.1.0 smoke evidence: `docs/release/smoke_verification_v1.1.0.md` (pending — not yet published)
 - External publish status (v1.0.3): **`1.0.3` published on PyPI** — https://pypi.org/project/po-core-flyingpig/1.0.3/
-- External publish status (v1.1.0): `1.1.0` published on PyPI — ⏳ pending (not yet uploaded)
+- PyPI publication for `1.1.0`: pending — not yet uploaded.
 - PyPI upload timestamp (v1.0.3): `2026-03-22T15:10:30` UTC (confirmed via PyPI JSON API)
 - TestPyPI upload timestamp (v1.0.3): `2026-03-22T13:44:50` UTC (confirmed via TestPyPI JSON API)
 - Pending evidence (v1.1.0): Record GitHub Actions workflow run URL(s); record clean import + runtime smoke transcript post-publish.

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,16 +8,19 @@
 
 ## Current Release State
 
-- Repository target version: `1.0.3`
+- Repository target version: `1.1.0`
 - Latest published public version: `1.0.3`
 - Package version SSOT: `src/po_core/__init__.py` の `__version__`
 - Public release evidence in-repo: `docs/release/pypi_publication_v1.0.3.md` fixes PyPI publication evidence for `1.0.3`
 - TestPyPI evidence in-repo: `docs/release/testpypi_publish_log_v1.0.3.md`
 - Post-publish smoke evidence in-repo: `docs/release/smoke_verification_v1.0.3.md` (post-publish section updated 2026-03-22; full-deps smoke transcript appended 2026-04-28)
-- External publish status: **`1.0.3` published on PyPI** — https://pypi.org/project/po-core-flyingpig/1.0.3/
-- PyPI upload timestamp: `2026-03-22T15:10:30` UTC (confirmed via PyPI JSON API)
-- TestPyPI upload timestamp: `2026-03-22T13:44:50` UTC (confirmed via TestPyPI JSON API)
-- Pending evidence: GitHub Actions workflow run URL(s) — not retrievable via available MCP tooling (no `list_workflow_runs` endpoint); PyPI JSON API serves as proof of publication. No other evidence gaps remain.
+- v1.1.0 candidate handoff: `docs/release/release_candidate_handoff_v1.1.0.md`
+- v1.1.0 smoke evidence: `docs/release/smoke_verification_v1.1.0.md` (pending — not yet published)
+- External publish status (v1.0.3): **`1.0.3` published on PyPI** — https://pypi.org/project/po-core-flyingpig/1.0.3/
+- External publish status (v1.1.0): `1.1.0` published on PyPI — ⏳ pending (not yet uploaded)
+- PyPI upload timestamp (v1.0.3): `2026-03-22T15:10:30` UTC (confirmed via PyPI JSON API)
+- TestPyPI upload timestamp (v1.0.3): `2026-03-22T13:44:50` UTC (confirmed via TestPyPI JSON API)
+- Pending evidence (v1.1.0): Record GitHub Actions workflow run URL(s); record clean import + runtime smoke transcript post-publish.
 
 ## Canonical public wording
 
@@ -28,7 +31,7 @@
 ## Release Readiness Facts
 
 - `pyproject.toml` は version を `po_core.__version__` から動的読込する。
-- README / QUICKSTART / QUICKSTART_EN / CHANGELOG / REPOSITORY_STRUCTURE / この `docs/status.md` は、`1.0.3` を repository target version として扱う。
+- README / QUICKSTART / QUICKSTART_EN / CHANGELOG / REPOSITORY_STRUCTURE / この `docs/status.md` は、`1.1.0` を repository target version として扱う。
 - Release workflow (`.github/workflows/publish.yml`) は same-SHA TestPyPI prerequisite を含む strict gate を維持している。
 - `docs/release/pypi_publication_v1.0.3.md` により `1.0.3` の public PyPI publication fact は repo 内へ固定されている（確認 2026-03-22）。
 - `docs/release/testpypi_publish_log_v1.0.3.md` により `1.0.3` の TestPyPI publication fact は repo 内へ固定されている（確認 2026-03-22）。
@@ -66,9 +69,16 @@ All evidence gaps are now closed:
 
 ## Next
 
-Post-release follow-up:
+v1.1.0 publish tasks:
 
-- Stage 2 planning: v1.1.x feature work, ecosystem expansion (see ROADMAP_FINAL_FORM.md).
+- Record GitHub Actions workflow run URL(s) for the v1.1.0 publish run.
+- record clean import + runtime smoke transcript in a fresh venv post-publish.
+- Update `docs/release/smoke_verification_v1.1.0.md` from "pending" to confirmed evidence.
+- Update `docs/status.md`: Latest published public version → `1.1.0`; External publish status → confirmed.
+
+Stage 2 planning (after publish):
+
+- Stage 2 planning: v1.2.x feature work, ecosystem expansion (see ROADMAP_FINAL_FORM.md).
 
 ## Completed
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -195,7 +195,7 @@ python examples/philosopher_comparison.py
 pip install -e .
 ```
 
-> `requirements.txt` / `requirements-dev.txt` は clone 済み checkout 用の repo-local convenience wrappers です。外部利用者向けの依存 truth source は `pyproject.toml` なので、配布物から使う場合は `pip install "po-core-flyingpig==1.0.3"` か extras を使ってください。
+> `requirements.txt` / `requirements-dev.txt` は clone 済み checkout 用の repo-local convenience wrappers です。外部利用者向けの依存 truth source は `pyproject.toml` なので、配布物から使う場合は `pip install "po-core-flyingpig==1.0.3"` か extras を使ってください（repository target: `1.1.0`; 1.1.0 publish は pending）。
 
 ### 最小限のコード例
 

--- a/src/po_core/__init__.py
+++ b/src/po_core/__init__.py
@@ -11,7 +11,7 @@ Public API:
     from po_core import PoSelf, PoSelfResponse  # High-level wrapper
 """
 
-__version__ = "1.0.3"
+__version__ = "1.1.0"
 __author__ = "Flying Pig Project"
 __email__ = "flyingpig0229+github@gmail.com"
 

--- a/tests/acceptance/scenarios/at_001_expected.json
+++ b/tests/acceptance/scenarios/at_001_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "a999e46e-3e3b-4516-0fb6-ee9b2231e413",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_002_expected.json
+++ b/tests/acceptance/scenarios/at_002_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "dcb13e7c-4397-c96c-884e-03dc266f9640",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_003_expected.json
+++ b/tests/acceptance/scenarios/at_003_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "f0114944-ebbc-2093-4b9d-82d9311de68d",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_004_expected.json
+++ b/tests/acceptance/scenarios/at_004_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "f0bed7ad-aedf-ccc6-281e-412886722b47",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_005_expected.json
+++ b/tests/acceptance/scenarios/at_005_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "2dea63ef-4bd3-fc1c-af45-b5c2f16b4f4c",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_006_expected.json
+++ b/tests/acceptance/scenarios/at_006_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "9c7f481d-fb3c-3db1-b46f-f8993170ea04",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_007_expected.json
+++ b/tests/acceptance/scenarios/at_007_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "6a4af85e-e922-2e39-be6e-a9508d0639d0",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_008_expected.json
+++ b/tests/acceptance/scenarios/at_008_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "95b51cca-16fe-6261-5bba-a05cd94e8a35",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_009_expected.json
+++ b/tests/acceptance/scenarios/at_009_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "c23ad049-4f8f-e4e5-c276-61df6ee3feee",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_010_expected.json
+++ b/tests/acceptance/scenarios/at_010_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "6afe20af-63c1-3ee0-5bf3-48e1e8b29d9d",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_011_expected.json
+++ b/tests/acceptance/scenarios/at_011_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "e9196d85-1273-ec9b-0e82-d0631b6faa58",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/at_012_expected.json
+++ b/tests/acceptance/scenarios/at_012_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "2c5e957a-0ac1-347a-684a-528afe8d3d8c",
       "seed": 42,
       "deterministic": true,

--- a/tests/acceptance/scenarios/session_001_expected.json
+++ b/tests/acceptance/scenarios/session_001_expected.json
@@ -4,7 +4,7 @@
   "expected": {
     "meta": {
       "schema_version": "1.0",
-      "pocore_version": "1.0.3",
+      "pocore_version": "1.1.0",
       "run_id": "6f337caa-420f-f293-e2c9-20bff94d17bf",
       "seed": 42,
       "deterministic": true,

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -116,7 +116,10 @@ def test_release_state_split_is_explicit_and_honest() -> None:
     assert published_version == "1.0.3"
     assert f"Repository target version: `{version}`" in status_doc
     assert f"Latest published public version: `{published_version}`" in status_doc
-    assert f"`{version}` published on PyPI" in status_doc
+    # v1.1.0 is not yet published — assert honest pre-publish state
+    assert f"PyPI publication for `{version}`" in status_doc
+    assert "not yet uploaded" in status_doc
+    assert f"`{version}` published on PyPI" not in status_doc  # guard against false claims
     assert "Remaining Evidence Gaps" in status_doc
 
 

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -112,7 +112,7 @@ def test_release_state_split_is_explicit_and_honest() -> None:
     published_version = TARGET_PUBLIC_VERSION
     status_doc = _read("docs/status.md")
 
-    assert version == "1.0.3"
+    assert version == "1.1.0"
     assert published_version == "1.0.3"
     assert f"Repository target version: `{version}`" in status_doc
     assert f"Latest published public version: `{published_version}`" in status_doc

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -119,7 +119,9 @@ def test_release_state_split_is_explicit_and_honest() -> None:
     # v1.1.0 is not yet published — assert honest pre-publish state
     assert f"PyPI publication for `{version}`" in status_doc
     assert "not yet uploaded" in status_doc
-    assert f"`{version}` published on PyPI" not in status_doc  # guard against false claims
+    assert (
+        f"`{version}` published on PyPI" not in status_doc
+    )  # guard against false claims
     assert "Remaining Evidence Gaps" in status_doc
 
 


### PR DESCRIPTION
## 必須チェック（SSOT / 進捗 / テスト報告）

- [x] SSOT `docs/厳格固定ルール.md` を読んだ
- [x] `docs/status.md` を更新した（どこを動かしたかを記載）
- [x] 実行したテストコマンドと結果を下記に記載した
- [x] 影響範囲とロールバック手順を下記に記載した

Requirement IDs:
- NFR-GOV-001

## Status Update

更新箇所: `docs/status.md`, `docs/completion_matrix.md`, `CHANGELOG.md`, `docs/release/release_candidate_handoff_v1.1.0.md`, `docs/release/smoke_verification_v1.1.0.md`, version-stamped docs and golden metadata.

更新内容: Prepare repository target version `1.1.0` while keeping latest published public version at `1.0.3`. Add CHANGELOG `[1.1.0]`, update `__version__`, update release readiness assertions for honest pre-publish state, add v1.1.0 release candidate handoff, and keep v1.1.0 publish status explicitly pending / not uploaded.

## Test Report

実行ログ（コマンドと結果）:
- `pytest tests/test_release_readiness.py -q` → 24 passed / 0 failed

Known unrelated failures:
- `test_acceptance_golden_diff` failures at_001/007/008/009/011 are pre-existing on main and unrelated to this branch.

## Impact / Rollback

影響範囲: Release-prep only. Updates repository target version to `1.1.0`, release docs, release readiness expectations, and version-stamped golden metadata. Does not publish, tag, or create a GitHub Release.

ロールバック手順: Revert the squash merge commit for PR #548. This restores repository target version and release-prep docs to the previous main state. No package publication or external release rollback is needed because no TestPyPI/PyPI publish, git tag, or GitHub Release is performed.

## Summary

- Bumps package version to 1.1.0
- Adds CHANGELOG [1.1.0]
- Updates release-state docs while keeping latest published public version at 1.0.3
- Adds v1.1.0 release candidate handoff
- Adds pre-publish smoke placeholder clearly marked as not evidence
- Updates release readiness checks for honest pre-publish status
- Updates version-stamped golden metadata only
- Updates completion_matrix Source to release/v1.1.0-prep @ 04986bc

## Explicit non-actions

- No TestPyPI publish
- No PyPI publish
- No git tag
- No GitHub Release

https://claude.ai/code/session_012iE52MAKkTcFceywwEvy5H