### PR TITLE
docs(release): record post-PR#552/#553 re-verification for v1.1.0

### DIFF
--- a/docs/release/release_candidate_handoff_v1.1.0.md
+++ b/docs/release/release_candidate_handoff_v1.1.0.md
@@ -43,8 +43,8 @@ Do **not** claim any of the following for `1.1.0` until exact operator evidence 
 - [x] `tests/test_release_readiness.py` updated to expect `"1.1.0"`
 - [x] `docs/release/release_candidate_handoff_v1.1.0.md` (this file) exists
 - [x] `docs/release/smoke_verification_v1.1.0.md` exists (pending state)
-- [ ] CI green on `main` (`pytest tests/ -v -m "not slow"`)
-- [ ] Golden files regenerated after version bump
+- [x] CI green on `main` (`pytest tests/ -v -m "not slow"`) — 3973 passed @ `bb60897` (2026-05-14)
+- [x] Golden files regenerated — AT-001/007/008/009/011 updated in PR #552 after philosopher roster expansion (39→42)
 - [ ] TestPyPI publish and smoke
 - [ ] PyPI publish
 - [ ] Post-publish smoke (`scripts/release_smoke.py --check-entrypoints`)

--- a/docs/release/release_candidate_verification_v1.1.0.md
+++ b/docs/release/release_candidate_verification_v1.1.0.md
@@ -201,3 +201,68 @@ All six CLI entrypoints (`po-core`, `po-self`, `po-trace`, `po-interactive`, `po
 - ❌ No GitHub Release created
 
 These actions are deferred to the operator publish runbook (`docs/operations/publish_playbook.md`).
+
+---
+
+## Appendix — Post-PR#552/#553 Re-verification (2026-05-14)
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-05-14 |
+| Branch | `main` |
+| Verified tree commit | `bb60897` (fix(schemas): import Traversable from importlib.resources.abc #553) |
+| PRs merged | #552 (acceptance golden update), #553 (Traversable import fix) |
+| Python | 3.11.15 (primary) / 3.13.12 (supplementary) |
+| Verified by | Claude Code (audit-v1.1.0-release) |
+
+### Context
+
+After the initial RC verification (2026-04-30), two fixes were merged:
+
+- **PR #552** — Regenerated acceptance golden files (AT-001/007/008/009/011) after philosopher roster expansion from 39 → 42 (Phase 7). Only `options[0].description` (philosopher proposal content) changed; all other fields were confirmed identical by code comparison.
+- **PR #553** — Changed `src/po_core/schemas/__init__.py` to import `Traversable` from `importlib.resources.abc` (Python 3.9+) instead of deprecated `importlib.abc`. Python 3.13 confirms the old path emits `DeprecationWarning: slated for removal in Python 3.14`.
+
+### Re-verification Results (Python 3.11.15, commit `bb60897`)
+
+| Command | Result |
+|---------|--------|
+| `pytest tests/ -v -m "not slow"` | ✅ **3973 passed**, 16 deselected (6m 28s) |
+| `pytest tests/acceptance/ -v -m acceptance` | ✅ 43 passed |
+| `pytest tests/test_golden_e2e.py tests/test_input_schema.py -v` | ✅ 62 passed |
+| `pytest tests/test_release_readiness.py -v` | ✅ 24 passed |
+| `bandit -r src/ scripts/ -c pyproject.toml -ll` | ✅ No issues (CI gate PASS) |
+| `bandit -r src/ scripts/ -c pyproject.toml -l` | 2 Low B110 (`ensemble.py:311`, `tracer.py:237`); non-CI-gate |
+| `python -m build` | ✅ wheel + sdist produced |
+| `twine check dist/*` | ✅ PASSED |
+| `python scripts/release_smoke.py --check-entrypoints` | ✅ All entry points RC=0 |
+
+### Python 3.13.12 Supplementary Verification
+
+| Check | Result |
+|-------|--------|
+| `pytest tests/test_golden_e2e.py tests/test_input_schema.py -v` | ✅ **62 passed** |
+| `from importlib.resources.abc import Traversable` (post-PR#553 path) | ✅ OK — no DeprecationWarning |
+| `from importlib.abc import Traversable` (pre-PR#553 path) | ❌ `DeprecationWarning: slated for removal in Python 3.14` |
+| `-W error::DeprecationWarning` mode | ⚠️ 52 passed, 10 errors — errors caused by `src/pocore/` legacy shim DeprecationWarning, **unrelated to Traversable** |
+
+Note on 10 errors: `src/pocore/__init__.py` intentionally emits a DeprecationWarning at import (documented in CLAUDE.md: "test-only scaffold... will be deleted in a future release"). This is a separate, known issue, not introduced by PR #552 or #553.
+
+### Bandit Low Severity Detail (non-CI-gate)
+
+| # | Rule | File:Line | Note |
+|---|------|-----------|------|
+| 1 | B110 try_except_pass | `src/po_core/ensemble.py:311` | Silent fallback returning empty string for philosopher author extraction |
+| 2 | B110 try_except_pass | `src/po_core/trace/tracer.py:237` | Intentional swallow of PoTrace logging failures; comment present explaining rationale |
+
+Per `pyproject.toml` bandit policy: B110 is not globally skipped; intentional occurrences should carry `# nosec B110`. These two sites lack the annotation. Non-blocking for this release; tracked as next-PR candidate.
+
+### Python 3.14 Status
+
+Python 3.14 is not available in this environment. Python 3.13 proxy verification confirms the `importlib.resources.abc.Traversable` fix is correct and warning-free. Full test suite on Python 3.14 remains **unverified**.
+
+### Explicit Non-Actions (Appendix)
+
+- ❌ No PyPI publish
+- ❌ No git tag created
+- ❌ No GitHub Release created
+- ❌ No `pocore` shim DeprecationWarning suppressed (tracked separately)


### PR DESCRIPTION
## このPRで追記したもの

v1.1.0 RC の再検証結果（2026-05-14、commit `bb60897`）を docs に記録する。

### `docs/release/release_candidate_verification_v1.1.0.md`

末尾に **Appendix — Post-PR#552/#553 Re-verification (2026-05-14)** セクションを追加。

| コマンド | 環境 | 結果 |
|---|---|---|
| `pytest tests/ -v -m "not slow"` | Python 3.11.15 | ✅ 3973 passed |
| `pytest tests/acceptance/ -v -m acceptance` | Python 3.11.15 | ✅ 43 passed |
| `pytest tests/test_golden_e2e.py tests/test_input_schema.py -v` | Python 3.11.15 | ✅ 62 passed |
| `pytest tests/test_golden_e2e.py tests/test_input_schema.py -v` | Python 3.13.12 | ✅ 62 passed |
| `bandit -r src/ scripts/ -c pyproject.toml -ll` | Python 3.11.15 | ✅ No issues (CI gate) |
| `bandit -r src/ scripts/ -c pyproject.toml -l` | Python 3.11.15 | 2 Low B110（非 CI gate） |
| `python -m build` | Python 3.11.15 | ✅ PASS |
| `twine check dist/*` | Python 3.11.15 | ✅ PASS |
| `python scripts/release_smoke.py --check-entrypoints` | Python 3.11.15 | ✅ 全 entry point RC=0 |

Python 3.13 proxy 検証：`importlib.resources.abc.Traversable`（PR #553 修正後）は `DeprecationWarning` ゼロ。旧 `importlib.abc.Traversable` は `DeprecationWarning: slated for removal in Python 3.14` を出すことを実機確認。

### `docs/release/release_candidate_handoff_v1.1.0.md`

確認済みの 2 チェックボックスを更新：

```diff
-[ ] CI green on `main` (`pytest tests/ -v -m "not slow"`)
-[ ] Golden files regenerated after version bump
+[x] CI green on `main` (`pytest tests/ -v -m "not slow"`) — 3973 passed @ bb60897 (2026-05-14)
+[x] Golden files regenerated — AT-001/007/008/009/011 updated in PR #552 after philosopher roster expansion (39→42)
```

## このPRで変更していないもの

- コード・schema・テスト・golden：**一切変更なし**
- `docs/status.md`：変更なし
- `release_smoke.py`：変更なし

## 明示的に未解決として記録した事項

| 項目 | 理由 |
|---|---|
| Python 3.14 実環境フルテスト | 環境が存在しない |
| bandit B110 × 2 の `# nosec B110` annotation | 非 CI gate、次 PR 候補 |
| `pocore` shim DeprecationWarning（`-W error` 時 10 errors） | 既知設計、Traversable と無関係、別課題 |
| PyPI 本番 publish | operator runbook 参照 |

## 変更ファイル

```
docs/release/release_candidate_verification_v1.1.0.md  (+65 lines, appendix追加)
docs/release/release_candidate_handoff_v1.1.0.md       (+2/-2 lines, チェックボックス更新)
```

https://claude.ai/code/session_01D9oHUuDUSuUeuVL1LsE5fv

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9oHUuDUSuUeuVL1LsE5fv)_