### PR TITLE
fix(schemas): import Traversable from importlib.resources.abc

### DIFF
--- a/src/po_core/schemas/__init__.py
+++ b/src/po_core/schemas/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from importlib.resources import files
 from typing import Final
 


### PR DESCRIPTION
## このPRで解消するもの

- Python 3.14 互換の `Traversable` import 問題
  （`importlib.abc.Traversable` → `importlib.resources.abc.Traversable`）
- `pytest tests/test_golden_e2e.py tests/test_input_schema.py -v` → **62 passed**（Python 3.11.15 環境）

## このPRで解消しないもの

- bandit Low severity 2件の詳細確認
- build / twine CI 組み込み
- フル `pytest tests/ -v -m "not slow"` の実行確認
- Python 3.14 実環境での再検証（本環境は 3.11.15）

## 変更ファイル

`src/po_core/schemas/__init__.py` のみ（1行変更）

## 変更内容

`importlib.abc.Traversable` は Python 3.12 以降 deprecated、Python 3.14 での削除が懸念される。
正規パス `importlib.resources.abc.Traversable`（Python 3.9+）に移行。
`requires-python >=3.10` の変更なし、fallback なし。

```diff
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
```

## 根拠

- `importlib.resources.abc.Traversable` は Python 3.9 で追加
- プロジェクトの `requires-python = ">=3.10"` を下回るため fallback 不要
- Python 3.11 で両 import が同一クラスを指すことを確認済み（`T1 is T2 → True`）

## 検証ログ

```
pytest tests/test_golden_e2e.py tests/test_input_schema.py -v  →  62 passed
pytest tests/acceptance/ -v -m acceptance                       →  43 passed
pytest tests/test_release_readiness.py -v                       →  24 passed
python scripts/release_smoke.py --check-entrypoints             →  全 entry point RC=0
```

## 未解決の残課題（次PR）

- bandit Low 詳細 / build / twine CI 組み込み
- フル test suite 確認
- Python 3.14 実環境での再検証

https://claude.ai/code/session_01D9oHUuDUSuUeuVL1LsE5fv

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9oHUuDUSuUeuVL1LsE5fv)_