### PR TITLE
fix: restore Python 3.10 schema resource typing

### DIFF
--- a/src/po_core/schemas/__init__.py
+++ b/src/po_core/schemas/__init__.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from importlib.resources import files
-from importlib.resources.abc import Traversable
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from importlib.abc import Traversable
 
 PACKAGE_NAME: Final[str] = __name__
 


### PR DESCRIPTION
## Summary

- Fix Python 3.10 compatibility for packaged schema resource typing.
- Avoid runtime import of `importlib.resources.abc.Traversable`, which is unavailable on Python 3.10.
- Keep the `Traversable` type annotation available only under `TYPE_CHECKING`.

## Scope

- One-file change only: `src/po_core/schemas/__init__.py`
- No release-state docs changes
- No golden changes
- No acceptance expected changes
- No runtime behavior changes beyond avoiding the Python 3.10 import failure
- No publish, no tag, no GitHub Release

## Reason

PR #556 CI failed on Python 3.10 with:

```text
ModuleNotFoundError: No module named 'importlib.resources.abc'
```

This stacked PR targets PR #556's head branch so the fix can be merged into the release-state sync branch before rechecking CI.

## Expected Effect

- `must-pass-tests (3.10)` should progress past the schema/golden import failure.
- Other CI failures, if any, should be evaluated separately after PR #556 reruns.